### PR TITLE
Improve `new Vector4(0)` ARM64 codegen

### DIFF
--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -4719,7 +4719,8 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
             // zero in the target register, because an xor is smaller than a copy. Note that we could
             // potentially handle this in the register allocator, but we can't always catch it there
             // because the target may not have a register allocated for it yet.
-            if (op1->isUsedFromReg() && (op1->GetRegNum() != targetReg) && (op1->IsIntegralConst(0) || op1->IsFPZero()))
+            if (op1->isUsedFromReg() && (op1->GetRegNum() != targetReg) &&
+                (op1->IsIntegralConst(0) || op1->IsDblConPositiveZero()))
             {
                 op1->SetRegNum(REG_NA);
                 op1->ResetReuseRegVal();

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -12960,7 +12960,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 tiRetVal        = se.seTypeInfo;
                 op1             = tree;
 
-                if (!opts.compDbgCode && !op1->IsIntegralConst(0) && !op1->IsFPZero() && !op1->IsLocal())
+                if (!opts.compDbgCode && !op1->IsIntegralConst(0) && !op1->IsDblConPositiveZero() && !op1->IsLocal())
                 {
                     const unsigned tmpNum = lvaGrabTemp(true DEBUGARG("dup spill"));
                     impAssignTempGen(tmpNum, op1, tiRetVal.GetClassHandle(), (unsigned)CHECK_SPILL_ALL);

--- a/src/coreclr/src/jit/jitstd/utility.h
+++ b/src/coreclr/src/jit/jitstd/utility.h
@@ -11,6 +11,16 @@
 namespace jitstd
 {
 
+    template<class To, class From>
+    To bit_cast(const From& from)
+    {
+        static_assert_no_msg(sizeof(To) == sizeof(From));
+
+        To to;
+        memcpy(&to, &from, sizeof(to));
+        return to;
+    }
+
 namespace utility
 {
     // Template class for scoped execution of a lambda.

--- a/src/coreclr/src/jit/lowerarmarch.cpp
+++ b/src/coreclr/src/jit/lowerarmarch.cpp
@@ -812,7 +812,7 @@ void Lowering::ContainCheckSIMD(GenTreeSIMD* simdNode)
 
         case SIMDIntrinsicInit:
             op1 = simdNode->GetOp(0);
-            if (op1->IsIntegralConst(0))
+            if (op1->IsIntegralConst(0) || op1->IsDblConPositiveZero())
             {
                 MakeSrcContained(simdNode, op1);
             }

--- a/src/coreclr/src/jit/lowerxarch.cpp
+++ b/src/coreclr/src/jit/lowerxarch.cpp
@@ -2465,7 +2465,7 @@ void Lowering::ContainCheckSIMD(GenTreeSIMD* simdNode)
             }
             else
 #endif // !TARGET_64BIT
-                if (op1->IsFPZero() || op1->IsIntegralConst(0) ||
+                if (op1->IsDblConPositiveZero() || op1->IsIntegralConst(0) ||
                     (varTypeIsIntegral(simdNode->gtSIMDBaseType) && op1->IsIntegralConst(-1)))
             {
                 MakeSrcContained(simdNode, op1);

--- a/src/coreclr/src/jit/lsra.cpp
+++ b/src/coreclr/src/jit/lsra.cpp
@@ -2711,16 +2711,10 @@ bool LinearScan::isMatchingConstant(RegRecord* physRegRecord, RefPosition* refPo
                 }
                 break;
             case GT_CNS_DBL:
-            {
                 // For floating point constants, the values must be identical, not simply compare
                 // equal.  So we compare the bits.
-                if (refPosition->treeNode->AsDblCon()->isBitwiseEqual(otherTreeNode->AsDblCon()) &&
-                    (refPosition->treeNode->TypeGet() == otherTreeNode->TypeGet()))
-                {
-                    return true;
-                }
-                break;
-            }
+                return (refPosition->treeNode->GetType() == otherTreeNode->GetType()) &&
+                       (refPosition->treeNode->AsDblCon()->GetBits() == otherTreeNode->AsDblCon()->GetBits());
             default:
                 break;
         }

--- a/src/coreclr/src/jit/simdcodegenxarch.cpp
+++ b/src/coreclr/src/jit/simdcodegenxarch.cpp
@@ -828,7 +828,7 @@ void CodeGen::genSIMDIntrinsicInit(GenTreeSIMD* simdNode)
 #endif // !defined(TARGET_64BIT)
         if (op1->isContained())
     {
-        if (op1->IsIntegralConst(0) || op1->IsFPZero())
+        if (op1->IsIntegralConst(0) || op1->IsDblConPositiveZero())
         {
             genSIMDZero(targetType, baseType, targetReg);
         }


### PR DESCRIPTION
Generate
```
    movi    v16.4s, #0x00
```
instead of
```
    movi    v16.16b, #0x00
    dup     v16.4s, v16.s[0]
```
```
Total bytes of diff: -80 (-0.00% of base)
    diff is an improvement.
Top file improvements (bytes):
         -80 : System.Private.CoreLib.dasm (-0.00% of base)
1 total files with Code Size differences (1 improved, 0 regressed), 233 unchanged.
Top method improvements (bytes):
          -8 (-0.56% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateBillboard(Vector3,Vector3,Vector3,Vector3):Matrix4x4 (2 methods)
          -8 (-0.26% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateConstrainedBillboard(Vector3,Vector3,Vector3,Vector3,Vector3):Matrix4x4 (2 methods)
          -8 (-0.65% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateWorld(Vector3,Vector3,Vector3):Matrix4x4 (2 methods)
          -8 (-0.21% of base) : System.Private.CoreLib.dasm - Matrix4x4:Decompose(Matrix4x4,byref,byref,byref):bool (2 methods)
          -8 (-8.33% of base) : System.Private.CoreLib.dasm - Vector2:Negate(Vector2):Vector2 (2 methods)
          -8 (-8.33% of base) : System.Private.CoreLib.dasm - Vector2:op_UnaryNegation(Vector2):Vector2 (2 methods)
          -8 (-7.14% of base) : System.Private.CoreLib.dasm - Vector3:Negate(Vector3):Vector3 (2 methods)
          -8 (-7.14% of base) : System.Private.CoreLib.dasm - Vector3:op_UnaryNegation(Vector3):Vector3 (2 methods)
          -8 (-6.25% of base) : System.Private.CoreLib.dasm - Vector4:Negate(Vector4):Vector4 (2 methods)
          -8 (-6.25% of base) : System.Private.CoreLib.dasm - Vector4:op_UnaryNegation(Vector4):Vector4 (2 methods)
Top method improvements (percentages):
          -8 (-8.33% of base) : System.Private.CoreLib.dasm - Vector2:Negate(Vector2):Vector2 (2 methods)
          -8 (-8.33% of base) : System.Private.CoreLib.dasm - Vector2:op_UnaryNegation(Vector2):Vector2 (2 methods)
          -8 (-7.14% of base) : System.Private.CoreLib.dasm - Vector3:Negate(Vector3):Vector3 (2 methods)
          -8 (-7.14% of base) : System.Private.CoreLib.dasm - Vector3:op_UnaryNegation(Vector3):Vector3 (2 methods)
          -8 (-6.25% of base) : System.Private.CoreLib.dasm - Vector4:Negate(Vector4):Vector4 (2 methods)
          -8 (-6.25% of base) : System.Private.CoreLib.dasm - Vector4:op_UnaryNegation(Vector4):Vector4 (2 methods)
          -8 (-0.65% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateWorld(Vector3,Vector3,Vector3):Matrix4x4 (2 methods)
          -8 (-0.56% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateBillboard(Vector3,Vector3,Vector3,Vector3):Matrix4x4 (2 methods)
          -8 (-0.26% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateConstrainedBillboard(Vector3,Vector3,Vector3,Vector3,Vector3):Matrix4x4 (2 methods)
          -8 (-0.21% of base) : System.Private.CoreLib.dasm - Matrix4x4:Decompose(Matrix4x4,byref,byref,byref):bool (2 methods)
10 total methods with Code Size differences (10 improved, 0 regressed), 183630 unchanged.
```