### PR TITLE
Use LCL_VAR_ADDR for temp call args passed by ref

### DIFF
--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -1506,6 +1506,12 @@ public:
     {
         _lateArgInx = inx;
     }
+
+    unsigned GetTempLclNum() const
+    {
+        return tmpNum;
+    }
+
     regNumber GetRegNum()
     {
         return (regNumber)regNums[0];
@@ -1831,6 +1837,8 @@ public:
     void Dump();
 #endif
 };
+
+typedef fgArgTabEntry CallArgInfo;
 
 //-------------------------------------------------------------------------
 //
@@ -5144,7 +5152,7 @@ public:
 
     bool fgCastNeeded(GenTree* tree, var_types toType);
     GenTree* fgDoNormalizeOnStore(GenTree* tree);
-    GenTree* fgMakeTmpArgNode(fgArgTabEntry* curArgTabEntry);
+    GenTree* fgMakeTmpArgNode(CallArgInfo* argInfo);
 
     // The following check for loops that don't execute calls
     bool fgLoopCallMarked;

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -1313,6 +1313,7 @@ AGAIN:
         switch (oper)
         {
             case GT_LCL_VAR:
+            case GT_LCL_VAR_ADDR:
                 if (op1->AsLclVarCommon()->GetLclNum() != op2->AsLclVarCommon()->GetLclNum())
                 {
                     break;
@@ -1321,6 +1322,7 @@ AGAIN:
                 return true;
 
             case GT_LCL_FLD:
+            case GT_LCL_FLD_ADDR:
                 return GenTreeLclFld::Equals(op1->AsLclFld(), op2->AsLclFld());
 
             case GT_CLS_VAR:

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -1859,127 +1859,72 @@ void fgArgInfo::Dump(Compiler* compiler)
 #endif
 
 //------------------------------------------------------------------------------
-// fgMakeTmpArgNode : This function creates a tmp var only if needed.
-//                    We need this to be done in order to enforce ordering
-//                    of the evaluation of arguments.
+// fgMakeTmpArgNode: Create a tree for a call arg that requires a temp.
 //
-// Arguments:
-//    curArgTabEntry
-//
-// Return Value:
-//    the newly created temp var tree.
-
-GenTree* Compiler::fgMakeTmpArgNode(fgArgTabEntry* curArgTabEntry)
+GenTree* Compiler::fgMakeTmpArgNode(CallArgInfo* argInfo)
 {
-    unsigned   tmpVarNum = curArgTabEntry->tmpNum;
-    LclVarDsc* varDsc    = &lvaTable[tmpVarNum];
+    LclVarDsc* varDsc = lvaGetDesc(argInfo->GetTempLclNum());
     assert(varDsc->lvIsTemp);
-    var_types type = varDsc->TypeGet();
 
-    // Create a copy of the temp to go into the late argument list
-    GenTree* arg      = gtNewLclvNode(tmpVarNum, type);
-    GenTree* addrNode = nullptr;
-
-    if (varTypeIsStruct(type))
+    if (!varTypeIsStruct(varDsc->GetType()))
     {
+        return gtNewLclvNode(argInfo->GetTempLclNum(), varDsc->GetType());
+    }
 
 #if defined(TARGET_AMD64) || defined(TARGET_ARM64) || defined(TARGET_ARM)
-
-        // Can this type be passed as a primitive type?
-        // If so, the following call will return the corresponding primitive type.
-        // Otherwise, it will return TYP_UNKNOWN and we will pass it as a struct type.
-
-        bool passedAsPrimitive = false;
-        if (curArgTabEntry->isSingleRegOrSlot())
-        {
-            CORINFO_CLASS_HANDLE clsHnd = varDsc->lvVerTypeInfo.GetClassHandle();
-            var_types            structBaseType =
-                getPrimitiveTypeForStruct(lvaLclExactSize(tmpVarNum), clsHnd, curArgTabEntry->IsVararg());
-
-            if (structBaseType != TYP_UNKNOWN)
-            {
-                passedAsPrimitive = true;
-#if defined(UNIX_AMD64_ABI)
-                // TODO-Cleanup: This is inelegant, but eventually we'll track this in the fgArgTabEntry,
-                // and otherwise we'd have to either modify getPrimitiveTypeForStruct() to take
-                // a structDesc or call eeGetSystemVAmd64PassStructInRegisterDescriptor yet again.
-                //
-                if (genIsValidFloatReg(curArgTabEntry->GetRegNum()))
-                {
-                    if (structBaseType == TYP_INT)
-                    {
-                        structBaseType = TYP_FLOAT;
-                    }
-                    else
-                    {
-                        assert(structBaseType == TYP_LONG);
-                        structBaseType = TYP_DOUBLE;
-                    }
-                }
-#endif
-                type = structBaseType;
-            }
-        }
-
-        // If it is passed in registers, don't get the address of the var. Make it a
-        // field instead. It will be loaded in registers with putarg_reg tree in lower.
-        if (passedAsPrimitive)
-        {
-            arg->ChangeOper(GT_LCL_FLD);
-            arg->gtType = type;
-        }
-        else
-        {
-            var_types addrType = TYP_BYREF;
-            arg                = gtNewOperNode(GT_ADDR, addrType, arg);
-            addrNode           = arg;
-
-#if FEATURE_MULTIREG_ARGS
-#ifdef TARGET_ARM64
-            assert(varTypeIsStruct(type));
-            if (lvaIsMultiregStruct(varDsc, curArgTabEntry->IsVararg()))
-            {
-                // ToDo-ARM64: Consider using:  arg->ChangeOper(GT_LCL_FLD);
-                // as that is how UNIX_AMD64_ABI works.
-                // We will create a GT_OBJ for the argument below.
-                // This will be passed by value in two registers.
-                assert(addrNode != nullptr);
-
-                // Create an Obj of the temp to use it as a call argument.
-                arg = gtNewObjNode(lvaGetStruct(tmpVarNum), arg);
-            }
-#else
-            // Always create an Obj of the temp to use it as a call argument.
-            arg = gtNewObjNode(lvaGetStruct(tmpVarNum), arg);
-#endif // !TARGET_ARM64
-#endif // FEATURE_MULTIREG_ARGS
-        }
-
-#else // not (TARGET_AMD64 or TARGET_ARM64 or TARGET_ARM)
-
-        // other targets, we pass the struct by value
-        assert(varTypeIsStruct(type));
-
-        addrNode = gtNewOperNode(GT_ADDR, TYP_BYREF, arg);
-
-        // Get a new Obj node temp to use it as a call argument.
-        // gtNewObjNode will set the GTF_EXCEPT flag if this is not a local stack object.
-        arg = gtNewObjNode(lvaGetStruct(tmpVarNum), addrNode);
-
-#endif // not (TARGET_AMD64 or TARGET_ARM64 or TARGET_ARM)
-
-    } // (varTypeIsStruct(type))
-
-    if (addrNode != nullptr)
+    if (argInfo->isSingleRegOrSlot())
     {
-        assert(addrNode->gtOper == GT_ADDR);
+        var_types passedAsPrimitiveType =
+            getPrimitiveTypeForStruct(lvaLclExactSize(argInfo->GetTempLclNum()), varDsc->lvVerTypeInfo.GetClassHandle(),
+                                      argInfo->IsVararg());
 
-        // This will prevent this LclVar from being optimized away
-        lvaSetVarAddrExposed(tmpVarNum);
-
-        // the child of a GT_ADDR is required to have this flag set
-        addrNode->AsOp()->gtOp1->gtFlags |= GTF_DONT_CSE;
+        if (passedAsPrimitiveType != TYP_UNKNOWN)
+        {
+#if defined(UNIX_AMD64_ABI)
+            // TODO-Cleanup: This is inelegant, but eventually we'll track this in the fgArgTabEntry,
+            // and otherwise we'd have to either modify getPrimitiveTypeForStruct() to take
+            // a structDesc or call eeGetSystemVAmd64PassStructInRegisterDescriptor yet again.
+            if (genIsValidFloatReg(argInfo->GetRegNum()))
+            {
+                if (passedAsPrimitiveType == TYP_INT)
+                {
+                    passedAsPrimitiveType = TYP_FLOAT;
+                }
+                else
+                {
+                    assert(passedAsPrimitiveType == TYP_LONG);
+                    passedAsPrimitiveType = TYP_DOUBLE;
+                }
+            }
+#endif
+            // TODO-MIKE-Cleanup: Why doesn't this code set DNER_LocalField?
+            return gtNewLclFldNode(argInfo->GetTempLclNum(), passedAsPrimitiveType, 0);
+        }
     }
+#endif
+
+    GenTree* arg = gtNewLclvNode(argInfo->GetTempLclNum(), varDsc->GetType());
+    arg->gtFlags |= GTF_DONT_CSE;
+    arg = gtNewOperNode(GT_ADDR, TYP_BYREF, arg);
+    lvaSetVarAddrExposed(argInfo->GetTempLclNum());
+
+#if defined(TARGET_ARM64) || defined(TARGET_ARM) || defined(TARGET_X86) || defined(UNIX_AMD64_ABI)
+#if defined(TARGET_ARM64)
+    if (lvaIsMultiregStruct(varDsc, argInfo->IsVararg()))
+#endif
+    {
+        // ToDo-ARM64: Consider using:  arg->ChangeOper(GT_LCL_FLD);
+        // as that is how UNIX_AMD64_ABI works.
+        // We will create a GT_OBJ for the argument below.
+        // This will be passed by value in two registers.
+        arg = gtNewObjNode(lvaGetStruct(argInfo->GetTempLclNum()), arg);
+    }
+#elif defined(TARGET_AMD64)
+// Return the address as is. On win-x64 struct args that aren't passed
+// as primitive types are always passed by ref
+#else
+#error Unknown ABI
+#endif
 
     return arg;
 }


### PR DESCRIPTION
win-x64 diff shows a few improvements in corelib:
```
Total bytes of diff: -923 (-0.00% of base)
    diff is an improvement.
Top file improvements (bytes):
        -923 : System.Private.CoreLib.dasm (-0.03% of base)
1 total files with Code Size differences (1 improved, 0 regressed), 233 unchanged.
Top method regressions (bytes):
           7 ( 0.36% of base) : System.Private.CoreLib.dasm - MemberInfoCache`1:PopulateProperties(Filter,RuntimeType,Dictionary`2,ref,byref):this
Top method improvements (bytes):
         -40 (-4.01% of base) : System.Private.CoreLib.dasm - RuntimeType:GetInterfaceMap(Type):InterfaceMapping:this
         -35 (-3.09% of base) : System.Private.CoreLib.dasm - CustomAttribute:FilterCustomAttributeRecord(MetadataToken,byref,RuntimeModule,MetadataToken,RuntimeType,bool,byref,byref,byref,byref):bool
         -25 (-4.67% of base) : System.Private.CoreLib.dasm - RuntimeAssembly:GetName(bool):AssemblyName:this
         -21 (-0.92% of base) : System.Private.CoreLib.dasm - TypeBuilder:CreateTypeNoLock():TypeInfo:this
         -18 (-2.81% of base) : System.Private.CoreLib.dasm - Grisu3:TryDigitGenCounted(byref,int,Span`1,byref,byref):bool
         -18 (-4.84% of base) : System.Private.CoreLib.dasm - ILStubClass:IL_STUB_PInvoke(QCallAssembly):int (3 methods)
         -18 (-2.15% of base) : System.Private.CoreLib.dasm - ILStubClass:IL_STUB_PInvoke(QCallModule,int,bool,ref,int,ref,int,int,ref,int,ref,int)
         -18 (-3.90% of base) : System.Private.CoreLib.dasm - ILStubClass:IL_STUB_PInvoke(QCallModule,int,int,int) (3 methods)
         -15 (-6.82% of base) : System.Private.CoreLib.dasm - RuntimeTypeHandle:VerifyInterfaceIsImplemented(RuntimeTypeHandle):this
         -15 (-6.30% of base) : System.Private.CoreLib.dasm - RuntimeTypeHandle:GetInterfaceMethodImplementation(RuntimeTypeHandle,long):long:this
         -15 (-6.05% of base) : System.Private.CoreLib.dasm - ILStubClass:IL_STUB_PInvoke(QCallModule,String,QCallModule,String,int):int
         -15 (-6.79% of base) : System.Private.CoreLib.dasm - ModuleBuilder:GetMemberRef(Module,int,int):int:this
         -14 (-6.80% of base) : System.Private.CoreLib.dasm - ILStubClass:IL_STUB_PInvoke(QCallTypeHandle,long,QCallTypeHandle,QCallModule):int
         -14 (-3.12% of base) : System.Private.CoreLib.dasm - ILStubClass:IL_STUB_PInvoke(QCallModule,int,String,ref,int,int):int (2 methods)
         -14 (-3.20% of base) : System.Private.CoreLib.dasm - ILStubClass:IL_STUB_PInvoke(QCallModule,String,int,int,int,ref):int (2 methods)
         -12 (-4.40% of base) : System.Private.CoreLib.dasm - ILStubClass:IL_STUB_PInvoke(QCallTypeHandle,int):long (2 methods)
         -12 (-4.20% of base) : System.Private.CoreLib.dasm - ILStubClass:IL_STUB_PInvoke(QCallModule,int,int) (2 methods)
         -11 (-5.95% of base) : System.Private.CoreLib.dasm - RuntimeTypeHandle:ConstructName(int):String:this
         -11 (-5.73% of base) : System.Private.CoreLib.dasm - RuntimeTypeHandle:GetInstantiationInternal():ref:this
         -11 (-5.82% of base) : System.Private.CoreLib.dasm - RuntimeTypeHandle:GetInstantiationPublic():ref:this
Top method regressions (percentages):
           7 ( 0.36% of base) : System.Private.CoreLib.dasm - MemberInfoCache`1:PopulateProperties(Filter,RuntimeType,Dictionary`2,ref,byref):this
Top method improvements (percentages):
         -15 (-6.82% of base) : System.Private.CoreLib.dasm - RuntimeTypeHandle:VerifyInterfaceIsImplemented(RuntimeTypeHandle):this
         -14 (-6.80% of base) : System.Private.CoreLib.dasm - ILStubClass:IL_STUB_PInvoke(QCallTypeHandle,long,QCallTypeHandle,QCallModule):int
         -15 (-6.79% of base) : System.Private.CoreLib.dasm - ModuleBuilder:GetMemberRef(Module,int,int):int:this
         -10 (-6.58% of base) : System.Private.CoreLib.dasm - ILStubClass:IL_STUB_PInvoke(QCallTypeHandle,QCallTypeHandle)
         -15 (-6.30% of base) : System.Private.CoreLib.dasm - RuntimeTypeHandle:GetInterfaceMethodImplementation(RuntimeTypeHandle,long):long:this
         -10 (-6.06% of base) : System.Private.CoreLib.dasm - ILStubClass:IL_STUB_PInvoke(QCallTypeHandle,QCallTypeHandle,long):long
         -15 (-6.05% of base) : System.Private.CoreLib.dasm - ILStubClass:IL_STUB_PInvoke(QCallModule,String,QCallModule,String,int):int
         -11 (-5.95% of base) : System.Private.CoreLib.dasm - RuntimeTypeHandle:ConstructName(int):String:this
         -11 (-5.95% of base) : System.Private.CoreLib.dasm - RuntimeTypeHandle:MakeArray(int):RuntimeType:this
         -11 (-5.82% of base) : System.Private.CoreLib.dasm - RuntimeTypeHandle:GetInstantiationPublic():ref:this
         -11 (-5.73% of base) : System.Private.CoreLib.dasm - RuntimeTypeHandle:GetInstantiationInternal():ref:this
         -10 (-5.65% of base) : System.Private.CoreLib.dasm - ILStubClass:IL_STUB_PInvoke(QCallModule,QCallModule,int,int):int
         -10 (-5.65% of base) : System.Private.CoreLib.dasm - ILStubClass:IL_STUB_PInvoke(QCallModule,int,QCallTypeHandle,int):int
          -6 (-4.84% of base) : System.Private.CoreLib.dasm - ILStubClass:IL_STUB_PInvoke(QCallTypeHandle):int
         -18 (-4.84% of base) : System.Private.CoreLib.dasm - ILStubClass:IL_STUB_PInvoke(QCallAssembly):int (3 methods)
          -6 (-4.76% of base) : System.Private.CoreLib.dasm - ILStubClass:IL_STUB_PInvoke(QCallAssembly):long
          -6 (-4.76% of base) : System.Private.CoreLib.dasm - ILStubClass:IL_STUB_PInvoke(QCallModule):long
         -25 (-4.67% of base) : System.Private.CoreLib.dasm - RuntimeAssembly:GetName(bool):AssemblyName:this
          -6 (-4.65% of base) : System.Private.CoreLib.dasm - ILStubClass:IL_STUB_PInvoke(QCallTypeHandle,ObjectHandleOnStack)
          -6 (-4.65% of base) : System.Private.CoreLib.dasm - ILStubClass:IL_STUB_PInvoke(QCallModule,ObjectHandleOnStack)
118 total methods with Code Size differences (117 improved, 1 regressed), 184032 unchanged.
```
`LCL_VAR_ADDR` has type `TYP_I_IMPL` rather than `TYP_BYREF` so if it gets spilled the spill temp does not need zeroing. Though they shouldn't be spilled to begin with but `SortArgs` doesn't handle these nodes like constants.
One regression caused by an extra `movaps` in prolog local init.