### PR TITLE
Fix fgMorphStackArgForVarArgs SIMD arg morphing

### DIFF
--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -5710,9 +5710,9 @@ GenTree* Compiler::fgMorphStackArgForVarArgs(unsigned lclNum, var_types varType,
 
         // Access the argument through the local
         GenTree* tree;
-        if (varTypeIsStruct(varType))
+        if (varType == TYP_STRUCT)
         {
-            tree = new (this, GT_BLK) GenTreeBlk(GT_BLK, TYP_STRUCT, ptrArg, typGetBlkLayout(varDsc->lvExactSize));
+            tree = new (this, GT_BLK) GenTreeBlk(GT_BLK, varType, ptrArg, typGetBlkLayout(varDsc->lvExactSize));
         }
         else
         {

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -5756,10 +5756,6 @@ GenTree* Compiler::fgMorphLocalVar(GenTree* tree, bool forceRemorph)
         GenTree* newTree = fgMorphStackArgForVarArgs(lclNum, varType, 0);
         if (newTree != nullptr)
         {
-            if (newTree->OperIsBlk() && ((tree->gtFlags & GTF_VAR_DEF) == 0))
-            {
-                newTree->SetOper(GT_IND);
-            }
             return newTree;
         }
     }
@@ -8482,10 +8478,6 @@ GenTree* Compiler::fgMorphLeaf(GenTree* tree)
                                                          tree->AsLclFld()->GetLclOffs());
             if (newTree != nullptr)
             {
-                if (newTree->OperIsBlk() && ((tree->gtFlags & GTF_VAR_DEF) == 0))
-                {
-                    newTree->SetOper(GT_IND);
-                }
                 return newTree;
             }
         }

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -5712,7 +5712,7 @@ GenTree* Compiler::fgMorphStackArgForVarArgs(unsigned lclNum, var_types varType,
         GenTree* tree;
         if (varType == TYP_STRUCT)
         {
-            tree = new (this, GT_BLK) GenTreeBlk(GT_BLK, varType, ptrArg, typGetBlkLayout(varDsc->lvExactSize));
+            tree = gtNewObjNode(varDsc->lvVerTypeInfo.GetClassHandle(), ptrArg);
         }
         else
         {


### PR DESCRIPTION
```C#
static Vector4 Test(Vector4 v1, Vector4 v2, Vector4 v3, __arglist)
{
    v1 = v2 + v3;
    return v1;
}
```
crashes with `InvalidProgramException` on x86 due to a `TYP_STRUCT` `IND` node being generated as LHS of `ASG`.