### PR TITLE
Set proper flags when promoting block copies

### DIFF
--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -10185,19 +10185,7 @@ GenTree* Compiler::fgMorphCopyBlock(GenTree* tree)
                 noway_assert(destLclNum != BAD_VAR_NUM);
                 unsigned dstFieldLclNum = lvaTable[destLclNum].lvFieldLclStart + i;
                 dstFld                  = gtNewLclvNode(dstFieldLclNum, lvaTable[dstFieldLclNum].TypeGet());
-                // If it had been labeled a "USEASG", assignments to the the individual promoted fields are not.
-                if (destAddr != nullptr)
-                {
-                    noway_assert(destAddr->AsOp()->gtOp1->gtOper == GT_LCL_VAR);
-                    dstFld->gtFlags |= destAddr->AsOp()->gtOp1->gtFlags & ~(GTF_NODE_MASK | GTF_VAR_USEASG);
-                }
-                else
-                {
-                    noway_assert(lclVarTree != nullptr);
-                    dstFld->gtFlags |= lclVarTree->gtFlags & ~(GTF_NODE_MASK | GTF_VAR_USEASG);
-                }
-                // Don't CSE the lhs of an assignment.
-                dstFld->gtFlags |= GTF_DONT_CSE;
+                dstFld->gtFlags |= lvaTable[dstFieldLclNum].lvAddrExposed ? GTF_GLOB_REF : 0;
             }
             else
             {
@@ -10210,6 +10198,7 @@ GenTree* Compiler::fgMorphCopyBlock(GenTree* tree)
                     noway_assert(addrSpill == nullptr);
 
                     dstFld = gtNewLclvNode(destLclNum, destLclVar->TypeGet());
+                    dstFld->gtFlags |= lvaTable[destLclNum].lvAddrExposed ? GTF_GLOB_REF : 0;
                 }
                 else
                 {
@@ -10273,9 +10262,7 @@ GenTree* Compiler::fgMorphCopyBlock(GenTree* tree)
                 noway_assert(srcLclNum != BAD_VAR_NUM);
                 unsigned srcFieldLclNum = lvaTable[srcLclNum].lvFieldLclStart + i;
                 srcFld                  = gtNewLclvNode(srcFieldLclNum, lvaTable[srcFieldLclNum].TypeGet());
-
-                noway_assert(srcLclVarTree != nullptr);
-                srcFld->gtFlags |= srcLclVarTree->gtFlags & ~GTF_NODE_MASK;
+                srcFld->gtFlags |= lvaTable[srcFieldLclNum].lvAddrExposed ? GTF_GLOB_REF : 0;
             }
             else
             {
@@ -10290,6 +10277,7 @@ GenTree* Compiler::fgMorphCopyBlock(GenTree* tree)
                     noway_assert(addrSpill == nullptr);
 
                     srcFld = gtNewLclvNode(srcLclNum, lvaGetDesc(srcLclNum)->TypeGet());
+                    srcFld->gtFlags |= lvaTable[srcLclNum].lvAddrExposed ? GTF_GLOB_REF : 0;
                 }
                 else
                 {


### PR DESCRIPTION
`fgMorphCopyBlock` copies the flags from the original `LCL_VAR` node when creating new `LCL_VAR` nodes for field by field assignments. This is not necessary and can cause CQ issues:
* `GTF_VAR_DEF` and `GTF_DONT_CSE` are set by `gtNewAssignNode` as needed
* `GTF_DONT_CSE` may be present on the original `LCL_VAR` node due it being wrapped in `OBJ`/`ADDR` but the new `LCL_VAR` node is not and doesn't need `GTF_DONT_CSE` unless on the LHS of `ASG`. While there's no meaningful CSE that the new node may participate in, `GTF_DONT_CSE` also blocks VN const propagation.
* `GTF_VAR_USEASG` is obviously not needed on a `LCL_VAR`
* `GTF_GLOB_REF` can simply be set if the referenced is address exposed, no need to copy it
* `GTF_LATE_ARG` is not needed on these nodes, only on the top level assignment/comma
* `GTF_COLON_COND` was specifically not copied.   That's actually suspect, probably the only reason why this works is that the chance of having a copy block under a `QMARK` is practically 0.

Diff:
```
win-x64:
Total bytes of diff: -2122 (-0.01% of base)
    diff is an improvement.
Top file regressions by size (bytes):
           2 : System.Private.DataContractSerialization.dasm (0.00% of base)
           1 : System.IO.Compression.dasm (0.00% of base)
           1 : System.IO.Compression.ZipFile.dasm (0.02% of base)
Top file improvements by size (bytes):
        -676 : System.Linq.Parallel.dasm (-0.11% of base)
        -583 : System.Private.CoreLib.dasm (-0.02% of base)
        -168 : System.Net.Http.dasm (-0.04% of base)
        -142 : System.Memory.dasm (-0.18% of base)
         -94 : System.Security.Cryptography.Algorithms.dasm (-0.04% of base)
30 total files with size differences (27 improved, 3 regressed), 79 unchanged.
Top method regressions by size (bytes):
           8 ( 0.45% of base) : System.Private.Uri.dasm - IPv6AddressHelper:ParseCanonicalName(String,int,byref,byref):String
           5 ( 0.36% of base) : Microsoft.CodeAnalysis.dasm - <DescendantTriviaOnly>d__160:MoveNext():bool:this
           4 ( 0.24% of base) : Microsoft.CodeAnalysis.dasm - <DescendantTriviaIntoTrivia>d__161:MoveNext():bool:this
           4 ( 1.43% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - LookupResult:MergeMembersOfTheSameType(SingleLookupResult,bool):this
           4 ( 1.02% of base) : System.Private.CoreLib.dasm - DateTimeFormat:FormatStringBuilder(DateTime,ReadOnlySpan`1,DateTimeFormatInfo,TimeSpan):StringBuilder
Top method improvements by size (bytes):
        -152 (-1.52% of base) : System.Net.Http.dasm - KnownHeaders:.cctor()
        -111 (-2.85% of base) : System.Linq.Parallel.dasm - AssociativeAggregationOperator`3:Aggregate():Nullable`1:this (5 methods)
         -84 (-11.59% of base) : System.Security.Cryptography.Algorithms.dasm - ECCng:ImportKeyBlob(String,ReadOnlySpan`1,String,SafeNCryptProviderHandle):SafeNCryptKeyHandle
         -84 (-11.59% of base) : System.Security.Cryptography.Cng.dasm - ECCng:ImportKeyBlob(String,ReadOnlySpan`1,String,SafeNCryptProviderHandle):SafeNCryptKeyHandle
         -54 (-1.15% of base) : System.Private.CoreLib.dasm - CustomAttributeBuilder:InitCustomAttributeBuilder(ConstructorInfo,ref,ref,ref,ref,ref):this
Top method regressions by size (percentage):
           1 ( 2.63% of base) : System.IO.Compression.dasm - ZipArchive:CreateEntry(String):ZipArchiveEntry:this
           1 ( 2.63% of base) : System.IO.Compression.ZipFile.dasm - ZipFileExtensions:CreateEntryFromFile(ZipArchive,String,String):ZipArchiveEntry
           2 ( 2.15% of base) : Microsoft.CodeAnalysis.dasm - DeltaMetadataWriter:PopulateEncLogTableRows(List`1,int,int,int)
           2 ( 1.79% of base) : System.CommandLine.dasm - HelpBuilderFactory:CreateHelpBuilder(BindingContext):IHelpBuilder:this
           4 ( 1.43% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - LookupResult:MergeMembersOfTheSameType(SingleLookupResult,bool):this
Top method improvements by size (percentage):
         -84 (-11.59% of base) : System.Security.Cryptography.Algorithms.dasm - ECCng:ImportKeyBlob(String,ReadOnlySpan`1,String,SafeNCryptProviderHandle):SafeNCryptKeyHandle
         -84 (-11.59% of base) : System.Security.Cryptography.Cng.dasm - ECCng:ImportKeyBlob(String,ReadOnlySpan`1,String,SafeNCryptProviderHandle):SafeNCryptKeyHandle
          -7 (-6.31% of base) : System.Private.CoreLib.dasm - StringBuilder:AppendFormat(String,Object,Object):StringBuilder:this
          -7 (-5.60% of base) : Microsoft.CodeAnalysis.dasm - LineDirectiveMap`1:FindEntryIndex(int):int:this
         -23 (-5.26% of base) : System.Linq.Parallel.dasm - NullableDecimalSumAggregationOperator:InternalAggregate(byref):Nullable`1:this
304 total methods with size differences (270 improved, 34 regressed), 147214 unchanged.

linux-x64:
Total bytes of diff: -5439 (-0.01% of base)
    diff is an improvement.
Top file regressions by size (bytes):
          24 : Microsoft.CodeAnalysis.VisualBasic.dasm (0.00% of base)
Top file improvements by size (bytes):
       -1268 : System.Linq.Parallel.dasm (-0.10% of base)
       -1210 : System.Net.Http.dasm (-0.10% of base)
       -1104 : System.Private.CoreLib.dasm (-0.01% of base)
        -418 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00% of base)
        -302 : System.Memory.dasm (-0.15% of base)
26 total files with size differences (25 improved, 1 regressed), 83 unchanged.
Top method regressions by size (bytes):
          76 ( 3.21% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Scanner:ScanXmlTriviaInXmlDoc(ushort,SyntaxListBuilder`1):bool:this (4 methods)
          64 ( 4.03% of base) : Microsoft.CodeAnalysis.CSharp.dasm - TypeMap:.ctor(NamedTypeSymbol,ImmutableArray`1,ImmutableArray`1):this (4 methods)
          64 ( 3.86% of base) : Microsoft.CodeAnalysis.CSharp.dasm - TypeMap:ConstructMapping(ImmutableArray`1,ImmutableArray`1):SmallDictionary`2 (4 methods)
          48 ( 0.54% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Scanner:ScanXmlElementInXmlDoc(int):SyntaxToken:this (4 methods)
          38 ( 4.37% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - <>c__DisplayClass4_0:<.ctor>b__0(GCBulkTypeTraceData):this (2 methods)
Top method improvements by size (bytes):
       -1194 (-5.21% of base) : System.Net.Http.dasm - KnownHeaders:.cctor() (2 methods)
        -134 (-7.72% of base) : System.Security.Cryptography.Algorithms.dasm - ECCng:ImportKeyBlob(String,ReadOnlySpan`1,String,SafeNCryptProviderHandle):SafeNCryptKeyHandle (2 methods)
        -134 (-7.72% of base) : System.Security.Cryptography.Cng.dasm - ECCng:ImportKeyBlob(String,ReadOnlySpan`1,String,SafeNCryptProviderHandle):SafeNCryptKeyHandle (2 methods)
        -120 (-2.38% of base) : Microsoft.CodeAnalysis.CSharp.dasm - BinderFactoryVisitor:VisitAccessorDeclaration(AccessorDeclarationSyntax):Binder:this (4 methods)
        -102 (-2.77% of base) : System.Private.CoreLib.dasm - RuntimeParameterInfo:GetParameters(IRuntimeMethodInfo,MemberInfo,Signature,byref,bool):ref (2 methods)
Top method regressions by size (percentage):
          38 ( 4.37% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - <>c__DisplayClass4_0:<.ctor>b__0(GCBulkTypeTraceData):this (2 methods)
          64 ( 4.03% of base) : Microsoft.CodeAnalysis.CSharp.dasm - TypeMap:.ctor(NamedTypeSymbol,ImmutableArray`1,ImmutableArray`1):this (4 methods)
          64 ( 3.86% of base) : Microsoft.CodeAnalysis.CSharp.dasm - TypeMap:ConstructMapping(ImmutableArray`1,ImmutableArray`1):SmallDictionary`2 (4 methods)
          76 ( 3.21% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Scanner:ScanXmlTriviaInXmlDoc(ushort,SyntaxListBuilder`1):bool:this (4 methods)
           4 ( 2.78% of base) : System.Reflection.Metadata.dasm - DebugDirectoryBuilder:AddEntry(int,int,int):this (2 methods)
Top method improvements by size (percentage):
         -24 (-17.39% of base) : System.Private.CoreLib.dasm - CharEnumerable:System.Collections.IEnumerable.GetEnumerator():IEnumerator:this (2 methods)
         -24 (-17.39% of base) : System.Private.CoreLib.dasm - CharEnumerable:System.Collections.Generic.IEnumerable<System.Char>.GetEnumerator():IEnumerator`1:this (2 methods)
         -24 (-16.44% of base) : System.Reflection.Metadata.dasm - AssemblyReferenceHandleCollection:System.Collections.Generic.IEnumerable<System.Reflection.Metadata.AssemblyReferenceHandle>.GetEnumerator():IEnumerator`1:this (2 methods)
         -24 (-16.44% of base) : System.Reflection.Metadata.dasm - AssemblyReferenceHandleCollection:System.Collections.IEnumerable.GetEnumerator():IEnumerator:this (2 methods)
         -82 (-7.75% of base) : System.Linq.Parallel.dasm - NullableDoubleAverageAggregationOperator:InternalAggregate(byref):Nullable`1:this (2 methods)
298 total methods with size differences (262 improved, 36 regressed), 146826 unchanged.
```
Small regressions caused by changes in register allocation (resulting in extra REX prefixes) or unfortunate VN copy propagation decisions.