### PR TITLE
Generate more STRUCT typed LCL_FLDs

### DIFF
--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -1150,6 +1150,13 @@ unsigned CodeGenInterface::InferStructOpSizeAlign(GenTree* op, unsigned* alignme
         opSize                      = op->AsObj()->GetLayout()->GetSize();
         alignment = roundUp(compiler->info.compCompHnd->getClassAlignmentRequirement(clsHnd), TARGET_POINTER_SIZE);
     }
+    else if (op->OperIs(GT_LCL_FLD))
+    {
+        ClassLayout*         layout = op->AsLclFld()->GetLayout(compiler);
+        CORINFO_CLASS_HANDLE clsHnd = layout->GetClassHandle();
+        opSize                      = layout->GetSize();
+        alignment = roundUp(compiler->info.compCompHnd->getClassAlignmentRequirement(clsHnd), TARGET_POINTER_SIZE);
+    }
     else if (op->gtOper == GT_LCL_VAR)
     {
         unsigned   varNum = op->AsLclVarCommon()->GetLclNum();

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -16038,8 +16038,14 @@ CORINFO_CLASS_HANDLE Compiler::gtGetStructHandleIfPresent(GenTree* tree)
                 structHnd = gtGetStructHandleIfPresent(tree->gtGetOp1());
                 break;
             case GT_LCL_FLD:
+                ClassLayout* layout;
+                layout = tree->AsLclFld()->GetLayout(this);
+                if ((layout != nullptr) && !layout->IsBlockLayout())
+                {
+                    structHnd = layout->GetClassHandle();
+                }
 #ifdef FEATURE_SIMD
-                if (varTypeIsSIMD(tree))
+                else if (varTypeIsSIMD(tree))
                 {
                     structHnd = gtGetStructHandleForSIMD(tree->gtType, TYP_FLOAT);
                 }

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -3255,6 +3255,9 @@ public:
         m_layoutNum = static_cast<uint16_t>(layoutNum);
     }
 
+    ClassLayout* GetLayout(Compiler* compiler) const;
+    void SetLayout(ClassLayout* layout, Compiler* compiler);
+
     FieldSeqNode* GetFieldSeq() const
     {
         return m_fieldSeq;

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -1173,8 +1173,8 @@ GenTree* Compiler::impAssignStructPtr(GenTree*             destAddr,
         ilOffset = impCurStmtOffs;
     }
 
-    assert(src->OperIs(GT_LCL_VAR, GT_FIELD, GT_IND, GT_OBJ, GT_CALL, GT_MKREFANY, GT_RET_EXPR, GT_COMMA) ||
-           (src->TypeGet() != TYP_STRUCT && (src->OperIsSimdOrHWintrinsic() || src->OperIs(GT_LCL_FLD))));
+    assert(src->OperIs(GT_LCL_VAR, GT_LCL_FLD, GT_FIELD, GT_IND, GT_OBJ, GT_CALL, GT_MKREFANY, GT_RET_EXPR, GT_COMMA) ||
+           (!src->TypeIs(TYP_STRUCT) && src->OperIsSimdOrHWintrinsic()));
 
     var_types asgType = src->TypeGet();
 

--- a/src/coreclr/src/jit/jit.h
+++ b/src/coreclr/src/jit/jit.h
@@ -515,7 +515,7 @@ const bool dspGCtbls = true;
         if (JitTls::GetCompiler()->verbose)                                                                            \
         {                                                                                                              \
             logf(__VA_ARGS__);                                                                                         \
-            gtDispTree(tree);                                                                                          \
+            JitTls::GetCompiler()->gtDispTree(tree);                                                                   \
         }                                                                                                              \
     }
 #define JITLOG(x)                                                                                                      \

--- a/src/coreclr/src/jit/lclmorph.cpp
+++ b/src/coreclr/src/jit/lclmorph.cpp
@@ -1054,7 +1054,8 @@ private:
             indir->ChangeOper(GT_LCL_VAR);
             indir->AsLclVar()->SetLclNum(val.LclNum());
         }
-        else if (!varTypeIsStruct(indir->TypeGet()) || m_compiler->lvaIsImplicitByRefLocal(val.LclNum()))
+        else if (!varTypeIsStruct(indir->GetType()) || m_compiler->lvaIsImplicitByRefLocal(val.LclNum()) ||
+                 ((user != nullptr) && user->OperIs(GT_ASG)))
         {
             indir->ChangeOper(GT_LCL_FLD);
             indir->AsLclFld()->SetLclNum(val.LclNum());
@@ -1063,7 +1064,7 @@ private:
 
             if (structLayout != nullptr)
             {
-                indir->AsLclFld()->SetLayoutNum(m_compiler->typGetLayoutNum(structLayout));
+                indir->AsLclFld()->SetLayout(structLayout, m_compiler);
             }
 
             // Promoted struct vars aren't currently handled here so the created LCL_FLD can't be

--- a/src/coreclr/src/jit/lclmorph.cpp
+++ b/src/coreclr/src/jit/lclmorph.cpp
@@ -1005,14 +1005,6 @@ private:
                 return;
             }
 
-            if ((user == nullptr) || !user->OperIs(GT_ASG))
-            {
-                // TODO-ADDR: Skip TYP_STRUCT indirs for now, unless they're used by an ASG.
-                // At least call args will require extra work because currently they must be
-                // wrapped in OBJ nodes so we can't replace those with local nodes.
-                return;
-            }
-
             if (indir->OperIs(GT_FIELD))
             {
                 CORINFO_CLASS_HANDLE fieldClassHandle;
@@ -1054,8 +1046,7 @@ private:
             indir->ChangeOper(GT_LCL_VAR);
             indir->AsLclVar()->SetLclNum(val.LclNum());
         }
-        else if (!varTypeIsStruct(indir->GetType()) || m_compiler->lvaIsImplicitByRefLocal(val.LclNum()) ||
-                 ((user != nullptr) && user->OperIs(GT_ASG)))
+        else
         {
             indir->ChangeOper(GT_LCL_FLD);
             indir->AsLclFld()->SetLclNum(val.LclNum());
@@ -1070,13 +1061,6 @@ private:
             // Promoted struct vars aren't currently handled here so the created LCL_FLD can't be
             // later transformed into a LCL_VAR and the variable cannot be enregistered.
             m_compiler->lvaSetVarDoNotEnregister(val.LclNum() DEBUGARG(Compiler::DNER_LocalField));
-        }
-        else
-        {
-            // TODO-ADDR: Add TYP_STRUCT support to LCL_FLD. Currently these are generated
-            // only for unpromoted implicit-by-ref args, that are converted back to indirs
-            // by IndirectArgMorphVisitor.
-            return;
         }
 
         unsigned flags = 0;
@@ -1095,6 +1079,10 @@ private:
                     flags |= GTF_VAR_USEASG;
                 }
             }
+        }
+        else if (indir->TypeIs(TYP_STRUCT) && (user != nullptr) && user->IsCall())
+        {
+            flags |= GTF_DONT_CSE;
         }
 
         indir->gtFlags = flags;

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -297,6 +297,30 @@ GenTree* Lowering::LowerNode(GenTree* node)
 
         case GT_STORE_LCL_FLD:
         {
+            if (node->OperIs(GT_STORE_LCL_FLD) && node->TypeIs(TYP_STRUCT))
+            {
+                GenTreeLclFld* addr = node->AsLclFld();
+                addr = comp->gtNewLclFldAddrNode(addr->GetLclNum(), addr->GetLclOffs(), FieldSeqStore::NotAField());
+                BlockRange().InsertBefore(node, addr);
+
+                ClassLayout* layout = node->AsLclFld()->GetLayout(comp);
+                GenTree*     src    = node->AsLclFld()->GetOp(0);
+
+                node->ChangeOper(GT_STORE_OBJ);
+
+                GenTreeObj* store = node->AsObj();
+                store->gtFlags    = GTF_ASG | GTF_IND_NONFAULTING | GTF_IND_TGT_NOT_HEAP;
+#ifndef JIT32_GCENCODER
+                store->gtBlkOpGcUnsafe = false;
+#endif
+                store->gtBlkOpKind = GenTreeObj::BlkOpKindInvalid;
+                store->SetLayout(layout);
+                store->SetAddr(addr);
+                store->SetData(src);
+                LowerBlockStore(store->AsObj());
+                break;
+            }
+
             GenTreeLclVarCommon* const store = node->AsLclVarCommon();
             GenTree*                   src   = store->gtGetOp1();
             if ((varTypeUsesFloatReg(store) != varTypeUsesFloatReg(src)) && !store->IsPhiDefn() &&

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -8773,9 +8773,8 @@ GenTree* Compiler::fgMorphInitBlock(GenTreeOp* asg)
         }
         else
         {
-            assert(!dest->TypeIs(TYP_STRUCT));
-
-            destSize     = genTypeSize(dest->GetType());
+            destSize =
+                dest->TypeIs(TYP_STRUCT) ? dest->AsLclFld()->GetLayout(this)->GetSize() : genTypeSize(dest->GetType());
             destLclOffs  = dest->AsLclFld()->GetLclOffs();
             destFieldSeq = dest->AsLclFld()->GetFieldSeq();
         }
@@ -9431,9 +9430,8 @@ GenTree* Compiler::fgMorphCopyBlock(GenTreeOp* asg)
         }
         else
         {
-            assert(!dest->TypeIs(TYP_STRUCT));
-
-            destSize     = genTypeSize(dest->GetType());
+            destSize =
+                dest->TypeIs(TYP_STRUCT) ? dest->AsLclFld()->GetLayout(this)->GetSize() : genTypeSize(dest->GetType());
             destLclOffs  = dest->AsLclFld()->GetLclOffs();
             destFieldSeq = dest->AsLclFld()->GetFieldSeq();
         }
@@ -9785,9 +9783,7 @@ GenTree* Compiler::fgMorphCopyBlock(GenTreeOp* asg)
 
         if (src == srcLclNode)
         {
-            // TODO-MIKE-Cleanup: Stop wrapping struct LCL_FLDs in indirs, it's done only to minimize diffs.
-            if ((src->GetType() != dest->GetType()) ||
-                (srcLclNode->OperIs(GT_LCL_FLD) && srcLclNode->TypeIs(TYP_STRUCT)))
+            if (src->GetType() != dest->GetType())
             {
                 src = gtNewIndir(dest->GetType(), gtNewOperNode(GT_ADDR, TYP_I_IMPL, srcLclNode));
                 src->gtFlags |= srcLclVar->lvAddrExposed ? GTF_GLOB_REF : 0;

--- a/src/coreclr/src/jit/rationalize.cpp
+++ b/src/coreclr/src/jit/rationalize.cpp
@@ -278,9 +278,7 @@ static void RewriteAssignmentIntoStoreLclCore(GenTreeOp* assignment,
 
     genTreeOps storeOp = storeForm(locationOp);
 
-#ifdef DEBUG
     JITDUMP("rewriting asg(%s, X) to %s(X)\n", GenTree::OpName(locationOp), GenTree::OpName(storeOp));
-#endif // DEBUG
 
     assignment->ChangeOper(storeOp);
     GenTreeLclVarCommon* store = assignment->AsLclVarCommon();
@@ -293,6 +291,7 @@ static void RewriteAssignmentIntoStoreLclCore(GenTreeOp* assignment,
     {
         store->AsLclFld()->SetLclOffs(var->AsLclFld()->GetLclOffs());
         store->AsLclFld()->SetFieldSeq(var->AsLclFld()->GetFieldSeq());
+        store->AsLclFld()->SetLayoutNum(var->AsLclFld()->GetLayoutNum());
     }
 
     copyFlags(store, var, GTF_LIVENESS_MASK);


### PR DESCRIPTION
Minimal diffs. 

Many trivial instruction reorderings caused by `LCL_FLD` being simpler than `OBJ(ADDR(LCL_FLD))` as far as `gtSetEvalOrder` is concerned. Produces one 8 byte regression on x86 due to a register spill and one 16 byte improvement on ARM32 due a different register choice leading to shorter instruction encoding. 

One 16 byte regression on x86 caused by `LCL_FLD` having different costs, leading to one loop condition being cloned.

x86 diff:
```
Total bytes of diff: 39 (0.00% of base)
    diff is a regression.
Top file regressions (bytes):
          31 : System.Memory.dasm (0.05% of base)
           8 : System.Net.Http.dasm (0.00% of base)
2 total files with Code Size differences (0 improved, 2 regressed), 232 unchanged.
Top method regressions (bytes):
          31 ( 2.79% of base) : System.Memory.dasm - SequenceReader`1:IsNextSlow(ReadOnlySpan`1,bool):bool:this (2 methods)
           8 ( 0.61% of base) : System.Net.Http.dasm - <SendStreamDataAsync>d__72:MoveNext():this
Top method regressions (percentages):
          31 ( 2.79% of base) : System.Memory.dasm - SequenceReader`1:IsNextSlow(ReadOnlySpan`1,bool):bool:this (2 methods)
           8 ( 0.61% of base) : System.Net.Http.dasm - <SendStreamDataAsync>d__72:MoveNext():this
2 total methods with Code Size differences (0 improved, 2 regressed), 184048 unchanged.
```
arm32 altjit diff:
```
Total bytes of diff: -16 (-0.00% of base)
    diff is an improvement.
Top file improvements (bytes):
         -16 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.00% of base)
1 total files with Code Size differences (1 improved, 0 regressed), 233 unchanged.
Top method improvements (bytes):
         -16 (-0.35% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Scanner:TryScanXmlDocComment(SyntaxListBuilder):bool:this (4 methods)
Top method improvements (percentages):
         -16 (-0.35% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Scanner:TryScanXmlDocComment(SyntaxListBuilder):bool:this (4 methods)
1 total methods with Code Size differences (1 improved, 0 regressed), 183531 unchanged.
```
