### PR TITLE
Improve ARM64 STORE_LCLVAR|LCLFLD|IND(0)

### DIFF
--- a/src/coreclr/src/jit/codegenlinear.cpp
+++ b/src/coreclr/src/jit/codegenlinear.cpp
@@ -1446,7 +1446,7 @@ void CodeGen::genConsumeRegs(GenTree* tree)
 #ifdef FEATURE_SIMD
             // (In)Equality operation that produces bool result, when compared
             // against Vector zero, marks its Vector Zero operand as contained.
-            assert(tree->OperIsLeaf() || tree->IsIntegralConstVector(0));
+            assert(tree->OperIsLeaf() || tree->IsSIMDZero());
 #else
             assert(tree->OperIsLeaf());
 #endif

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -1622,9 +1622,10 @@ public:
     bool IsValidCallArgument();
 #endif // DEBUG
 
-    inline bool IsDblConPositiveZero();
-    inline bool IsIntegralConst(ssize_t constVal);
-    inline bool IsIntegralConstVector(ssize_t constVal);
+    bool IsDblConPositiveZero() const;
+    bool IsSIMDZero() const;
+    bool IsIntegralConst(ssize_t constVal);
+    bool IsIntegralConstVector(ssize_t constVal);
 
     inline bool IsBoxedValue();
 
@@ -6908,9 +6909,15 @@ inline bool GenTree::OperIsCopyBlkOp()
 // Return Value:
 //    Returns true iff the tree is an GT_CNS_DBL, with value of +0.0.
 
-inline bool GenTree::IsDblConPositiveZero()
+inline bool GenTree::IsDblConPositiveZero() const
 {
     return OperIs(GT_CNS_DBL) && AsDblCon()->IsPositiveZero();
+}
+
+inline bool GenTree::IsSIMDZero() const
+{
+    return OperIs(GT_SIMD) && (AsSIMD()->gtSIMDIntrinsicID == SIMDIntrinsicInit) &&
+           (AsSIMD()->GetOp(0)->IsIntegralConst(0) || AsSIMD()->GetOp(0)->IsDblConPositiveZero());
 }
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
0 can always be contained on stores, either XZR or an immediate 0 can be used depending on the destination.

```
Total bytes of diff: -145168 (-0.12% of base)
    diff is an improvement.
Top file improvements (bytes):
      -25328 : System.Private.CoreLib.dasm (-0.23% of base)
      -19464 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.13% of base)
      -15112 : Microsoft.CodeAnalysis.dasm (-0.33% of base)
      -10304 : Microsoft.CodeAnalysis.CSharp.dasm (-0.08% of base)
       -6208 : System.Net.Http.dasm (-0.33% of base)
       -6008 : System.Private.Xml.dasm (-0.06% of base)
       -4448 : System.Drawing.Common.dasm (-0.44% of base)
       -2864 : System.Linq.Parallel.dasm (-0.17% of base)
       -2280 : System.Data.Common.dasm (-0.06% of base)
       -2240 : System.Reflection.Metadata.dasm (-0.21% of base)
       -2112 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.02% of base)
       -1864 : System.Net.HttpListener.dasm (-0.26% of base)
       -1728 : System.Net.Security.dasm (-0.28% of base)
       -1688 : System.Threading.Tasks.Dataflow.dasm (-0.25% of base)
       -1640 : System.Drawing.Primitives.dasm (-1.68% of base)
       -1608 : Microsoft.VisualBasic.Core.dasm (-0.11% of base)
       -1408 : System.Management.dasm (-0.12% of base)
       -1392 : Newtonsoft.Json.dasm (-0.06% of base)
       -1296 : System.Data.OleDb.dasm (-0.14% of base)
       -1256 : System.Private.DataContractSerialization.dasm (-0.05% of base)
150 total files with Code Size differences (150 improved, 0 regressed), 84 unchanged.
Top method regressions (bytes):
         272 ( 1.18% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BinderFactory:CreateBinderForNodeAndUsage(VisualBasicSyntaxNode,ubyte,Binder):Binder:this (4 methods)
          80 ( 2.22% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Reader:CanReuse(SyntaxNodeOrToken):bool:this (4 methods)
          80 ( 8.93% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourcePropertySymbol:IsDefinedInSourceTree(SyntaxTree,Nullable`1,CancellationToken):bool:this (4 methods)
          64 ( 5.56% of base) : Microsoft.CodeAnalysis.dasm - ILBuilder:MarkReachableFromBranch(ArrayBuilder`1,BasicBlock) (4 methods)
          64 ( 3.01% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - LocalRewriter:RewriteDecimalUnaryOperator(BoundUnaryOperator):BoundExpression:this (4 methods)
          64 (12.50% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SynthesizedWithEventsAccessorSymbol:get_Syntax():VisualBasicSyntaxNode:this (4 methods)
          48 (11.11% of base) : Microsoft.CodeAnalysis.CSharp.dasm - <>c__DisplayClass105_0:<MostSpecificSourceTypeForImplicitUserDefinedConversion>b__0(UserDefinedConversionAnalysis):bool:this (4 methods)
          48 (11.11% of base) : Microsoft.CodeAnalysis.CSharp.dasm - <>c__DisplayClass106_0:<MostSpecificTargetTypeForImplicitUserDefinedConversion>b__0(UserDefinedConversionAnalysis):bool:this (4 methods)
          48 (11.11% of base) : Microsoft.CodeAnalysis.CSharp.dasm - <>c__DisplayClass99_0:<MostSpecificSourceTypeForExplicitUserDefinedConversion>b__0(UserDefinedConversionAnalysis):bool:this (4 methods)
          48 (11.11% of base) : Microsoft.CodeAnalysis.CSharp.dasm - <>c__DisplayClass100_0:<MostSpecificTargetTypeForExplicitUserDefinedConversion>b__0(UserDefinedConversionAnalysis):bool:this (4 methods)
          48 ( 0.79% of base) : Microsoft.CodeAnalysis.dasm - SyntaxDiffer:FindBestMatch(Stack`1,SyntaxNodeOrToken,byref,byref,int):this (4 methods)
          48 ( 0.57% of base) : Microsoft.CodeAnalysis.dasm - SeparatedSyntaxList`1:InsertRange(int,IEnumerable`1):SeparatedSyntaxList`1:this (4 methods)
          48 ( 1.56% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - MethodToClassRewriter`1:VisitMethodSymbol(MethodSymbol):MethodSymbol:this (4 methods)
          40 ( 3.68% of base) : System.Configuration.ConfigurationManager.dasm - ClientConfigurationHost:GetStreamName(String):String:this (2 methods)
          40 (10.00% of base) : System.Data.OleDb.dasm - OleDbConnection:get_Provider():String:this (2 methods)
          40 ( 0.78% of base) : System.Private.CoreLib.dasm - Utf8Formatter:TryFormat(long,Span`1,byref,StandardFormat):bool (4 methods)
          40 (12.50% of base) : System.Private.CoreLib.dasm - Task`1:get_DebuggerDisplayResultDescription():String:this (2 methods)
          40 ( 7.25% of base) : System.Threading.Tasks.Dataflow.dasm - Common:PropagateCompletion(Task,IDataflowBlock,Action`1) (2 methods)
          40 ( 2.75% of base) : xunit.console.dasm - DependencyContextAssemblyCache:GetFallbackRuntime(String):String:this (2 methods)
          32 ( 0.27% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:CheckViability(Symbol,int,int,TypeSymbol,bool,byref,ConsList`1):SingleLookupResult:this (4 methods)
Top method improvements (bytes):
       -2352 (-4.14% of base) : System.Private.CoreLib.dasm - ValueTuple`8:GetHashCode():int:this (36 methods)
       -1072 (-3.82% of base) : Microsoft.CodeAnalysis.dasm - PeWriter:WriteHeaders(Stream,NtHeader,CoffHeader,List`1,byref):this (4 methods)
       -1008 (-2.04% of base) : System.Private.CoreLib.dasm - ValueTuple`8:ToString():String:this (36 methods)
       -1008 (-2.12% of base) : System.Private.CoreLib.dasm - ValueTuple`8:System.IValueTupleInternal.ToStringEnd():String:this (36 methods)
        -840 (-2.08% of base) : System.Net.Http.dasm - Huffman:.cctor() (2 methods)
        -600 (-2.06% of base) : System.Net.Http.dasm - KnownHeaders:.cctor() (2 methods)
        -480 (-13.10% of base) : System.Drawing.Primitives.dasm - ColorTranslator:FromOle(int):Color (2 methods)
        -472 (-2.78% of base) : System.Private.Xml.dasm - BigNumber:.cctor() (2 methods)
        -464 (-8.84% of base) : Microsoft.CodeAnalysis.CSharp.dasm - BinopEasyOut:TypeToIndex(TypeSymbol):Nullable`1 (4 methods)
        -464 (-8.84% of base) : Microsoft.CodeAnalysis.CSharp.dasm - UnopEasyOut:TypeToIndex(TypeSymbol):Nullable`1 (4 methods)
        -448 (-0.29% of base) : Microsoft.CodeAnalysis.dasm - DesktopAssemblyIdentityComparer:.cctor() (4 methods)
        -432 (-6.12% of base) : System.Drawing.Primitives.dasm - ColorTranslator:InitializeHtmlSysColorTable() (2 methods)
        -416 (-5.44% of base) : Microsoft.CodeAnalysis.dasm - MetadataWriter:SerializeAssemblyRefTable(BlobBuilder,MetadataSizes):this (4 methods)
        -368 (-3.29% of base) : Microsoft.CodeAnalysis.dasm - PeWriter:WriteDirectory(Directory,BlobBuilder,int,int,int,int,BlobBuilder):this (4 methods)
        -352 (-5.71% of base) : Microsoft.CodeAnalysis.dasm - MetadataWriter:SerializeTypeDefTable(BlobBuilder,MetadataSizes):this (4 methods)
        -320 (-6.21% of base) : Microsoft.CodeAnalysis.dasm - MetadataWriter:SerializeMethodDefTable(BlobBuilder,MetadataSizes,int):this (4 methods)
        -224 (-1.84% of base) : Microsoft.CodeAnalysis.CSharp.dasm - OverloadResolution:GetEnumOperation(int,TypeSymbol,BoundExpression,BoundExpression,ArrayBuilder`1):this (4 methods)
        -224 (-4.40% of base) : Microsoft.CodeAnalysis.dasm - MetadataWriter:SerializeImplMapTable(BlobBuilder,MetadataSizes):this (4 methods)
        -216 (-5.88% of base) : System.Linq.Parallel.dasm - QueryOperator`1:GetEnumerator():IEnumerator`1:this (54 methods)
        -216 (-2.35% of base) : System.Private.CoreLib.dasm - Dictionary`2:TrimExcess(int):this (20 methods)
Top method regressions (percentages):
          32 (25.00% of base) : System.Private.CoreLib.dasm - String:Concat(Object):String (2 methods)
          32 (19.05% of base) : System.Private.CoreLib.dasm - Task`1:get_DebuggerDisplayMethodDescription():String:this (2 methods)
          32 (19.05% of base) : System.Private.CoreLib.dasm - Task:get_DebuggerDisplayMethodDescription():String:this (2 methods)
          32 (16.00% of base) : System.Configuration.ConfigurationManager.dasm - ConfigurationException:GetXmlNodeFilename(XmlNode):String (2 methods)
          32 (15.38% of base) : xunit.core.dasm - <>c:<GetData>b__17_1(Object):String:this (2 methods)
          32 (13.33% of base) : System.Data.Common.dasm - DbCommandBuilder:GetColumnValue(DataRow,String,DataTableMapping,int):Object:this (2 methods)
          64 (12.50% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SynthesizedWithEventsAccessorSymbol:get_Syntax():VisualBasicSyntaxNode:this (4 methods)
          40 (12.50% of base) : System.Private.CoreLib.dasm - Task`1:get_DebuggerDisplayResultDescription():String:this (2 methods)
          48 (11.11% of base) : Microsoft.CodeAnalysis.CSharp.dasm - <>c__DisplayClass105_0:<MostSpecificSourceTypeForImplicitUserDefinedConversion>b__0(UserDefinedConversionAnalysis):bool:this (4 methods)
          48 (11.11% of base) : Microsoft.CodeAnalysis.CSharp.dasm - <>c__DisplayClass106_0:<MostSpecificTargetTypeForImplicitUserDefinedConversion>b__0(UserDefinedConversionAnalysis):bool:this (4 methods)
          48 (11.11% of base) : Microsoft.CodeAnalysis.CSharp.dasm - <>c__DisplayClass99_0:<MostSpecificSourceTypeForExplicitUserDefinedConversion>b__0(UserDefinedConversionAnalysis):bool:this (4 methods)
          48 (11.11% of base) : Microsoft.CodeAnalysis.CSharp.dasm - <>c__DisplayClass100_0:<MostSpecificTargetTypeForExplicitUserDefinedConversion>b__0(UserDefinedConversionAnalysis):bool:this (4 methods)
          16 (10.00% of base) : Newtonsoft.Json.dasm - JsonWriter:get_Top():int:this (2 methods)
          40 (10.00% of base) : System.Data.OleDb.dasm - OleDbConnection:get_Provider():String:this (2 methods)
          32 ( 9.76% of base) : System.Diagnostics.PerformanceCounter.dasm - DiagnosticsConfiguration:get_ConfigFilePath():String (2 methods)
          80 ( 8.93% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourcePropertySymbol:IsDefinedInSourceTree(SyntaxTree,Nullable`1,CancellationToken):bool:this (4 methods)
          16 ( 8.70% of base) : System.Runtime.Serialization.Formatters.dasm - NameInfo:get_NIname():String:this (2 methods)
          40 ( 7.25% of base) : System.Threading.Tasks.Dataflow.dasm - Common:PropagateCompletion(Task,IDataflowBlock,Action`1) (2 methods)
          32 ( 5.80% of base) : Microsoft.VisualBasic.Core.dasm - Interaction:InvokeMethod(String,ref):Object (2 methods)
          16 ( 5.71% of base) : System.Reflection.MetadataLoadContext.dasm - RoAssembly:ToString():String:this (2 methods)
Top method improvements (percentages):
         -48 (-17.14% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateTranslation(float,float,float):Matrix4x4 (2 methods)
          -8 (-16.67% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - HistogramController:InvalidateScale():this (2 methods)
          -8 (-14.29% of base) : System.Data.Common.dasm - SqlDouble:.ctor(bool):this (2 methods)
          -8 (-14.29% of base) : System.Data.Common.dasm - SqlSingle:.ctor(bool):this (2 methods)
        -480 (-13.10% of base) : System.Drawing.Primitives.dasm - ColorTranslator:FromOle(int):Color (2 methods)
         -24 (-13.04% of base) : System.Runtime.WindowsRuntime.UI.Xaml.dasm - Matrix:CreateIdentity():Matrix (2 methods)
         -40 (-12.82% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateTranslation(Vector3):Matrix4x4 (2 methods)
         -16 (-12.50% of base) : Microsoft.CodeAnalysis.dasm - FloatFloatingPointType:get_Zero():long:this (4 methods)
          -8 (-12.50% of base) : System.Linq.dasm - CopyPosition:get_Start():CopyPosition (2 methods)
         -16 (-12.50% of base) : System.Private.CoreLib.dasm - NullStream:ReadAsync(Memory`1,CancellationToken):ValueTask`1:this (2 methods)
         -32 (-12.50% of base) : System.Private.CoreLib.dasm - Matrix4x4:.ctor(Matrix3x2):this (2 methods)
         -16 (-11.76% of base) : System.Drawing.Primitives.dasm - SystemColors:get_ActiveBorder():Color (2 methods)
         -16 (-11.76% of base) : System.Private.CoreLib.dasm - Matrix3x2:CreateTranslation(float,float):Matrix3x2 (2 methods)
         -16 (-11.11% of base) : Microsoft.CodeAnalysis.dasm - SubsystemVersion:get_None():SubsystemVersion (4 methods)
         -16 (-11.11% of base) : Microsoft.CodeAnalysis.dasm - Location:get_SourceSpan():TextSpan:this (4 methods)
          -8 (-11.11% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - StackSource:get_SamplingRate():Nullable`1:this (2 methods)
         -16 (-11.11% of base) : System.Drawing.Primitives.dasm - SystemColors:get_ActiveCaption():Color (2 methods)
         -16 (-11.11% of base) : System.Drawing.Primitives.dasm - SystemColors:get_ActiveCaptionText():Color (2 methods)
         -16 (-11.11% of base) : System.Drawing.Primitives.dasm - SystemColors:get_AppWorkspace():Color (2 methods)
         -16 (-11.11% of base) : System.Drawing.Primitives.dasm - SystemColors:get_ButtonFace():Color (2 methods)
8440 total methods with Code Size differences (8269 improved, 171 regressed), 175200 unchanged.
3 files had text diffs but no metric diffs.
System.Net.WebProxy.dasm had 20 diffs
Microsoft.Diagnostics.Tools.RuntimeClient.dasm had 12 diffs
Microsoft.Extensions.FileProviders.Composite.dasm had 12 diffs
```
Regressions seem to be caused by unfortunate changes in register allocation, it may be that LSRA's constant interval handling may need improvements. In general, on ARM64 if 0 is loaded into a GPR then all subsequent uses of that register could be replaced with XZR instead of allocating an actual register.