### PR TITLE
Enable cast operand containment

### DIFF
--- a/src/coreclr/src/jit/codegen.h
+++ b/src/coreclr/src/jit/codegen.h
@@ -869,7 +869,17 @@ protected:
 
     struct GenIntCastDesc
     {
-        enum CheckKind
+        enum LoadKind : unsigned
+        {
+            LOAD,
+            LOAD_ZERO_EXTEND_SMALL_INT,
+            LOAD_SIGN_EXTEND_SMALL_INT,
+#ifdef TARGET_64BIT
+            LOAD_SIGN_EXTEND_INT
+#endif
+        };
+
+        enum CheckKind : unsigned
         {
             CHECK_NONE,
             CHECK_SMALL_INT_RANGE,
@@ -881,7 +891,7 @@ protected:
 #endif
         };
 
-        enum ExtendKind
+        enum ExtendKind : unsigned
         {
             COPY,
             ZERO_EXTEND_SMALL_INT,
@@ -893,6 +903,8 @@ protected:
         };
 
     private:
+        LoadKind   m_loadKind;
+        unsigned   m_loadSrcSize;
         CheckKind  m_checkKind;
         unsigned   m_checkSrcSize;
         int        m_checkSmallIntMin;
@@ -902,6 +914,16 @@ protected:
 
     public:
         GenIntCastDesc(GenTreeCast* cast);
+
+        LoadKind LoadKind() const
+        {
+            return m_loadKind;
+        }
+
+        unsigned LoadSrcSize() const
+        {
+            return m_loadSrcSize;
+        }
 
         CheckKind CheckKind() const
         {

--- a/src/coreclr/src/jit/codegenlinear.cpp
+++ b/src/coreclr/src/jit/codegenlinear.cpp
@@ -2131,7 +2131,9 @@ void CodeGen::genCodeForCast(GenTreeOp* tree)
 
 CodeGen::GenIntCastDesc::GenIntCastDesc(GenTreeCast* cast)
 {
-    const var_types srcType      = genActualType(cast->gtGetOp1()->TypeGet());
+    GenTree* src = cast->GetOp(0);
+
+    const var_types srcType      = genActualType(src->TypeGet());
     const bool      srcUnsigned  = cast->IsUnsigned();
     const unsigned  srcSize      = genTypeSize(srcType);
     const var_types castType     = cast->gtCastType;
@@ -2244,6 +2246,117 @@ CodeGen::GenIntCastDesc::GenIntCastDesc(GenTreeCast* cast)
 
         m_extendKind    = COPY;
         m_extendSrcSize = srcSize;
+    }
+
+    if (src->isUsedFromMemory())
+    {
+        bool     memUnsigned = varTypeIsUnsigned(src->GetType());
+        unsigned memSize     = genTypeSize(src->GetType());
+
+        if (m_checkKind != CHECK_NONE)
+        {
+            // For overflow checking casts the memory load is performed as usual and
+            // the cast only checks if the resulting TYP_(U)INT/TYP_(U)LONG value is
+            // within the cast type's range.
+            //
+            // There is one specific case that normally requires sign extending the
+            // loaded value - casting TYP_INT to TYP_ULONG. But this isn't needed:
+            //   - the overflow check guarantees that the TYP_INT value is positive
+            //     so zero extend can be used instead
+            //   - this case is 64 bit specific and both x64 and arm64 zero extend
+            //     while loading (even when using SIGN_EXTEND_SMALL_INT because the
+            //     the value is positive)
+            //
+            // Other TYP_(U)INT/TYP_(U)LONG widening casts do not require overflow
+            // checks so they are not handled here.
+
+            if (memSize < 4)
+            {
+                m_loadKind = memUnsigned ? LOAD_ZERO_EXTEND_SMALL_INT : LOAD_SIGN_EXTEND_SMALL_INT;
+            }
+            else
+            {
+                m_loadKind = LOAD;
+            }
+
+            m_loadSrcSize = memSize;
+
+            m_extendKind = COPY;
+        }
+        else
+        {
+            if (castSize <= memSize)
+            {
+                // If we have a narrowing cast then we can narrow the memory load itself.
+                // The upper bits contained in the wider memory location and the sign/zero
+                // extension bits that a small type load would have produced are anyway
+                // discarded by the cast.
+                //
+                // Handle the sign changing cast as well, just to pick up the sign of the
+                // cast type (see the memSize < 4 case below).
+                //
+                // This effectively turns all casts into widening or sign changing casts.
+                memSize     = castSize;
+                memUnsigned = castUnsigned;
+            }
+
+            if (memSize < 4)
+            {
+                m_loadKind    = memUnsigned ? LOAD_ZERO_EXTEND_SMALL_INT : LOAD_SIGN_EXTEND_SMALL_INT;
+                m_loadSrcSize = memSize;
+
+                // Most of the time the load itself is sufficient, even on 64 bit where we
+                // may need to widen directly to 64 bit (CodeGen needs to ensure that 64 bit
+                // instructions are used on 64 bit targets). But there are 2 exceptions that
+                // involve loading signed values and then zero extending:
+
+                // Loading a TYP_BYTE and then casting to TYP_USHORT - bits 8-15 will contain
+                // the sign bit of the original value while bits 16-31/63 will be 0. There's
+                // no single instruction that does this so we'll need to emit an extra zero
+                // extend to zero out bits 16-31/63.
+                if ((memSize == 1) && !memUnsigned && (castType == TYP_USHORT))
+                {
+                    assert(m_extendKind == ZERO_EXTEND_SMALL_INT);
+                    assert(m_extendSrcSize == 2);
+                }
+#ifdef TARGET_64BIT
+                // Loading a small signed value and then zero extending to TYP_LONG - on x64
+                // this requires a 32 bit MOVSX but the emitter lacks support for it so we'll
+                // need to emit a 32 bit MOV to zero out the upper 32 bits. This kind of
+                // signed/unsigned mix should be rare.
+                else if (!memUnsigned && (castSize == 8) && srcUnsigned)
+                {
+                    assert(m_extendKind == ZERO_EXTEND_INT);
+                    assert(m_extendSrcSize == 4);
+                }
+#endif
+                // Various other combinations do not need extra instructions. For example:
+                // - Unsigned value load and sign extending cast - if the value is unsigned
+                //   then sign extending is in fact zero extending.
+                // - TYP_SHORT value load and cast to TYP_UINT - that's a TYP_INT to TYP_UINT
+                //   cast that's basically a NOP.
+                else
+                {
+                    m_extendKind = COPY;
+                }
+            }
+#ifdef TARGET_64BIT
+            else if ((memSize == 4) && !srcUnsigned && (castSize == 8))
+            {
+                m_loadKind    = LOAD_SIGN_EXTEND_INT;
+                m_loadSrcSize = memSize;
+
+                m_extendKind = COPY;
+            }
+#endif
+            else
+            {
+                m_loadKind    = LOAD;
+                m_loadSrcSize = memSize;
+
+                m_extendKind = COPY;
+            }
+        }
     }
 }
 

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -3294,6 +3294,12 @@ struct GenTreeCast : public GenTreeOp
     {
         gtFlags |= fromUnsigned ? GTF_UNSIGNED : 0;
     }
+
+    var_types GetCastType() const
+    {
+        return gtCastType;
+    }
+
 #if DEBUGGABLE_GENTREE
     GenTreeCast() : GenTreeOp()
     {

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -2570,6 +2570,8 @@ GenTree* Lowering::OptimizeConstCompare(GenTree* cmp)
                 cmp->SetOperRaw(cmpEq ? GT_TEST_EQ : GT_TEST_NE);
                 op2->SetIconValue(0xff);
                 op2->gtType = castOp->gtType;
+                // CAST may have a contained memory operand but ARM compare/test nodes do not.
+                castOp->ClearContained();
 #else
                 castOp->gtType        = castToType;
                 op2->gtType           = castToType;

--- a/src/coreclr/src/jit/lsraarmarch.cpp
+++ b/src/coreclr/src/jit/lsraarmarch.cpp
@@ -736,6 +736,13 @@ int LinearScan::BuildCast(GenTreeCast* cast)
     if (cast->gtOverflow() && varTypeIsLong(srcType) && !cast->IsUnsigned() && (castType == TYP_INT))
     {
         buildInternalIntRegisterDefForNode(cast);
+
+        // If the cast operand ends up being in memory then the value will be loaded directly
+        // into the destination register and thus the internal register has to be different.
+        if (src->isContained() || src->IsRegOptional())
+        {
+            setInternalRegsDelayFree = true;
+        }
     }
 #endif
 

--- a/src/coreclr/src/jit/lsraxarch.cpp
+++ b/src/coreclr/src/jit/lsraxarch.cpp
@@ -2808,6 +2808,13 @@ int LinearScan::BuildCast(GenTreeCast* cast)
         // Here we don't need internal register to be different from targetReg,
         // rather require it to be different from operand's reg.
         buildInternalIntRegisterDefForNode(cast);
+
+        // If the cast operand ends up being in memory then the value will be loaded directly
+        // into the destination register and thus the internal register has to be different.
+        if (src->isContained() || src->IsRegOptional())
+        {
+            setInternalRegsDelayFree = true;
+        }
     }
 #endif
 


### PR DESCRIPTION
diff summary:
```
x64:
Total bytes of diff: -14153 (-0.04% of base)
    diff is an improvement.
Top file improvements (bytes):
       -2166 : System.Private.CoreLib.dasm (-0.07% of base)
       -1434 : System.Reflection.Metadata.dasm (-0.44% of base)
       -1312 : Microsoft.CodeAnalysis.CSharp.dasm (-0.06% of base)
        -866 : System.Private.Xml.dasm (-0.03% of base)
        -836 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.04% of base)
114 total files with Code Size differences (114 improved, 0 regressed), 120 unchanged.
Top method regressions (bytes):
          47 ( 2.35% of base) : System.Private.Xml.dasm - ReflectionXmlSerializationWriter:WriteStructMethod(StructMapping,String,String,Object,bool,bool):this
          17 ( 1.16% of base) : System.Net.Http.dasm - QPackDecoder:OnByte(ubyte,IHttpHeadersHandler):this
          11 ( 0.22% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:ReportOverloadResolutionFailureAndProduceBoundNode(VisualBasicSyntaxNode,int,ArrayBuilder`1,ImmutableArray`1,TypeSymbol,ImmutableArray`1,ImmutableArray`1,DiagnosticBag,VisualBasicSyntaxNode,BoundMethodOrPropertyGroup,Symbol,bool,BoundTypeExpression,Symbol,Location):BoundExpression:this
           3 ( 0.37% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:MakeArguments(CSharpSyntaxNode,ImmutableArray`1,Symbol,MethodSymbol,bool,ImmutableArray`1,byref,byref,bool,ubyte):ImmutableArray`1:this
           2 ( 2.00% of base) : System.Data.Odbc.dasm - OdbcConnectionHandle:GetInfo1(ushort,ref):short:this
           2 ( 7.41% of base) : System.Private.CoreLib.dasm - UIntPtr:ToUInt32():int:this
           2 ( 7.69% of base) : System.Private.CoreLib.dasm - UIntPtr:op_Explicit(long):int
Top method improvements (bytes):
        -119 (-7.34% of base) : System.Private.CoreLib.dasm - Vector128:Create(ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte):Vector128`1
        -104 (-0.87% of base) : System.Reflection.Metadata.dasm - MetadataReader:InitializeTableReaders(MemoryBlock,ubyte,ref,ref):this
         -93 (-5.73% of base) : System.Private.CoreLib.dasm - Vector128:Create(byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte):Vector128`1
         -79 (-3.24% of base) : Microsoft.VisualBasic.Core.dasm - OverloadResolution:MoreSpecificProcedure(Method,Method,ref,ref,int,byref,bool):Method
         -70 (-3.39% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:MakeConversion(BoundConversion,CSharpSyntaxNode,BoundExpression,ubyte,MethodSymbol,bool,bool,bool,bool,ConstantValue,TypeSymbol):BoundExpression:this
Top method regressions (percentages):
           2 ( 7.69% of base) : System.Private.CoreLib.dasm - UIntPtr:op_Explicit(long):int
           2 ( 7.41% of base) : System.Private.CoreLib.dasm - UIntPtr:ToUInt32():int:this
          47 ( 2.35% of base) : System.Private.Xml.dasm - ReflectionXmlSerializationWriter:WriteStructMethod(StructMapping,String,String,Object,bool,bool):this
           2 ( 2.00% of base) : System.Data.Odbc.dasm - OdbcConnectionHandle:GetInfo1(ushort,ref):short:this
          17 ( 1.16% of base) : System.Net.Http.dasm - QPackDecoder:OnByte(ubyte,IHttpHeadersHandler):this
           3 ( 0.37% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:MakeArguments(CSharpSyntaxNode,ImmutableArray`1,Symbol,MethodSymbol,bool,ImmutableArray`1,byref,byref,bool,ubyte):ImmutableArray`1:this
          11 ( 0.22% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:ReportOverloadResolutionFailureAndProduceBoundNode(VisualBasicSyntaxNode,int,ArrayBuilder`1,ImmutableArray`1,TypeSymbol,ImmutableArray`1,ImmutableArray`1,DiagnosticBag,VisualBasicSyntaxNode,BoundMethodOrPropertyGroup,Symbol,bool,BoundTypeExpression,Symbol,Location):BoundExpression:this
Top method improvements (percentages):
          -2 (-28.57% of base) : Microsoft.Diagnostics.FastSerialization.dasm - SegmentedMemoryStreamReader:get_Length():long:this
          -2 (-28.57% of base) : Microsoft.Diagnostics.FastSerialization.dasm - MemoryStreamReader:get_Length():long:this
          -2 (-28.57% of base) : Microsoft.Diagnostics.FastSerialization.dasm - MemoryStreamWriter:get_Length():long:this
          -2 (-28.57% of base) : System.Runtime.Caching.dasm - PhysicalMemoryMonitor:get_MemoryLimit():long:this
          -2 (-18.18% of base) : Microsoft.Diagnostics.FastSerialization.dasm - SegmentedMemoryStreamWriter:get_Length():long:this
3321 total methods with Code Size differences (3314 improved, 7 regressed), 180829 unchanged.

x86:
Total bytes of diff: -12769 (-0.05% of base)
    diff is an improvement.
Top file improvements (bytes):
       -2019 : System.Private.CoreLib.dasm (-0.07% of base)
       -1566 : Microsoft.CodeAnalysis.CSharp.dasm (-0.10% of base)
       -1146 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.06% of base)
        -831 : System.Private.Xml.dasm (-0.03% of base)
        -509 : System.Data.Common.dasm (-0.06% of base)
118 total files with Code Size differences (118 improved, 0 regressed), 116 unchanged.
Top method regressions (bytes):
          34 ( 4.00% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - CtfInteger:Read(ref,int):Object:this
          23 ( 3.54% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:MakeConversion(CSharpSyntaxNode,BoundExpression,Conversion,TypeSymbol,bool,bool,ConstantValue):BoundExpression:this
          16 ( 1.24% of base) : System.Net.Http.dasm - QPackDecoder:OnByte(ubyte,IHttpHeadersHandler):this
          15 ( 5.64% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SourceMemberContainerTypeSymbol:CalculateSyntaxOffsetInSynthesizedConstructor(int,SyntaxTree,bool):int:this
          15 ( 6.33% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceMemberContainerTypeSymbol:CalculateSyntaxOffsetInSynthesizedConstructor(int,SyntaxTree,bool):int:this
Top method improvements (bytes):
         -62 (-26.27% of base) : System.Private.CoreLib.dasm - Vector256:Create(ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte):Vector256`1
         -62 (-26.27% of base) : System.Private.CoreLib.dasm - Vector256:Create(byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte):Vector256`1
         -60 (-2.01% of base) : System.Net.Http.dasm - KnownHeaders:GetCandidate(BytePtrAccessor):KnownHeader
         -60 (-5.41% of base) : System.Private.CoreLib.dasm - Vector128:Create(ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte):Vector128`1
         -60 (-5.41% of base) : System.Private.CoreLib.dasm - Vector128:Create(byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte):Vector128`1
Top method regressions (percentages):
          15 ( 6.33% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceMemberContainerTypeSymbol:CalculateSyntaxOffsetInSynthesizedConstructor(int,SyntaxTree,bool):int:this
          15 ( 5.64% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SourceMemberContainerTypeSymbol:CalculateSyntaxOffsetInSynthesizedConstructor(int,SyntaxTree,bool):int:this
          34 ( 4.00% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - CtfInteger:Read(ref,int):Object:this
          23 ( 3.54% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:MakeConversion(CSharpSyntaxNode,BoundExpression,Conversion,TypeSymbol,bool,bool,ConstantValue):BoundExpression:this
           4 ( 1.97% of base) : Microsoft.CodeAnalysis.dasm - RealParser:ConvertBigIntegerToFloatingPointBits(ref,int,bool,FloatingPointType,byref):int
Top method improvements (percentages):
         -62 (-26.27% of base) : System.Private.CoreLib.dasm - Vector256:Create(ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte):Vector256`1
         -62 (-26.27% of base) : System.Private.CoreLib.dasm - Vector256:Create(byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte):Vector256`1
         -30 (-24.79% of base) : System.Private.CoreLib.dasm - Vector256:Create(short,short,short,short,short,short,short,short,short,short,short,short,short,short,short,short):Vector256`1
         -30 (-24.79% of base) : System.Private.CoreLib.dasm - Vector256:Create(ushort,ushort,ushort,ushort,ushort,ushort,ushort,ushort,ushort,ushort,ushort,ushort,ushort,ushort,ushort,ushort):Vector256`1
          -2 (-20.00% of base) : System.Private.CoreLib.dasm - Char8:op_Implicit(Char8):ubyte
3694 total methods with Code Size differences (3685 improved, 9 regressed), 180356 unchanged.

arm64:
Total bytes of diff: -28000 (-0.02% of base)
    diff is an improvement.
Top file improvements (bytes):
       -4240 : System.Private.CoreLib.dasm (-0.04% of base)
       -3288 : Microsoft.CodeAnalysis.CSharp.dasm (-0.02% of base)
       -3256 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.02% of base)
       -1448 : System.Data.Common.dasm (-0.04% of base)
       -1232 : Microsoft.CodeAnalysis.dasm (-0.03% of base)
104 total files with Code Size differences (104 improved, 0 regressed), 130 unchanged.
Top method regressions (bytes):
          16 ( 0.31% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:MakeArguments(CSharpSyntaxNode,ImmutableArray`1,Symbol,MethodSymbol,bool,ImmutableArray`1,byref,byref,bool,ubyte):ImmutableArray`1:this (4 methods)
          16 ( 0.15% of base) : System.Text.Json.dasm - JsonSerializer:ReadValueCore(JsonSerializerOptions,byref,byref):__Canon (4 methods)
           8 ( 0.95% of base) : Microsoft.VisualBasic.Core.dasm - Conversions:ToInteger(String):int (2 methods)
           8 ( 0.95% of base) : Microsoft.VisualBasic.Core.dasm - IntegerType:FromString(String):int (2 methods)
           8 ( 1.22% of base) : Microsoft.Win32.SystemEvents.dasm - SystemEvents:OnCreateTimer(long):long:this (2 methods)
Top method improvements (bytes):
        -224 (-4.79% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CSharpSemanticModel:GetSymbolInfoForNode(int,BoundNode,BoundNode,BoundNode,Binder):SymbolInfo:this (4 methods)
        -192 (-25.00% of base) : System.Private.CoreLib.dasm - Vector256:Create(ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte):Vector256`1 (2 methods)
        -192 (-25.00% of base) : System.Private.CoreLib.dasm - Vector256:Create(byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte):Vector256`1 (2 methods)
        -176 (-1.60% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:MakeConversion(BoundConversion,CSharpSyntaxNode,BoundExpression,ubyte,MethodSymbol,bool,bool,bool,bool,ConstantValue,TypeSymbol):BoundExpression:this (4 methods)
        -160 (-2.37% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Lexer:ScanIdentifier_CrefSlowPath(byref):bool:this (4 methods)
        -160 (-1.75% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Lexer:ScanXmlEntity(byref):this (4 methods)
        -160 (-1.16% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - OverloadResolution:CollectOverloadedCandidates(Binder,ArrayBuilder`1,ArrayBuilder`1,ImmutableArray`1,ImmutableArray`1,ImmutableArray`1,TypeSymbol,BoundNode,bool,bool,bool,byref,byref) (4 methods)
VisualBasicCompilationOptions:.ctor(int,bool,String,String,String,IEnumerable`1,String,ubyte,bool,bool,bool,VisualBasicParseOptions,bool,int,bool,String,String,ImmutableArray`1,Nullable`1,int,int,IEnumerable`1,bool,bool,XmlReferenceResolver,SourceReferenceResolver,MetadataReferenceResolver,AssemblyIdentityComparer,StrongNameProvider):this (4 methods)
        -128 (-5.63% of base) : System.Private.CoreLib.dasm - CalendarData:LoadCalendarDataFromSystem(String,ushort):bool:this (2 methods)
        -112 (-1.16% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CodeGenerator:EmitCondBranchCore(BoundExpression,byref,bool):this (4 methods)
        -112 (-1.52% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - CodeGenerator:EmitCondBranchCore(BoundExpression,byref,bool):this (4 methods)
        -112 (-0.44% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:ReportOverloadResolutionFailureAndProduceBoundNode(VisualBasicSyntaxNode,int,ArrayBuilder`1,ImmutableArray`1,TypeSymbol,ImmutableArray`1,ImmutableArray`1,DiagnosticBag,VisualBasicSyntaxNode,BoundMethodOrPropertyGroup,Symbol,bool,BoundTypeExpression,Symbol,Location):BoundExpression:this (4 methods)
         -96 (-1.44% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:BindMemberOfType(CSharpSyntaxNode,CSharpSyntaxNode,String,int,BoundExpression,SeparatedSyntaxList`1,ImmutableArray`1,LookupResult,int,DiagnosticBag):BoundExpression:this (4 methods)
         -96 (-5.45% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CSharpCompilationOptions:.ctor(int,bool,String,String,String,IEnumerable`1,int,bool,bool,String,String,ImmutableArray`1,Nullable`1,int,int,int,IEnumerable`1,bool,bool,bool,bool,XmlReferenceResolver,SourceReferenceResolver,MetadataReferenceResolver,AssemblyIdentityComparer,StrongNameProvider,ubyte):this (4 methods)
         -96 (-0.62% of base) : Microsoft.CodeAnalysis.CSharp.dasm - OverloadResolution:BetterFunctionMember(MemberResolutionResult`1,MemberResolutionResult`1,ArrayBuilder`1,bool,byref):int:this (4 methods)
Top method regressions (percentages):
           8 ( 2.50% of base) : System.Data.OleDb.dasm - ADP:IntPtrToInt32(long):int (2 methods)
           8 ( 1.22% of base) : Microsoft.Win32.SystemEvents.dasm - SystemEvents:OnCreateTimer(long):long:this (2 methods)
           8 ( 0.95% of base) : Microsoft.VisualBasic.Core.dasm - Conversions:ToInteger(String):int (2 methods)
           8 ( 0.95% of base) : Microsoft.VisualBasic.Core.dasm - IntegerType:FromString(String):int (2 methods)
           8 ( 0.65% of base) : System.Text.Json.dasm - JsonConverter:DoSingleValueReadWithReadAhead(byref,byref):bool (2 methods)
Top method improvements (percentages):
        -192 (-25.00% of base) : System.Private.CoreLib.dasm - Vector256:Create(ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte):Vector256`1 (2 methods)
        -192 (-25.00% of base) : System.Private.CoreLib.dasm - Vector256:Create(byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte):Vector256`1 (2 methods)
         -64 (-16.67% of base) : System.Private.CoreLib.dasm - Vector256:Create(short,short,short,short,short,short,short,short,short,short,short,short,short,short,short,short):Vector256`1 (2 methods)
         -64 (-16.67% of base) : System.Private.CoreLib.dasm - Vector256:Create(ushort,ushort,ushort,ushort,ushort,ushort,ushort,ushort,ushort,ushort,ushort,ushort,ushort,ushort,ushort,ushort):Vector256`1 (2 methods)
         -32 (-15.38% of base) : System.Reflection.Metadata.dasm - Handle:Compare(Handle,Handle):int (2 methods)
         -16 (-14.29% of base) : Microsoft.CodeAnalysis.dasm - FloatFloatingPointType:get_Zero():long:this (4 methods)
VisualBasicCompilationOptions:.ctor(int,bool,String,String,String,IEnumerable`1,String,ubyte,bool,bool,bool,VisualBasicParseOptions,bool,int,bool,String,String,ImmutableArray`1,Nullable`1,int,int,IEnumerable`1,bool,bool,XmlReferenceResolver,SourceReferenceResolver,MetadataReferenceResolver,AssemblyIdentityComparer,StrongNameProvider):this (4 methods)
         -16 (-10.53% of base) : System.Private.CoreLib.dasm - NativeRuntimeEventSource:TieredCompilationBackgroundJitStop(ushort,int,int):this (2 methods)
          -8 (-10.00% of base) : System.IO.FileSystem.dasm - FILE_TIME:ToTicks():long:this (2 methods)
          -8 (-10.00% of base) : System.Private.CoreLib.dasm - EventPipeMetadataGenerator:WriteToBuffer(long,int,byref,int) (2 methods)
          -8 (-10.00% of base) : System.Private.CoreLib.dasm - EventPipeMetadataGenerator:WriteToBuffer(long,int,byref,long) (2 methods)
          -8 (-10.00% of base) : System.Private.CoreLib.dasm - EventPipeMetadataGenerator:WriteToBuffer(long,int,byref,ushort) (2 methods)
1709 total methods with Code Size differences (1698 improved, 11 regressed), 181931 unchanged.

arm32:
Total bytes of diff: -18444 (-0.02% of base)
    diff is an improvement.
Top file regressions (bytes):
          12 : CommandLine.dasm (0.00% of base)
Top file improvements (bytes):
       -4236 : System.Private.CoreLib.dasm (-0.05% of base)
       -2400 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.02% of base)
       -2280 : Microsoft.CodeAnalysis.CSharp.dasm (-0.02% of base)
        -716 : Microsoft.CodeAnalysis.dasm (-0.02% of base)
        -644 : System.Private.Xml.dasm (-0.01% of base)
107 total files with Code Size differences (106 improved, 1 regressed), 127 unchanged.
Top method regressions (bytes):
         128 ( 0.99% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:CheckIsVariable(CSharpSyntaxNode,BoundExpression,ubyte,bool,DiagnosticBag):bool:this (4 methods)
          56 ( 1.50% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:MakeArguments(CSharpSyntaxNode,ImmutableArray`1,Symbol,MethodSymbol,bool,ImmutableArray`1,byref,byref,bool,ubyte):ImmutableArray`1:this (4 methods)
          32 ( 1.90% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:BindQualifiedName(ExpressionSyntax,SimpleNameSyntax,DiagnosticBag,ConsList`1,bool):NamespaceOrTypeSymbol:this (4 methods)
          24 ( 0.74% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:BuildStoresToTemps(bool,ImmutableArray`1,ImmutableArray`1,ImmutableArray`1,ref,ArrayBuilder`1,ArrayBuilder`1):this (4 methods)
          24 ( 0.88% of base) : System.Data.OleDb.dasm - OleDbDataReader:CreateBindingsFromMetaData(bool):ref:this (2 methods)
Top method improvements (bytes):
        -700 (-3.02% of base) : System.Private.CoreLib.dasm - Vector256:Create(ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte):Vector256`1 (2 methods)
        -700 (-3.02% of base) : System.Private.CoreLib.dasm - Vector256:Create(byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte):Vector256`1 (2 methods)
        -256 (-0.45% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:ReportOverloadResolutionFailureForASingleCandidate(VisualBasicSyntaxNode,Location,int,byref,ImmutableArray`1,ImmutableArray`1,bool,bool,bool,bool,DiagnosticBag,Symbol,bool,VisualBasicSyntaxNode,Symbol):this (4 methods)
        -192 (-2.18% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:MakeConversion(BoundConversion,CSharpSyntaxNode,BoundExpression,ubyte,MethodSymbol,bool,bool,bool,bool,ConstantValue,TypeSymbol):BoundExpression:this (4 methods)
        -172 (-1.81% of base) : System.Private.CoreLib.dasm - Vector128:Create(ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte):Vector128`1 (2 methods)
        -172 (-1.81% of base) : System.Private.CoreLib.dasm - Vector128:Create(byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte):Vector128`1 (2 methods)
        -128 (-10.13% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VisualBasicCompilationOptions:.ctor(int,bool,String,String,String,IEnumerable`1,String,ubyte,bool,bool,bool,VisualBasicParseOptions,bool,int,bool,String,String,ImmutableArray`1,Nullable`1,int,int,IEnumerable`1,bool,bool,XmlReferenceResolver,SourceReferenceResolver,MetadataReferenceResolver,AssemblyIdentityComparer,StrongNameProvider):this (4 methods)
         -96 (-1.38% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - OverloadResolution:MethodInvocationOverloadResolution(BoundMethodGroup,ImmutableArray`1,ImmutableArray`1,Binder,VisualBasicSyntaxNode,byref,bool,TypeSymbol,BoundNode,bool,bool,bool):OverloadResolutionResult (4 methods)
         -88 (-4.18% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ReadWriteWalker:AssignImpl(BoundNode,BoundExpression,ubyte,bool,bool):this (4 methods)
         -80 (-4.22% of base) : Microsoft.CodeAnalysis.CSharp.dasm - BoundConversion:Update(BoundExpression,ubyte,ubyte,bool,MethodSymbol,bool,bool,bool,bool,ConstantValue,TypeSymbol):BoundConversion:this (4 methods)
         -80 (-2.81% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:RewriteNullableConversion(CSharpSyntaxNode,BoundExpression,ubyte,bool,bool,TypeSymbol):BoundExpression:this (4 methods)
         -80 (-3.48% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AssemblySymbol:GetTypeByMetadataName(String,bool,bool,bool):NamedTypeSymbol:this (4 methods)
CSharpCompilationOptions:.ctor(int,bool,String,String,String,IEnumerable`1,int,bool,bool,String,String,ImmutableArray`1,Nullable`1,int,int,int,IEnumerable`1,bool,bool,XmlReferenceResolver,SourceReferenceResolver,MetadataReferenceResolver,AssemblyIdentityComparer,StrongNameProvider):this (4 methods)
         -64 (-1.06% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - TypeBinder:LookupDottedName(LookupResult,QualifiedNameSyntax,Binder,DiagnosticBag,byref,bool,bool) (4 methods)
         -64 (-1.19% of base) : System.Security.Cryptography.Pkcs.dasm - PkcsPalWindows:GetPrivateKey(X509Certificate2,bool,bool):__Canon:this (4 methods)
         -56 (-2.94% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:MakeIndexerAccess(CSharpSyntaxNode,BoundExpression,PropertySymbol,ImmutableArray`1,ImmutableArray`1,ImmutableArray`1,bool,ImmutableArray`1,TypeSymbol,BoundIndexerAccess,bool):BoundExpression:this (4 methods)
Top method regressions (percentages):
          12 ( 5.00% of base) : CommandLine.dasm - TypeConverter:ChangeType(IEnumerable`1,Type,bool,CultureInfo,bool):Maybe`1 (2 methods)
          32 ( 1.90% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:BindQualifiedName(ExpressionSyntax,SimpleNameSyntax,DiagnosticBag,ConsList`1,bool):NamespaceOrTypeSymbol:this (4 methods)
          56 ( 1.50% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:MakeArguments(CSharpSyntaxNode,ImmutableArray`1,Symbol,MethodSymbol,bool,ImmutableArray`1,byref,byref,bool,ubyte):ImmutableArray`1:this (4 methods)
         128 ( 0.99% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:CheckIsVariable(CSharpSyntaxNode,BoundExpression,ubyte,bool,DiagnosticBag):bool:this (4 methods)
          24 ( 0.88% of base) : System.Data.OleDb.dasm - OleDbDataReader:CreateBindingsFromMetaData(bool):ref:this (2 methods)
Top method improvements (percentages):
         -32 (-14.81% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VisualBasicSyntaxNode:GetLastToken(bool,bool,bool,bool):SyntaxToken:this (4 methods)
         -32 (-14.81% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VisualBasicSyntaxNode:GetFirstToken(bool,bool,bool,bool):SyntaxToken:this (4 methods)
         -24 (-14.63% of base) : System.Private.Xml.dasm - SoapReflectionImporter:ImportMembersMapping(String,String,ref,bool,bool,bool):XmlMembersMapping:this (2 methods)
         -24 (-14.63% of base) : System.Private.Xml.dasm - XmlReflectionImporter:ImportMembersMapping(String,String,ref,bool,bool,bool):XmlMembersMapping:this (2 methods)
         -48 (-11.76% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BoundConversion:.ctor(VisualBasicSyntaxNode,BoundExpression,int,bool,bool,TypeSymbol,bool):this (4 methods)
VisualBasicCompilationOptions:.ctor(int,bool,String,String,String,IEnumerable`1,String,ubyte,bool,bool,bool,VisualBasicParseOptions,bool,int,bool,String,String,ImmutableArray`1,Nullable`1,int,int,IEnumerable`1,bool,bool,XmlReferenceResolver,SourceReferenceResolver,MetadataReferenceResolver,AssemblyIdentityComparer,StrongNameProvider):this (4 methods)
          -8 (-10.00% of base) : Microsoft.VisualBasic.Core.dasm - NewLateBinding:FallbackIndexSetComplex(Object,ref,ref,bool,bool) (2 methods)
         -16 (-9.30% of base) : Microsoft.VisualBasic.Core.dasm - NewLateBinding:ObjectLateSetComplex(Object,Type,String,ref,ref,ref,bool,bool) (2 methods)
          -8 (-9.09% of base) : System.Private.Xml.dasm - XmlSerializationReaderCodeGen:WriteLocalDecl(String,String,String,bool):this (2 methods)
          -8 (-9.09% of base) : System.Private.Xml.dasm - XmlSerializationWriterCodeGen:WriteLocalDecl(String,String,String,bool):this (2 methods)
          -8 (-9.09% of base) : System.Private.Xml.dasm - XmlSerializationWriterCodeGen:WriteArrayTypeCompare(String,String,String,bool):this (2 methods)
2276 total methods with Code Size differences (2263 improved, 13 regressed), 181256 unchanged.
```
Most regressions seem to be caused by changes in register allocation caused by reg optional or by making the temp reg used by some overflow checking casts delay free.