### PR TITLE
Remove unexpected creation of primitive struct typed locals

### DIFF
--- a/src/coreclr/src/jit/layout.cpp
+++ b/src/coreclr/src/jit/layout.cpp
@@ -324,6 +324,7 @@ ClassLayout* ClassLayout::Create(Compiler* compiler, CORINFO_CLASS_HANDLE classH
 
     if (isValueClass)
     {
+        assert(compiler->info.compCompHnd->getTypeForPrimitiveValueClass(classHandle) == CORINFO_TYPE_UNDEF);
         size = compiler->info.compCompHnd->getClassSize(classHandle);
     }
     else


### PR DESCRIPTION
Attempting to create a struct local having primitive type (e.g. `System.Int32`) works but results in the promotion of the local, wasting a local variable and possibly causing other issues.

Also, the copy destination can be changed to a `LCL_VAR`, keeping the indir is not necessary and may affect CQ.

```
Total bytes of diff: -280 (-0.01% of base)
    diff is an improvement.
Top file improvements by size (bytes):
        -280 : System.Private.CoreLib.dasm (-0.01% of base)
1 total files with size differences (1 improved, 0 regressed), 0 unchanged.
Top method improvements by size (bytes):
         -65 (-0.87% of base) : System.Private.CoreLib.dasm - Vector64`1:ToString():String:this (11 methods)
         -62 (-0.77% of base) : System.Private.CoreLib.dasm - Vector128`1:ToString():String:this (11 methods)
         -62 (-0.75% of base) : System.Private.CoreLib.dasm - Vector256`1:ToString():String:this (11 methods)
         -44 (-3.55% of base) : System.Private.CoreLib.dasm - Vector64`1:Equals(Vector64`1):bool:this (11 methods)
         -36 (-9.16% of base) : System.Private.CoreLib.dasm - Vector3:ToString(String,IFormatProvider):String:this
Top method improvements by size (percentage):
         -36 (-9.16% of base) : System.Private.CoreLib.dasm - Vector3:ToString(String,IFormatProvider):String:this
         -44 (-3.55% of base) : System.Private.CoreLib.dasm - Vector64`1:Equals(Vector64`1):bool:this (11 methods)
         -65 (-0.87% of base) : System.Private.CoreLib.dasm - Vector64`1:ToString():String:this (11 methods)
         -62 (-0.77% of base) : System.Private.CoreLib.dasm - Vector128`1:ToString():String:this (11 methods)
         -62 (-0.75% of base) : System.Private.CoreLib.dasm - Vector256`1:ToString():String:this (11 methods)
6 total methods with size differences (6 improved, 0 regressed), 20783 unchanged.
```