### PR TITLE
Do implicit byref arg morphing before tree morph

### DIFF
--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -2625,7 +2625,7 @@ public:
     GenTreeLclFld* gtNewLclFldNode(unsigned lnum, var_types type, unsigned offset);
     GenTree* gtNewInlineCandidateReturnExpr(GenTree* inlineCandidate, var_types type);
 
-    GenTree* gtNewFieldRef(var_types typ, CORINFO_FIELD_HANDLE fldHnd, GenTree* obj = nullptr, DWORD offset = 0);
+    GenTreeField* gtNewFieldRef(var_types typ, CORINFO_FIELD_HANDLE fldHnd, GenTree* obj = nullptr, DWORD offset = 0);
 
     GenTree* gtNewIndexRef(var_types typ, GenTree* arrayOp, GenTree* indexOp);
 
@@ -5602,7 +5602,7 @@ private:
 #if (defined(TARGET_AMD64) && !defined(UNIX_AMD64_ABI)) || defined(TARGET_ARM64)
     // Rewrite appearances of implicit byrefs (manifest the implied additional level of indirection).
     bool fgMorphImplicitByRefArgs(GenTree* tree);
-    GenTree* fgMorphImplicitByRefArgs(GenTree* tree, bool isAddr);
+    GenTree* fgMorphImplicitByRefArgsWorker(GenTree* tree);
 #endif
 
     // Clear up annotations for any struct promotion temps created for implicit byrefs.

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -2554,8 +2554,8 @@ public:
 
     GenTreeCall* gtNewHelperCallNode(unsigned helper, var_types type, GenTreeCall::Use* args = nullptr);
 
-    GenTree* gtNewLclvNode(unsigned lnum, var_types type DEBUGARG(IL_OFFSETX ILoffs = BAD_IL_OFFSET));
-    GenTree* gtNewLclLNode(unsigned lnum, var_types type DEBUGARG(IL_OFFSETX ILoffs = BAD_IL_OFFSET));
+    GenTreeLclVar* gtNewLclvNode(unsigned lnum, var_types type DEBUGARG(IL_OFFSETX ILoffs = BAD_IL_OFFSET));
+    GenTreeLclVar* gtNewLclLNode(unsigned lnum, var_types type DEBUGARG(IL_OFFSETX ILoffs = BAD_IL_OFFSET));
 
     GenTreeLclVar* gtNewLclVarAddrNode(unsigned lclNum, var_types type = TYP_I_IMPL);
     GenTreeLclFld* gtNewLclFldAddrNode(unsigned      lclNum,

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -5601,8 +5601,7 @@ private:
 
 #if (defined(TARGET_AMD64) && !defined(UNIX_AMD64_ABI)) || defined(TARGET_ARM64)
     // Rewrite appearances of implicit byrefs (manifest the implied additional level of indirection).
-    bool fgMorphImplicitByRefArgs(GenTree* tree);
-    GenTree* fgMorphImplicitByRefArgsWorker(GenTree* tree);
+    void fgMorphImplicitByRefArgs(Statement* stmt);
 #endif
 
     // Clear up annotations for any struct promotion temps created for implicit byrefs.

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -5599,9 +5599,11 @@ private:
     // promoted, create new promoted struct temps.
     void fgRetypeImplicitByRefArgs();
 
+#if (defined(TARGET_AMD64) && !defined(UNIX_AMD64_ABI)) || defined(TARGET_ARM64)
     // Rewrite appearances of implicit byrefs (manifest the implied additional level of indirection).
     bool fgMorphImplicitByRefArgs(GenTree* tree);
     GenTree* fgMorphImplicitByRefArgs(GenTree* tree, bool isAddr);
+#endif
 
     // Clear up annotations for any struct promotion temps created for implicit byrefs.
     void fgMarkDemotedImplicitByRefArgs();

--- a/src/coreclr/src/jit/compiler.hpp
+++ b/src/coreclr/src/jit/compiler.hpp
@@ -1169,7 +1169,7 @@ inline GenTree* Compiler::gtNewRuntimeLookup(CORINFO_GENERIC_HANDLE hnd, CorInfo
  *  A little helper to create a data member reference node.
  */
 
-inline GenTree* Compiler::gtNewFieldRef(var_types typ, CORINFO_FIELD_HANDLE fldHnd, GenTree* obj, DWORD offset)
+inline GenTreeField* Compiler::gtNewFieldRef(var_types typ, CORINFO_FIELD_HANDLE fldHnd, GenTree* obj, DWORD offset)
 {
     /* 'GT_FIELD' nodes may later get transformed into 'GT_IND' */
     assert(GenTree::s_gtNodeSizes[GT_IND] <= GenTree::s_gtNodeSizes[GT_FIELD]);
@@ -1180,7 +1180,7 @@ inline GenTree* Compiler::gtNewFieldRef(var_types typ, CORINFO_FIELD_HANDLE fldH
         (void)info.compCompHnd->getFieldType(fldHnd, &fieldClass);
         typ = impNormStructType(fieldClass);
     }
-    GenTree* tree = new (this, GT_FIELD) GenTreeField(typ, obj, fldHnd, offset);
+    GenTreeField* tree = new (this, GT_FIELD) GenTreeField(typ, obj, fldHnd, offset);
 
     // If "obj" is the address of a local, note that a field of that struct local has been accessed.
     if (obj != nullptr && obj->OperGet() == GT_ADDR && varTypeIsStruct(obj->AsOp()->gtOp1) &&

--- a/src/coreclr/src/jit/compiler.hpp
+++ b/src/coreclr/src/jit/compiler.hpp
@@ -1481,6 +1481,7 @@ inline void GenTree::ChangeOper(genTreeOps oper, ValueNumberUpdate vnUpdate)
             Compiler*     compiler     = JitTls::GetCompiler();
             bool          isZeroOffset = compiler->GetZeroOffsetFieldMap()->Lookup(this, &zeroFieldSeq);
 
+            AsLclFld()->SetLayoutNum(0);
             AsLclFld()->SetLclOffs(0);
             AsLclFld()->SetFieldSeq(FieldSeqStore::NotAField());
 

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -1321,13 +1321,7 @@ AGAIN:
                 return true;
 
             case GT_LCL_FLD:
-                if ((op1->AsLclFld()->GetLclNum() != op2->AsLclFld()->GetLclNum()) ||
-                    (op1->AsLclFld()->GetLclOffs() != op2->AsLclFld()->GetLclOffs()))
-                {
-                    break;
-                }
-
-                return true;
+                return GenTreeLclFld::Equals(op1->AsLclFld(), op2->AsLclFld());
 
             case GT_CLS_VAR:
                 if (op1->AsClsVar()->gtClsVarHnd != op2->AsClsVar()->gtClsVarHnd)
@@ -1982,6 +1976,7 @@ AGAIN:
                 break;
             case GT_LCL_FLD:
                 hash = genTreeHashAdd(hash, tree->AsLclFld()->GetLclNum());
+                hash = genTreeHashAdd(hash, tree->AsLclFld()->GetLayoutNum());
                 add  = tree->AsLclFld()->GetLclOffs();
                 break;
 
@@ -5586,9 +5581,10 @@ GenTreeCall* Compiler::gtNewCallNode(
 
 GenTreeLclVar* Compiler::gtNewLclvNode(unsigned lnum, var_types type DEBUGARG(IL_OFFSETX ILoffs))
 {
-    // Cannot have this assert because the inliner uses this function to add temporaries
-    // assert(lnum < lvaCount);
+// Cannot have this assert because the inliner uses this function to add temporaries
+// assert(lnum < lvaCount);
 
+#ifdef DEBUG
     // We need to ensure that all struct values are normalized.
     // It might be nice to assert this in general, but we have assignments of int to long.
     if (varTypeIsStruct(type))
@@ -5607,6 +5603,7 @@ GenTreeLclVar* Compiler::gtNewLclvNode(unsigned lnum, var_types type DEBUGARG(IL
                (lvaIsImplicitByRefLocal(lnum) && fgGlobalMorph && (varDsc->lvType == TYP_BYREF)) ||
                ((varDsc->lvType == TYP_STRUCT) && (genTypeSize(type) == varDsc->lvExactSize)));
     }
+#endif
 
     return new (this, GT_LCL_VAR) GenTreeLclVar(GT_LCL_VAR, type, lnum DEBUGARG(ILoffs));
 }
@@ -6365,11 +6362,11 @@ GenTree* Compiler::gtClone(GenTree* tree, bool complexOK)
             break;
 
         case GT_LCL_VAR:
+        case GT_LCL_VAR_ADDR:
             // Remember that the LclVar node has been cloned. The flag will be set
             // on 'copy' as well.
             tree->gtFlags |= GTF_VAR_CLONED;
-            copy = gtNewLclvNode(tree->AsLclVarCommon()->GetLclNum(),
-                                 tree->gtType DEBUGARG(tree->AsLclVar()->gtLclILoffs));
+            copy = new (this, tree->GetOper()) GenTreeLclVar(tree->AsLclVar());
             break;
 
         case GT_LCL_FLD:
@@ -6377,10 +6374,7 @@ GenTree* Compiler::gtClone(GenTree* tree, bool complexOK)
             // Remember that the LclVar node has been cloned. The flag will be set
             // on 'copy' as well.
             tree->gtFlags |= GTF_VAR_CLONED;
-            copy = new (this, tree->OperGet())
-                GenTreeLclFld(tree->OperGet(), tree->TypeGet(), tree->AsLclFld()->GetLclNum(),
-                              tree->AsLclFld()->GetLclOffs());
-            copy->AsLclFld()->SetFieldSeq(tree->AsLclFld()->GetFieldSeq());
+            copy = new (this, tree->GetOper()) GenTreeLclFld(tree->AsLclFld());
             break;
 
         case GT_CLS_VAR:
@@ -6541,8 +6535,8 @@ GenTree* Compiler::gtCloneExpr(
                 goto DONE;
 
             case GT_LCL_VAR:
-
-                if (tree->AsLclVarCommon()->GetLclNum() == varNum)
+            case GT_LCL_VAR_ADDR:
+                if (tree->AsLclVar()->GetLclNum() == varNum)
                 {
                     copy = gtNewIconNode(varVal, tree->gtType);
                     if (tree->gtFlags & GTF_VAR_ARR_INDEX)
@@ -6555,28 +6549,20 @@ GenTree* Compiler::gtCloneExpr(
                     // Remember that the LclVar node has been cloned. The flag will
                     // be set on 'copy' as well.
                     tree->gtFlags |= GTF_VAR_CLONED;
-                    copy = gtNewLclvNode(tree->AsLclVar()->GetLclNum(),
-                                         tree->gtType DEBUGARG(tree->AsLclVar()->gtLclILoffs));
-                    copy->AsLclVarCommon()->SetSsaNum(tree->AsLclVarCommon()->GetSsaNum());
+                    copy = new (this, tree->GetOper()) GenTreeLclVar(tree->AsLclVar());
                 }
                 copy->gtFlags = tree->gtFlags;
                 goto DONE;
 
             case GT_LCL_FLD:
+            case GT_LCL_FLD_ADDR:
                 if (tree->AsLclFld()->GetLclNum() == varNum)
                 {
                     IMPL_LIMITATION("replacing GT_LCL_FLD with a constant");
                 }
                 else
                 {
-                    // Remember that the LclVar node has been cloned. The flag will
-                    // be set on 'copy' as well.
-                    tree->gtFlags |= GTF_VAR_CLONED;
-                    copy =
-                        new (this, GT_LCL_FLD) GenTreeLclFld(GT_LCL_FLD, tree->TypeGet(), tree->AsLclFld()->GetLclNum(),
-                                                             tree->AsLclFld()->GetLclOffs());
-                    copy->AsLclFld()->SetFieldSeq(tree->AsLclFld()->GetFieldSeq());
-                    copy->gtFlags = tree->gtFlags;
+                    copy = new (this, tree->GetOper()) GenTreeLclFld(tree->AsLclFld());
                 }
                 goto DONE;
 
@@ -6619,16 +6605,6 @@ GenTree* Compiler::gtCloneExpr(
 #endif // !FEATURE_EH_FUNCLETS
             case GT_JMP:
                 copy = new (this, oper) GenTreeVal(oper, tree->gtType, tree->AsVal()->gtVal1);
-                goto DONE;
-
-            case GT_LCL_VAR_ADDR:
-                copy = new (this, oper) GenTreeLclVar(oper, tree->TypeGet(), tree->AsLclVar()->GetLclNum());
-                goto DONE;
-
-            case GT_LCL_FLD_ADDR:
-                copy = new (this, oper)
-                    GenTreeLclFld(oper, tree->TypeGet(), tree->AsLclFld()->GetLclNum(), tree->AsLclFld()->GetLclOffs());
-                copy->AsLclFld()->SetFieldSeq(tree->AsLclFld()->GetFieldSeq());
                 goto DONE;
 
             default:
@@ -8996,6 +8972,10 @@ void Compiler::gtDispNode(GenTree* tree, IndentStack* indentStack, __in __in_z _
                     {
                         layout = varDsc->GetLayout();
                     }
+                }
+                else if (tree->OperIs(GT_LCL_FLD, GT_STORE_LCL_FLD) && (tree->AsLclFld()->GetLayoutNum() != 0))
+                {
+                    layout = typGetLayoutByNum(tree->AsLclFld()->GetLayoutNum());
                 }
 
                 if (layout != nullptr)

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -5584,8 +5584,11 @@ GenTreeCall* Compiler::gtNewCallNode(
     return node;
 }
 
-GenTree* Compiler::gtNewLclvNode(unsigned lnum, var_types type DEBUGARG(IL_OFFSETX ILoffs))
+GenTreeLclVar* Compiler::gtNewLclvNode(unsigned lnum, var_types type DEBUGARG(IL_OFFSETX ILoffs))
 {
+    // Cannot have this assert because the inliner uses this function to add temporaries
+    // assert(lnum < lvaCount);
+
     // We need to ensure that all struct values are normalized.
     // It might be nice to assert this in general, but we have assignments of int to long.
     if (varTypeIsStruct(type))
@@ -5604,17 +5607,11 @@ GenTree* Compiler::gtNewLclvNode(unsigned lnum, var_types type DEBUGARG(IL_OFFSE
                (lvaIsImplicitByRefLocal(lnum) && fgGlobalMorph && (varDsc->lvType == TYP_BYREF)) ||
                ((varDsc->lvType == TYP_STRUCT) && (genTypeSize(type) == varDsc->lvExactSize)));
     }
-    GenTree* node = new (this, GT_LCL_VAR) GenTreeLclVar(GT_LCL_VAR, type, lnum DEBUGARG(ILoffs));
 
-    /* Cannot have this assert because the inliner uses this function
-     * to add temporaries */
-
-    // assert(lnum < lvaCount);
-
-    return node;
+    return new (this, GT_LCL_VAR) GenTreeLclVar(GT_LCL_VAR, type, lnum DEBUGARG(ILoffs));
 }
 
-GenTree* Compiler::gtNewLclLNode(unsigned lnum, var_types type DEBUGARG(IL_OFFSETX ILoffs))
+GenTreeLclVar* Compiler::gtNewLclLNode(unsigned lnum, var_types type DEBUGARG(IL_OFFSETX ILoffs))
 {
     // We need to ensure that all struct values are normalized.
     // It might be nice to assert this in general, but we have assignments of int to long.
@@ -5626,11 +5623,12 @@ GenTree* Compiler::gtNewLclLNode(unsigned lnum, var_types type DEBUGARG(IL_OFFSE
         assert(type == lvaTable[lnum].lvType ||
                (lvaIsImplicitByRefLocal(lnum) && fgGlobalMorph && (lvaTable[lnum].lvType == TYP_BYREF)));
     }
+
     // This local variable node may later get transformed into a large node
     assert(GenTree::s_gtNodeSizes[LargeOpOpcode()] > GenTree::s_gtNodeSizes[GT_LCL_VAR]);
-    GenTree* node =
-        new (this, LargeOpOpcode()) GenTreeLclVar(GT_LCL_VAR, type, lnum DEBUGARG(ILoffs) DEBUGARG(/*largeNode*/ true));
-    return node;
+
+    return new (this, LargeOpOpcode())
+        GenTreeLclVar(GT_LCL_VAR, type, lnum DEBUGARG(ILoffs) DEBUGARG(/*largeNode*/ true));
 }
 
 GenTreeLclVar* Compiler::gtNewLclVarAddrNode(unsigned lclNum, var_types type)

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -2694,16 +2694,30 @@ protected:
     }
 
 public:
-    GenTree* GetOp1() const
+    GenTree* GetOp(unsigned index) const
     {
-        assert(gtOp1 != nullptr);
-        return gtOp1;
+        switch (index)
+        {
+            case 0:
+                assert(gtOp1 != nullptr);
+                return gtOp1;
+            default:
+                unreached();
+        }
     }
 
-    void SetOp1(GenTree* op1)
+    void SetOp(unsigned index, GenTree* op)
     {
-        assert(op1 != nullptr);
-        gtOp1 = op1;
+        assert(op != nullptr);
+
+        switch (index)
+        {
+            case 0:
+                gtOp1 = op;
+                return;
+            default:
+                unreached();
+        }
     }
 
 #if DEBUGGABLE_GENTREE
@@ -2743,16 +2757,36 @@ struct GenTreeOp : public GenTreeUnOp
         assert(oper == GT_NOP || oper == GT_RETURN || oper == GT_RETFILT || OperIsBlk(oper));
     }
 
-    GenTree* GetOp2() const
+    GenTree* GetOp(unsigned index) const
     {
-        assert(gtOp2 != nullptr);
-        return gtOp2;
+        switch (index)
+        {
+            case 0:
+                assert(gtOp1 != nullptr);
+                return gtOp1;
+            case 1:
+                assert(gtOp2 != nullptr);
+                return gtOp2;
+            default:
+                unreached();
+        }
     }
 
-    void SetOp2(GenTree* op2)
+    void SetOp(unsigned index, GenTree* op)
     {
-        assert(op2 != nullptr);
-        gtOp2 = op2;
+        assert(op != nullptr);
+
+        switch (index)
+        {
+            case 0:
+                gtOp1 = op;
+                return;
+            case 1:
+                gtOp2 = op;
+                return;
+            default:
+                unreached();
+        }
     }
 
 #if DEBUGGABLE_GENTREE

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -397,6 +397,17 @@ struct GenTree
         return gtType;
     }
 
+    var_types GetType() const
+    {
+        return gtType;
+    }
+
+    void SetType(var_types type)
+    {
+        assert((TYP_UNDEF < type) && (type < TYP_UNKNOWN));
+        gtType = type;
+    }
+
 #ifdef DEBUG
     genTreeOps gtOperSave; // Only used to save gtOper when we destroy a node, to aid debugging.
 #endif
@@ -2682,6 +2693,19 @@ protected:
         }
     }
 
+public:
+    GenTree* GetOp1() const
+    {
+        assert(gtOp1 != nullptr);
+        return gtOp1;
+    }
+
+    void SetOp1(GenTree* op1)
+    {
+        assert(op1 != nullptr);
+        gtOp1 = op1;
+    }
+
 #if DEBUGGABLE_GENTREE
     GenTreeUnOp() : GenTree(), gtOp1(nullptr)
     {
@@ -2717,6 +2741,18 @@ struct GenTreeOp : public GenTreeUnOp
     {
         // Unary operators with optional arguments:
         assert(oper == GT_NOP || oper == GT_RETURN || oper == GT_RETFILT || OperIsBlk(oper));
+    }
+
+    GenTree* GetOp2() const
+    {
+        assert(gtOp2 != nullptr);
+        return gtOp2;
+    }
+
+    void SetOp2(GenTree* op2)
+    {
+        assert(op2 != nullptr);
+        gtOp2 = op2;
     }
 
 #if DEBUGGABLE_GENTREE

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -397,6 +397,11 @@ struct GenTree
         return gtType;
     }
 
+    genTreeOps GetOper() const
+    {
+        return gtOper;
+    }
+
     var_types GetType() const
     {
         return gtType;
@@ -3068,8 +3073,16 @@ struct GenTreeStrCon : public GenTree
 struct GenTreeLclVarCommon : public GenTreeUnOp
 {
 private:
-    unsigned _gtLclNum; // The local number. An index into the Compiler::lvaTable array.
-    unsigned _gtSsaNum; // The SSA number.
+    unsigned m_lclNum; // The local number. An index into the Compiler::lvaTable array.
+    unsigned m_ssaNum; // The SSA number.
+
+protected:
+    GenTreeLclVarCommon(GenTreeLclVarCommon* copyFrom)
+        : GenTreeUnOp(copyFrom->GetOper(), copyFrom->GetType())
+        , m_lclNum(copyFrom->m_lclNum)
+        , m_ssaNum(copyFrom->m_ssaNum)
+    {
+    }
 
 public:
     GenTreeLclVarCommon(genTreeOps oper, var_types type, unsigned lclNum DEBUGARG(bool largeNode = false))
@@ -3080,28 +3093,28 @@ public:
 
     unsigned GetLclNum() const
     {
-        return _gtLclNum;
+        return m_lclNum;
     }
 
     void SetLclNum(unsigned lclNum)
     {
-        _gtLclNum = lclNum;
-        _gtSsaNum = SsaConfig::RESERVED_SSA_NUM;
+        m_lclNum = lclNum;
+        m_ssaNum = SsaConfig::RESERVED_SSA_NUM;
     }
 
     unsigned GetSsaNum() const
     {
-        return _gtSsaNum;
+        return m_ssaNum;
     }
 
     void SetSsaNum(unsigned ssaNum)
     {
-        _gtSsaNum = ssaNum;
+        m_ssaNum = ssaNum;
     }
 
     bool HasSsaName()
     {
-        return (GetSsaNum() != SsaConfig::RESERVED_SSA_NUM);
+        return (m_ssaNum != SsaConfig::RESERVED_SSA_NUM);
     }
 
 #if DEBUGGABLE_GENTREE
@@ -3111,8 +3124,7 @@ public:
 #endif
 };
 
-// gtLclVar -- load/store/addr of local variable
-
+// GenTreeLclVar - load/store/addr of local variable
 struct GenTreeLclVar : public GenTreeLclVarCommon
 {
     INDEBUG(IL_OFFSET gtLclILoffs;) // instr offset of ref (only for JIT dumps)
@@ -3125,6 +3137,14 @@ struct GenTreeLclVar : public GenTreeLclVarCommon
         assert(OperIsLocal(oper) || OperIsLocalAddr(oper));
     }
 
+    GenTreeLclVar(GenTreeLclVar* copyFrom)
+        : GenTreeLclVarCommon(copyFrom)
+#ifdef DEBUG
+        , gtLclILoffs(copyFrom->gtLclILoffs)
+#endif
+    {
+    }
+
 #if DEBUGGABLE_GENTREE
     GenTreeLclVar() : GenTreeLclVarCommon()
     {
@@ -3132,19 +3152,30 @@ struct GenTreeLclVar : public GenTreeLclVarCommon
 #endif
 };
 
-// gtLclFld -- load/store/addr of local variable field
-
+// GenTreeLclFld - load/store/addr of local variable field
 struct GenTreeLclFld : public GenTreeLclVarCommon
 {
 private:
-    uint16_t      m_lclOffs;  // offset into the variable to access
-    FieldSeqNode* m_fieldSeq; // This LclFld node represents some sequences of accesses.
+    uint16_t      m_lclOffs;   // offset into the variable to access
+    uint16_t      m_layoutNum; // the class layout number for struct typed nodes
+    FieldSeqNode* m_fieldSeq;  // This LclFld node represents some sequences of accesses.
 
 public:
     GenTreeLclFld(genTreeOps oper, var_types type, unsigned lclNum, unsigned lclOffs)
-        : GenTreeLclVarCommon(oper, type, lclNum), m_lclOffs(static_cast<uint16_t>(lclOffs)), m_fieldSeq(nullptr)
+        : GenTreeLclVarCommon(oper, type, lclNum)
+        , m_lclOffs(static_cast<uint16_t>(lclOffs))
+        , m_layoutNum(0)
+        , m_fieldSeq(nullptr)
     {
         assert(lclOffs <= UINT16_MAX);
+    }
+
+    GenTreeLclFld(GenTreeLclFld* copyFrom)
+        : GenTreeLclVarCommon(copyFrom)
+        , m_lclOffs(copyFrom->m_lclOffs)
+        , m_layoutNum(copyFrom->m_layoutNum)
+        , m_fieldSeq(copyFrom->m_fieldSeq)
+    {
     }
 
     uint16_t GetLclOffs() const
@@ -3158,6 +3189,18 @@ public:
         m_lclOffs = static_cast<uint16_t>(lclOffs);
     }
 
+    uint16_t GetLayoutNum() const
+    {
+        return varTypeIsStruct(GetType()) ? m_layoutNum : 0;
+    }
+
+    void SetLayoutNum(unsigned layoutNum)
+    {
+        assert(layoutNum <= UINT16_MAX);
+        assert((layoutNum == 0) || varTypeIsStruct(GetType()));
+        m_layoutNum = static_cast<uint16_t>(layoutNum);
+    }
+
     FieldSeqNode* GetFieldSeq() const
     {
         return m_fieldSeq;
@@ -3166,6 +3209,13 @@ public:
     void SetFieldSeq(FieldSeqNode* fieldSeq)
     {
         m_fieldSeq = fieldSeq;
+    }
+
+    static bool Equals(GenTreeLclFld* f1, GenTreeLclFld* f2)
+    {
+        assert((f1->OperGet() == f2->OperGet()) && (f1->GetType() == f2->GetType()));
+        return (f1->GetLclNum() == f2->GetLclNum()) && (f1->m_lclOffs == f2->m_lclOffs) &&
+               ((f1->m_layoutNum == f2->m_layoutNum) || !varTypeIsStruct(f1->GetType()));
     }
 
 #if DEBUGGABLE_GENTREE

--- a/src/coreclr/src/jit/lclmorph.cpp
+++ b/src/coreclr/src/jit/lclmorph.cpp
@@ -1512,8 +1512,6 @@ public:
             // Change LCL_VAR<STRUCT>(arg) into OBJ<STRUCT>(LCL_VAR<BYREF>(arg))
             tree = m_compiler->gtNewObjNode(lclVarDsc->lvVerTypeInfo.GetClassHandle(), lclNode);
             m_compiler->gtSetObjGcInfo(tree->AsObj());
-            // TODO-CQ: If the VM ever stops violating the ABI and passing heap references we could remove TGTANYWHERE
-            tree->gtFlags |= GTF_IND_TGTANYWHERE;
             return tree;
         }
 


### PR DESCRIPTION
Attempting to morph implicit byref args during normal tree morph causes more problems than it solves - it requires lookahead and sometimes ends up being done more than once for the same node. This is neither efficient nor very reliable.


BASE | DIFF
-- | --
21234816089 | 21141568076
21230637867 | 21139328915
21234976876 | 21137745219
21231438221 | 21146639962
21233410735 | 21142493571
21232192854 | 21140501399
21237579663 | 21140003966
21235030049 | 21144195163
21238536895 | 21137776842
21234161269 | 21139839955
AVG |  
21,234,278,052 | 21,141,009,307
STDEV |  
2,383,511 | 2,663,308
DELTA |  
-93,268,745 | -0.44%

x64 diff:
```
Total bytes of diff: -6 (-0.00% of base)
    diff is an improvement.
Top file improvements by size (bytes):
          -6 : System.Private.CoreLib.dasm (-0.00% of base)
1 total files with size differences (1 improved, 0 regressed), 108 unchanged.
Top method improvements by size (bytes):
          -6 (-3.85% of base) : System.Private.CoreLib.dasm - DateTime:SystemSupportsLeapSeconds():bool
Top method improvements by size (percentage):
          -6 (-3.85% of base) : System.Private.CoreLib.dasm - DateTime:SystemSupportsLeapSeconds():bool
1 total methods with size differences (1 improved, 0 regressed), 147517 unchanged.
80 files had text diffs but not size diffs.
System.Private.Xml.dasm had 3354 diffs
Microsoft.CodeAnalysis.VisualBasic.dasm had 2790 diffs
Microsoft.CodeAnalysis.CSharp.dasm had 2108 diffs
System.Security.Cryptography.Algorithms.dasm had 1668 diffs
Newtonsoft.Json.dasm had 1344 diffs
```
Small diffs due to using LCL_VAR|FLD_ADDR in more places, they have type TYP_I_IMPL rather than TYP_BYREF and sometimes this avoids the need to zero out a temp.