### PR TITLE
Do not copy dependent promoted call args

### DIFF
--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -3702,7 +3702,7 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
                         unsigned   lclNum = argObj->AsLclVarCommon()->GetLclNum();
                         LclVarDsc* varDsc = &lvaTable[lclNum];
 
-                        if (varDsc->lvPromoted)
+                        if (varDsc->lvPromoted && !varDsc->lvDoNotEnregister)
                         {
                             if (varDsc->lvFieldCnt == 1)
                             {


### PR DESCRIPTION
x64:
```
Total bytes of diff: -17848 (-0.06% of base)
    diff is an improvement.
Top file regressions (bytes):
           8 : System.Configuration.ConfigurationManager.dasm (0.00% of base)
           1 : System.IO.Pipelines.dasm (0.00% of base)
Top file improvements (bytes):
       -5266 : System.Security.Cryptography.Pkcs.dasm (-1.58% of base)
       -2490 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.11% of base)
       -1963 : Microsoft.CodeAnalysis.CSharp.dasm (-0.09% of base)
       -1366 : System.Security.Cryptography.X509Certificates.dasm (-0.97% of base)
       -1007 : System.Data.Common.dasm (-0.09% of base)
        -988 : System.Private.CoreLib.dasm (-0.03% of base)
        -883 : System.Security.Cryptography.Algorithms.dasm (-0.32% of base)
        -677 : Microsoft.CodeAnalysis.dasm (-0.09% of base)
        -413 : System.Drawing.Common.dasm (-0.13% of base)
        -399 : System.Security.Cryptography.Cng.dasm (-0.26% of base)
        -396 : Newtonsoft.Json.dasm (-0.06% of base)
        -351 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.01% of base)
        -347 : System.Text.Json.dasm (-0.08% of base)
        -241 : xunit.console.dasm (-0.34% of base)
        -151 : ILCompiler.Reflection.ReadyToRun.dasm (-0.14% of base)
        -145 : xunit.runner.utility.netcoreapp10.dasm (-0.10% of base)
        -132 : System.Private.DataContractSerialization.dasm (-0.02% of base)
        -124 : System.Private.Xml.dasm (-0.00% of base)
         -93 : System.Net.Http.dasm (-0.02% of base)
         -83 : System.Reflection.Metadata.dasm (-0.03% of base)
31 total files with Code Size differences (29 improved, 2 regressed), 203 unchanged.
Top method regressions (bytes):
           2 ( 1.23% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:AreLocationAttributesModified(SectionRecord,ConfigurationSection):bool:this
           2 ( 0.07% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:CopyConfigDefinitionsRecursive(ConfigDefinitionUpdates,XmlUtil,XmlUtilWriter,bool,LocationUpdates,SectionUpdates,bool,String,int,int):bool:this
           1 ( 0.33% of base) : System.Configuration.ConfigurationManager.dasm - ConfigDefinitionUpdates:FindLocationUpdates(OverrideModeSetting,bool):LocationUpdates:this
           1 ( 0.09% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:AddConfigurationSection(String,String,ConfigurationSection):this
           1 ( 0.03% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:GetConfigDefinitionUpdates(bool,int,bool,byref,byref):this
           1 ( 0.04% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:UpdateRecords():this
           1 ( 3.23% of base) : System.Data.Common.dasm - SqlDateTime:op_Inequality(SqlDateTime,SqlDateTime):SqlBoolean
           1 ( 1.12% of base) : System.Data.Common.dasm - SqlDateTime:NotEquals(SqlDateTime,SqlDateTime):SqlBoolean
           1 ( 3.23% of base) : System.Data.Common.dasm - SqlDecimal:op_Inequality(SqlDecimal,SqlDecimal):SqlBoolean
           1 ( 0.84% of base) : System.Data.Common.dasm - SqlDecimal:NotEquals(SqlDecimal,SqlDecimal):SqlBoolean
           1 ( 3.23% of base) : System.Data.Common.dasm - SqlDouble:op_Inequality(SqlDouble,SqlDouble):SqlBoolean
           1 ( 1.30% of base) : System.Data.Common.dasm - SqlDouble:NotEquals(SqlDouble,SqlDouble):SqlBoolean
           1 ( 3.23% of base) : System.Data.Common.dasm - SqlGuid:op_Inequality(SqlGuid,SqlGuid):SqlBoolean
           1 ( 3.23% of base) : System.Data.Common.dasm - SqlGuid:NotEquals(SqlGuid,SqlGuid):SqlBoolean
           1 ( 2.04% of base) : System.Data.Common.dasm - SqlInt16:op_Inequality(SqlInt16,SqlInt16):SqlBoolean
           1 ( 1.11% of base) : System.Data.Common.dasm - SqlInt16:NotEquals(SqlInt16,SqlInt16):SqlBoolean
           1 ( 1.96% of base) : System.Data.Common.dasm - SqlInt32:op_Inequality(SqlInt32,SqlInt32):SqlBoolean
           1 ( 1.15% of base) : System.Data.Common.dasm - SqlInt32:NotEquals(SqlInt32,SqlInt32):SqlBoolean
           1 ( 3.23% of base) : System.Data.Common.dasm - SqlInt64:op_Inequality(SqlInt64,SqlInt64):SqlBoolean
           1 ( 1.33% of base) : System.Data.Common.dasm - SqlInt64:NotEquals(SqlInt64,SqlInt64):SqlBoolean
Top method improvements (bytes):
        -850 (-4.93% of base) : System.Data.Common.dasm - BinaryNode:EvalBinaryOp(int,ExpressionNode,ExpressionNode,DataRow,int,ref):Object:this
        -384 (-11.72% of base) : System.Security.Cryptography.Pkcs.dasm - GeneralNameAsn:Decode(byref,ReadOnlyMemory`1,byref)
        -212 (-16.38% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VisualBasicCompilationOptions:.ctor(VisualBasicCompilationOptions):this
        -200 (-11.09% of base) : System.Security.Cryptography.Pkcs.dasm - PssParamsAsn:Encode(AsnWriter,Asn1Tag):this
        -200 (-11.09% of base) : System.Security.Cryptography.X509Certificates.dasm - PssParamsAsn:Encode(AsnWriter,Asn1Tag):this
        -167 (-18.98% of base) : xunit.console.dasm - DependencyContextJsonReader:ReadCompilationOptions(JsonObject):CompilationOptions:this
        -166 (-10.63% of base) : System.Security.Cryptography.Pkcs.dasm - PssParamsAsn:Decode(byref,Asn1Tag,ReadOnlyMemory`1,byref)
        -163 (-12.17% of base) : Newtonsoft.Json.dasm - JsonSchemaModel:Combine(JsonSchemaModel,JsonSchema)
        -153 (-3.01% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CSharpDeclarationComputer:ComputeDeclarations(SemanticModel,SyntaxNode,Func`3,bool,List`1,Nullable`1,CancellationToken)
        -150 (-10.94% of base) : System.Security.Cryptography.Pkcs.dasm - OaepParamsAsn:Encode(AsnWriter,Asn1Tag):this
        -150 (-8.37% of base) : System.Security.Cryptography.X509Certificates.dasm - TbsCertificateAsn:Encode(AsnWriter,Asn1Tag):this
        -148 (-8.62% of base) : System.Security.Cryptography.Pkcs.dasm - GeneralNameAsn:Encode(AsnWriter):this
        -148 (-8.62% of base) : System.Security.Cryptography.X509Certificates.dasm - GeneralNameAsn:Encode(AsnWriter):this
        -144 (-8.30% of base) : System.Security.Cryptography.X509Certificates.dasm - AsnWriter:WriteGeneralizedTimeCore(Asn1Tag,DateTimeOffset,bool):this
        -136 (-5.65% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SyntaxTreeSemanticModel:GetMemberModel(CSharpSyntaxNode):MemberSemanticModel:this
        -135 (-12.99% of base) : System.Security.Cryptography.Pkcs.dasm - AsnWriter:WriteUtcTimeCore(Asn1Tag,DateTimeOffset):this
        -135 (-13.06% of base) : System.Security.Cryptography.X509Certificates.dasm - AsnWriter:WriteUtcTimeCore(Asn1Tag,DateTimeOffset):this
        -132 (-9.02% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceMethodSymbol:FindSymbolFromSyntax(MethodBaseSyntax,SyntaxTree,NamedTypeSymbol):Symbol
        -131 (-8.29% of base) : System.Security.Cryptography.Pkcs.dasm - SignedDataAsn:Decode(byref,Asn1Tag,ReadOnlyMemory`1,byref)
        -130 (-3.07% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VisualBasicDeclarationComputer:ComputeDeclarationsCore(SemanticModel,SyntaxNode,Func`3,bool,List`1,Nullable`1,CancellationToken)
Top method regressions (percentages):
           1 ( 3.23% of base) : System.Data.Common.dasm - SqlDateTime:op_Inequality(SqlDateTime,SqlDateTime):SqlBoolean
           1 ( 3.23% of base) : System.Data.Common.dasm - SqlDecimal:op_Inequality(SqlDecimal,SqlDecimal):SqlBoolean
           1 ( 3.23% of base) : System.Data.Common.dasm - SqlDouble:op_Inequality(SqlDouble,SqlDouble):SqlBoolean
           1 ( 3.23% of base) : System.Data.Common.dasm - SqlGuid:op_Inequality(SqlGuid,SqlGuid):SqlBoolean
           1 ( 3.23% of base) : System.Data.Common.dasm - SqlGuid:NotEquals(SqlGuid,SqlGuid):SqlBoolean
           1 ( 3.23% of base) : System.Data.Common.dasm - SqlInt64:op_Inequality(SqlInt64,SqlInt64):SqlBoolean
           1 ( 3.23% of base) : System.Data.Common.dasm - SqlMoney:op_Inequality(SqlMoney,SqlMoney):SqlBoolean
           1 ( 3.23% of base) : System.Data.Common.dasm - SqlBinary:op_Inequality(SqlBinary,SqlBinary):SqlBoolean
           1 ( 3.23% of base) : System.Data.Common.dasm - SqlBinary:NotEquals(SqlBinary,SqlBinary):SqlBoolean
           1 ( 3.23% of base) : System.Data.Common.dasm - SqlBoolean:op_Inequality(SqlBoolean,SqlBoolean):SqlBoolean
           1 ( 3.23% of base) : System.Data.Common.dasm - SqlBoolean:NotEquals(SqlBoolean,SqlBoolean):SqlBoolean
           1 ( 2.04% of base) : System.Data.Common.dasm - SqlInt16:op_Inequality(SqlInt16,SqlInt16):SqlBoolean
           1 ( 1.96% of base) : System.Data.Common.dasm - SqlInt32:op_Inequality(SqlInt32,SqlInt32):SqlBoolean
           1 ( 1.96% of base) : System.Data.Common.dasm - SqlSingle:op_Inequality(SqlSingle,SqlSingle):SqlBoolean
           1 ( 1.89% of base) : System.Data.Common.dasm - SqlByte:op_Inequality(SqlByte,SqlByte):SqlBoolean
           1 ( 1.33% of base) : System.Data.Common.dasm - SqlInt64:NotEquals(SqlInt64,SqlInt64):SqlBoolean
           1 ( 1.33% of base) : System.Data.Common.dasm - SqlMoney:NotEquals(SqlMoney,SqlMoney):SqlBoolean
           1 ( 1.30% of base) : System.Data.Common.dasm - SqlDouble:NotEquals(SqlDouble,SqlDouble):SqlBoolean
           2 ( 1.23% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:AreLocationAttributesModified(SectionRecord,ConfigurationSection):bool:this
           1 ( 1.15% of base) : System.Data.Common.dasm - SqlInt32:NotEquals(SqlInt32,SqlInt32):SqlBoolean
Top method improvements (percentages):
         -17 (-34.69% of base) : System.Data.Common.dasm - SqlInt16:op_Explicit(SqlDecimal):SqlInt16
         -17 (-34.69% of base) : System.Data.Common.dasm - SqlByte:op_Explicit(SqlDecimal):SqlByte
         -92 (-32.97% of base) : xunit.runner.utility.netcoreapp10.dasm - TestFrameworkOptions:ForDiscovery(TestAssemblyConfiguration):ITestFrameworkDiscoveryOptions
         -32 (-32.00% of base) : System.Drawing.Common.dasm - DpiHelper:CreateScaledBitmap(Bitmap):Bitmap
         -24 (-29.63% of base) : System.Drawing.Common.dasm - Graphics:IsVisible(float,float):bool:this
         -32 (-28.83% of base) : Microsoft.CodeAnalysis.dasm - TextLineCollection:GetTextSpan(LinePositionSpan):TextSpan:this
         -24 (-28.57% of base) : System.Drawing.Common.dasm - Region:IsVisible(float,float):bool:this
         -24 (-28.57% of base) : System.Drawing.Common.dasm - GraphicsPath:IsVisible(float,float):bool:this
         -24 (-26.97% of base) : System.Drawing.Common.dasm - Region:IsVisible(float,float,Graphics):bool:this
         -24 (-26.97% of base) : System.Drawing.Common.dasm - GraphicsPath:IsVisible(float,float,Graphics):bool:this
         -24 (-26.09% of base) : System.Drawing.Common.dasm - GraphicsPath:IsOutlineVisible(float,float,Pen):bool:this
         -24 (-25.53% of base) : System.Drawing.Common.dasm - GraphicsPath:IsOutlineVisible(float,float,Pen,Graphics):bool:this
         -41 (-24.85% of base) : Microsoft.CodeAnalysis.dasm - TextLineCollection:GetLinePositionSpan(TextSpan):LinePositionSpan:this
         -40 (-24.39% of base) : Microsoft.CodeAnalysis.dasm - TextChange:Equals(TextChange):bool:this
         -16 (-23.53% of base) : System.Drawing.Common.dasm - Graphics:IsVisible(int,int):bool:this
         -17 (-23.29% of base) : System.Security.Cryptography.Algorithms.dasm - AsnWriter:PushSequenceCore(Asn1Tag):this
         -17 (-23.29% of base) : System.Security.Cryptography.Cng.dasm - AsnWriter:PushSequenceCore(Asn1Tag):this
         -17 (-23.29% of base) : System.Security.Cryptography.Pkcs.dasm - AsnWriter:PushSequenceCore(Asn1Tag):this
         -17 (-23.29% of base) : System.Security.Cryptography.X509Certificates.dasm - AsnWriter:PushSequenceCore(Asn1Tag):this
         -16 (-22.54% of base) : System.Drawing.Common.dasm - GraphicsPath:IsVisible(int,int):bool:this
528 total methods with Code Size differences (487 improved, 41 regressed), 183622 unchanged.
```

arm64:
```
Total bytes of diff: -35928 (-0.03% of base)
    diff is an improvement.
Top file improvements (bytes):
       -8144 : System.Security.Cryptography.Pkcs.dasm (-0.78% of base)
       -7408 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.05% of base)
       -6080 : Microsoft.CodeAnalysis.CSharp.dasm (-0.05% of base)
       -2512 : Microsoft.CodeAnalysis.dasm (-0.05% of base)
       -2248 : System.Security.Cryptography.X509Certificates.dasm (-0.47% of base)
       -1864 : System.Private.CoreLib.dasm (-0.02% of base)
       -1336 : System.Data.Common.dasm (-0.04% of base)
       -1160 : System.Security.Cryptography.Algorithms.dasm (-0.14% of base)
        -968 : System.Text.Json.dasm (-0.07% of base)
        -736 : Newtonsoft.Json.dasm (-0.03% of base)
        -480 : System.Security.Cryptography.Cng.dasm (-0.10% of base)
        -432 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
        -384 : System.Drawing.Common.dasm (-0.04% of base)
        -360 : xunit.console.dasm (-0.15% of base)
        -256 : System.Private.DataContractSerialization.dasm (-0.01% of base)
        -256 : xunit.runner.utility.netcoreapp10.dasm (-0.05% of base)
        -240 : System.Private.Xml.dasm (-0.00% of base)
        -216 : ILCompiler.Reflection.ReadyToRun.dasm (-0.06% of base)
        -200 : System.Net.Http.dasm (-0.01% of base)
        -160 : System.Reflection.Metadata.dasm (-0.01% of base)
28 total files with Code Size differences (28 improved, 0 regressed), 206 unchanged.
Top method improvements (bytes):
       -1032 (-1.97% of base) : System.Data.Common.dasm - BinaryNode:EvalBinaryOp(int,ExpressionNode,ExpressionNode,DataRow,int,ref):Object:this (2 methods)
        -464 (-1.54% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CSharpDeclarationComputer:ComputeDeclarations(SemanticModel,SyntaxNode,Func`3,bool,List`1,Nullable`1,CancellationToken) (4 methods)
        -448 (-3.05% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SyntaxTreeSemanticModel:GetMemberModel(CSharpSyntaxNode):MemberSemanticModel:this (4 methods)
        -416 (-5.66% of base) : System.Security.Cryptography.Pkcs.dasm - GeneralNameAsn:Decode(byref,ReadOnlyMemory`1,byref) (2 methods)
        -400 (-1.65% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VisualBasicDeclarationComputer:ComputeDeclarationsCore(SemanticModel,SyntaxNode,Func`3,bool,List`1,Nullable`1,CancellationToken) (4 methods)
        -392 (-8.80% of base) : System.Security.Cryptography.Pkcs.dasm - AsnWriter:WriteGeneralizedTimeCore(Asn1Tag,DateTimeOffset,bool):this (2 methods)
        -392 (-8.78% of base) : System.Security.Cryptography.X509Certificates.dasm - AsnWriter:WriteGeneralizedTimeCore(Asn1Tag,DateTimeOffset,bool):this (2 methods)
        -384 (-6.52% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VisualBasicCompilationOptions:.ctor(VisualBasicCompilationOptions):this (4 methods)
        -384 (-3.98% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceMethodSymbol:FindSymbolFromSyntax(MethodBaseSyntax,SyntaxTree,NamedTypeSymbol):Symbol (4 methods)
        -296 (-10.85% of base) : System.Security.Cryptography.Pkcs.dasm - AsnWriter:WriteUtcTimeCore(Asn1Tag,DateTimeOffset):this (2 methods)
        -296 (-10.85% of base) : System.Security.Cryptography.X509Certificates.dasm - AsnWriter:WriteUtcTimeCore(Asn1Tag,DateTimeOffset):this (2 methods)
        -288 (-5.48% of base) : System.Security.Cryptography.Pkcs.dasm - GeneralNameAsn:Encode(AsnWriter):this (2 methods)
        -288 (-5.48% of base) : System.Security.Cryptography.X509Certificates.dasm - GeneralNameAsn:Encode(AsnWriter):this (2 methods)
        -256 (-1.58% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:GetDefaultParameterValue(CSharpSyntaxNode,ParameterSymbol,ubyte):BoundExpression:this (4 methods)
        -256 (-10.74% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CSharpLineDirectiveMap:TranslateSpanAndVisibility(SourceText,String,TextSpan,byref):FileLinePositionSpan:this (4 methods)
        -256 (-2.99% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DeclarationTreeBuilder:VisitNamespaceBlock(NamespaceBlockSyntax):SingleNamespaceOrTypeDeclaration:this (4 methods)
        -256 (-1.09% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BinderFactory:CreateBinderForNodeAndUsage(VisualBasicSyntaxNode,ubyte,Binder):Binder:this (4 methods)
        -256 (-8.56% of base) : Newtonsoft.Json.dasm - JsonSchemaModel:Combine(JsonSchemaModel,JsonSchema) (2 methods)
        -256 (-5.35% of base) : System.Security.Cryptography.Pkcs.dasm - PssParamsAsn:Encode(AsnWriter,Asn1Tag):this (2 methods)
        -256 (-6.04% of base) : System.Security.Cryptography.Pkcs.dasm - PssParamsAsn:Decode(byref,Asn1Tag,ReadOnlyMemory`1,byref) (2 methods)
Top method improvements (percentages):
         -64 (-19.51% of base) : System.Drawing.Common.dasm - DpiHelper:CreateScaledBitmap(Bitmap):Bitmap (2 methods)
         -96 (-19.35% of base) : Microsoft.CodeAnalysis.dasm - <>c:<ComputeTextChangesFromOld>b__12_0(ChangeRangeWithText):TextChange:this (4 methods)
        -160 (-19.05% of base) : xunit.runner.utility.netcoreapp10.dasm - TestFrameworkOptions:ForDiscovery(TestAssemblyConfiguration):ITestFrameworkDiscoveryOptions (2 methods)
         -32 (-18.18% of base) : System.Data.Common.dasm - SqlInt16:op_Explicit(SqlDecimal):SqlInt16 (2 methods)
         -32 (-18.18% of base) : System.Data.Common.dasm - SqlByte:op_Explicit(SqlDecimal):SqlByte (2 methods)
        -128 (-17.39% of base) : Microsoft.CodeAnalysis.dasm - TextLineCollection:GetTextSpan(LinePositionSpan):TextSpan:this (4 methods)
        -128 (-16.00% of base) : Microsoft.CodeAnalysis.dasm - TextLineCollection:GetLinePositionSpan(TextSpan):LinePositionSpan:this (4 methods)
         -32 (-13.79% of base) : System.Drawing.Common.dasm - Graphics:IsVisible(int,int):bool:this (2 methods)
         -32 (-13.79% of base) : System.Security.Cryptography.Algorithms.dasm - AsnWriter:PushSequenceCore(Asn1Tag):this (2 methods)
         -32 (-13.79% of base) : System.Security.Cryptography.Cng.dasm - AsnWriter:PushSequenceCore(Asn1Tag):this (2 methods)
         -32 (-13.79% of base) : System.Security.Cryptography.Pkcs.dasm - AsnWriter:PushSequenceCore(Asn1Tag):this (2 methods)
         -32 (-13.79% of base) : System.Security.Cryptography.X509Certificates.dasm - AsnWriter:PushSequenceCore(Asn1Tag):this (2 methods)
         -32 (-13.33% of base) : System.Drawing.Common.dasm - GraphicsPath:IsVisible(int,int):bool:this (2 methods)
        -128 (-13.11% of base) : Microsoft.CodeAnalysis.dasm - TextChange:Equals(TextChange):bool:this (4 methods)
         -32 (-12.90% of base) : System.Data.Common.dasm - SqlDecimal:ToSqlByte():SqlByte:this (2 methods)
         -32 (-12.90% of base) : System.Data.Common.dasm - SqlDecimal:ToSqlInt16():SqlInt16:this (2 methods)
         -32 (-12.90% of base) : System.Drawing.Common.dasm - Region:IsVisible(int,int,Graphics):bool:this (2 methods)
         -32 (-12.90% of base) : System.Drawing.Common.dasm - GraphicsPath:IsVisible(int,int,Graphics):bool:this (2 methods)
         -32 (-12.90% of base) : System.Security.Cryptography.Pkcs.dasm - AsnReader:ReadCharacterString(int):String:this (2 methods)
         -32 (-12.50% of base) : System.Data.Common.dasm - RBTree`1:GetIndexByKey(__Canon):int:this (2 methods)
476 total methods with Code Size differences (476 improved, 0 regressed), 183164 unchanged.
```

x64 small regressions caused by the use of `movsx` instead of `movzx`. `movzx` should always be used for small structs, not only that it's one byte shorter but it doesn't make much sense to sign extend something that isn't really an integer. Native compilers use `movzx` even when the struct consists of a single small signed integer field.