### PR TITLE
Delete "normed struct" case from MorphStructField

### DIFF
--- a/src/coreclr/src/jit/emitxarch.cpp
+++ b/src/coreclr/src/jit/emitxarch.cpp
@@ -2870,6 +2870,8 @@ void emitter::emitHandleMemOp(GenTreeIndir* indir, instrDesc* id, insFormat fmt,
     }
     else
     {
+        assert(!indir->GetAddr()->OperIs(GT_LCL_VAR_ADDR, GT_LCL_FLD_ADDR) || !indir->GetAddr()->isContained());
+
         if (memBase != nullptr)
         {
             id->idAddr()->iiaAddrMode.amBaseReg = memBase->GetRegNum();

--- a/src/coreclr/src/jit/error.cpp
+++ b/src/coreclr/src/jit/error.cpp
@@ -276,8 +276,9 @@ extern "C" void __cdecl assertAbort(const char* why, const char* file, unsigned 
     if (env->compiler)
     {
         phaseName = PhaseNames[env->compiler->mostRecentlyActivePhase];
-        _snprintf_s(buff, BUFF_SIZE, _TRUNCATE, "Assertion failed '%s' in '%s' during '%s' (IL size %d)\n", why,
-                    env->compiler->info.compFullName, phaseName, env->compiler->info.compILCodeSize);
+        _snprintf_s(buff, BUFF_SIZE, _TRUNCATE, "Assertion failed '%s' in '%s' (%x) during '%s' (IL size %d)\n", why,
+                    env->compiler->info.compFullName, env->compiler->info.compMethodHash(), phaseName,
+                    env->compiler->info.compILCodeSize);
         msg = buff;
     }
     printf(""); // null string means flush

--- a/src/coreclr/src/jit/layout.cpp
+++ b/src/coreclr/src/jit/layout.cpp
@@ -328,7 +328,7 @@ ClassLayout* ClassLayout::Create(Compiler* compiler, CORINFO_CLASS_HANDLE classH
         // manages to do that by importing `initobj T` where T may be a primitive type in
         // generic code. Ideally the importer should convert that to scalar initialization.
 
-        //assert(compiler->info.compCompHnd->getTypeForPrimitiveValueClass(classHandle) == CORINFO_TYPE_UNDEF);
+        // assert(compiler->info.compCompHnd->getTypeForPrimitiveValueClass(classHandle) == CORINFO_TYPE_UNDEF);
 
         size = compiler->info.compCompHnd->getClassSize(classHandle);
     }

--- a/src/coreclr/src/jit/lclmorph.cpp
+++ b/src/coreclr/src/jit/lclmorph.cpp
@@ -927,6 +927,11 @@ private:
             // TODO-ADDR: We shouldn't remove the indir because it's volatile but we should
             // transform the tree into IND(LCL_VAR|FLD_ADDR) instead of leaving this to
             // fgMorphField.
+
+            // For now make the local address exposed to workaround a bug in fgMorphSmpOp's
+            // IND morphing code. It completly ignores volatile indirs and in doing so it
+            // fails to DNER the local which leads to asserts in the backend.
+            m_compiler->lvaSetVarAddrExposed(val.LclNum());
             return;
         }
 

--- a/src/coreclr/src/jit/lclmorph.cpp
+++ b/src/coreclr/src/jit/lclmorph.cpp
@@ -1271,58 +1271,7 @@ private:
         unsigned   lclNum = obj->AsLclVar()->GetLclNum();
         LclVarDsc* varDsc = m_compiler->lvaGetDesc(lclNum);
 
-        if (!varTypeIsStruct(obj->TypeGet()))
-        {
-            // Normed struct
-            // A "normed struct" is a struct that the VM tells us is a basic type. This can only happen if
-            // the struct contains a single element, and that element is 4 bytes (on x64 it can also be 8
-            // bytes). Normally, the type of the local var and the type of GT_FIELD are equivalent. However,
-            // there is one extremely rare case where that won't be true. An enum type is a special value type
-            // that contains exactly one element of a primitive integer type (that, for CLS programs is named
-            // "value__"). The VM tells us that a local var of that enum type is the primitive type of the
-            // enum's single field. It turns out that it is legal for IL to access this field using ldflda or
-            // ldfld. For example:
-            //
-            //  .class public auto ansi sealed mynamespace.e_t extends [mscorlib]System.Enum
-            //  {
-            //    .field public specialname rtspecialname int16 value__
-            //    .field public static literal valuetype mynamespace.e_t one = int16(0x0000)
-            //  }
-            //  .method public hidebysig static void  Main() cil managed
-            //  {
-            //     .locals init (valuetype mynamespace.e_t V_0)
-            //     ...
-            //     ldloca.s   V_0
-            //     ldflda     int16 mynamespace.e_t::value__
-            //     ...
-            //  }
-            //
-            // Normally, compilers will not generate the ldflda, since it is superfluous.
-            //
-            // In the example, the lclVar is short, but the JIT promotes all trees using this local to the
-            // "actual type", that is, INT. But the GT_FIELD is still SHORT. So, in the case of a type
-            // mismatch like this, don't do this morphing. The local var may end up getting marked as
-            // address taken, and the appropriate SHORT load will be done from memory in that case.
-
-            if (node->TypeGet() == obj->TypeGet())
-            {
-                node->ChangeOper(GT_LCL_VAR);
-                node->AsLclVar()->SetLclNum(lclNum);
-                node->gtFlags = 0;
-
-                if (user->OperIs(GT_ASG) && (user->AsOp()->gtGetOp1() == node))
-                {
-                    node->gtFlags |= GTF_VAR_DEF | GTF_DONT_CSE;
-                }
-
-                JITDUMP("Replaced the field in normed struct with local var V%02u\n", lclNum);
-                INDEBUG(m_stmtModified = true;)
-            }
-
-            return;
-        }
-
-        if (!varDsc->lvPromoted)
+        if (!varTypeIsStruct(obj->GetType()) || !varDsc->lvPromoted)
         {
             return;
         }

--- a/src/coreclr/src/jit/lowerxarch.cpp
+++ b/src/coreclr/src/jit/lowerxarch.cpp
@@ -3204,7 +3204,7 @@ bool Lowering::LowerRMWMemOp(GenTreeIndir* storeInd)
         // We would still need a reg for GT_CNS_INT if it doesn't fit within addressing mode base.
         // For GT_CLS_VAR_ADDR, we don't need a reg to hold the address, because field address value is known at jit
         // time. Also, we don't need a reg for GT_CLS_VAR_ADDR.
-        if (indirCandidateChild->OperGet() == GT_LCL_VAR_ADDR || indirCandidateChild->OperGet() == GT_CLS_VAR_ADDR)
+        if (indirCandidateChild->OperIs(GT_CLS_VAR_ADDR))
         {
             indirDst->SetContained();
         }


### PR DESCRIPTION
MorphLocalIndir already handles the more general case of indirect access to a same type local via both IND and FIELD, not just FIELD.

x86:
```
Total bytes of diff: 104 (0.00% of base)
    diff is a regression.
Top file regressions (bytes):
         104 : System.Private.CoreLib.dasm (0.00% of base)
1 total files with Code Size differences (0 improved, 1 regressed), 263 unchanged.
Top method regressions (bytes):
          68 (25.95% of base) : System.Private.CoreLib.dasm - Bucket:.ctor(int,int,int):this (4 methods)
          18 (51.43% of base) : System.Private.CoreLib.dasm - CallbackPartition:.ctor(CancellationTokenSource):this
          18 (46.15% of base) : System.Private.CoreLib.dasm - WorkStealingQueue:.ctor():this
Top method regressions (percentages):
          18 (51.43% of base) : System.Private.CoreLib.dasm - CallbackPartition:.ctor(CancellationTokenSource):this
          18 (46.15% of base) : System.Private.CoreLib.dasm - WorkStealingQueue:.ctor():this
          68 (25.95% of base) : System.Private.CoreLib.dasm - Bucket:.ctor(int,int,int):this (4 methods)
3 total methods with Code Size differences (0 improved, 3 regressed), 187598 unchanged.
Completed analysis in 20.46s
```
arm32:
```
Total bytes of diff: 460 (0.00% of base)
    diff is a regression.
Top file regressions (bytes):
         460 : System.Private.CoreLib.dasm (0.01% of base)
1 total files with Code Size differences (0 improved, 1 regressed), 263 unchanged.
Top method regressions (bytes):
         316 (32.11% of base) : System.Private.CoreLib.dasm - Bucket:.ctor(int,int,int):this (10 methods)
          84 (123.53% of base) : System.Private.CoreLib.dasm - CallbackPartition:.ctor(CancellationTokenSource):this (2 methods)
          60 (50.00% of base) : System.Private.CoreLib.dasm - WorkStealingQueue:.ctor():this (2 methods)
Top method regressions (percentages):
          84 (123.53% of base) : System.Private.CoreLib.dasm - CallbackPartition:.ctor(CancellationTokenSource):this (2 methods)
          60 (50.00% of base) : System.Private.CoreLib.dasm - WorkStealingQueue:.ctor():this (2 methods)
         316 (32.11% of base) : System.Private.CoreLib.dasm - Bucket:.ctor(int,int,int):this (10 methods)
3 total methods with Code Size differences (0 improved, 3 regressed), 187074 unchanged.
```
Regressions are due to the old code ignoring volatile field access and `SpinLock` being a "normed struct" on 32 bit targets. It's likely that volatile can actually be ignored in these cases as those spinlocks are actually class fields and the locals are only temporaries created for `newobj`. But that's not something that the JIT can figure out.