### PR TITLE
Pack promoted call args

### DIFF
--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -1915,7 +1915,7 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
     }
     else
     {
-        assert(genTypeSize(targetType) <= REGSIZE_BYTES);
+        assert((dataReg != REG_ZR) || (genTypeSize(targetType) <= REGSIZE_BYTES));
         emit->emitIns_S_R(ins_Store(targetType), emitActualTypeSize(targetType), dataReg, varNum, offset);
     }
 

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -9916,6 +9916,7 @@ public:
 
 #endif // defined(UNIX_AMD64_ABI)
 
+    GenTree* abiMorphPromotedRegisterCallArg(LclVarDsc* lcl, var_types argType);
 #if FEATURE_MULTIREG_ARGS
     void fgMorphMultiregStructArgs(GenTreeCall* call);
     GenTree* fgMorphMultiregStructArg(GenTree* arg, fgArgTabEntry* fgEntryPtr);

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -9916,7 +9916,7 @@ public:
 
 #endif // defined(UNIX_AMD64_ABI)
 
-    GenTree* abiMorphPromotedRegisterCallArg(LclVarDsc* lcl, var_types argType);
+    GenTree* abiMorphPromotedStructArgToSingleReg(GenTreeLclVar* arg, var_types argRegType, unsigned argSize);
 #if FEATURE_MULTIREG_ARGS
     void fgMorphMultiregStructArgs(GenTreeCall* call);
     GenTree* fgMorphMultiregStructArg(GenTree* arg, fgArgTabEntry* fgEntryPtr);

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -10228,10 +10228,11 @@ void Compiler::gtDispTree(GenTree*     tree,
 
 #ifdef FEATURE_HW_INTRINSICS
         case GT_HWINTRINSIC:
-            printf(" %s %s", tree->AsHWIntrinsic()->gtSIMDBaseType == TYP_UNKNOWN
-                                 ? ""
-                                 : varTypeName(tree->AsHWIntrinsic()->gtSIMDBaseType),
-                   HWIntrinsicInfo::lookupName(tree->AsHWIntrinsic()->gtHWIntrinsicId));
+            printf(" %s %s %u", HWIntrinsicInfo::lookupName(tree->AsHWIntrinsic()->gtHWIntrinsicId),
+                   tree->AsHWIntrinsic()->gtSIMDBaseType == TYP_UNKNOWN
+                       ? ""
+                       : varTypeName(tree->AsHWIntrinsic()->gtSIMDBaseType),
+                   tree->AsHWIntrinsic()->gtSIMDSize);
 
             gtDispCommonEndLine(tree);
 

--- a/src/coreclr/src/jit/lowerarm64.cpp
+++ b/src/coreclr/src/jit/lowerarm64.cpp
@@ -708,7 +708,6 @@ void Lowering::CombineShiftImmediate(GenTreeInstr* shift)
             // doing this so code like "(x_byte & 3) << 6" also generates an extra uxtb.
 
             assert(varActualType(cast->GetType()) == TYP_INT);
-            assert(size == EA_4BYTE);
 
             bitFieldWidth = varTypeBitSize(cast->GetCastType());
             isUnsigned    = varTypeIsUnsigned(cast->GetCastType());

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -3759,7 +3759,7 @@ GenTree* Compiler::abiMorphPromotedStructArgToSingleReg(GenTreeLclVar* arg, var_
         LclVarDsc* fieldLcl = lvaGetDesc(lcl->GetPromotedFieldLclNum(0));
         assert(varTypeIsEnregisterable(fieldLcl->GetType()));
 
-        if (argSize <= varTypeSize(fieldLcl->GetType()))
+        if ((argSize <= varTypeSize(fieldLcl->GetType())) && (fieldLcl->GetPromotedFieldOffset() == 0))
         {
             arg->SetLclNum(lcl->GetPromotedFieldLclNum(0));
 

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -3847,11 +3847,6 @@ GenTree* Compiler::abiMorphPromotedStructArgToSingleReg(GenTreeLclVar* arg, var_
         return nullptr;
     }
 
-    if (lcl->lvExactSize > varTypeSize(argRegType))
-    {
-        return nullptr;
-    }
-
     argRegType = varActualType(argRegType);
 
     GenTree* newArg = nullptr;
@@ -3860,7 +3855,13 @@ GenTree* Compiler::abiMorphPromotedStructArgToSingleReg(GenTreeLclVar* arg, var_
     {
         unsigned   fieldLclNum = lcl->GetPromotedFieldLclNum(i);
         LclVarDsc* fieldLcl    = lvaGetDesc(fieldLclNum);
-        GenTree*   field       = gtNewLclvNode(fieldLclNum, fieldLcl->GetType());
+
+        if (fieldLcl->GetPromotedFieldOffset() >= argSize)
+        {
+            break;
+        }
+
+        GenTree* field = gtNewLclvNode(fieldLclNum, fieldLcl->GetType());
 
         if (varTypeIsSmall(fieldLcl->GetType()))
         {

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -3307,27 +3307,31 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
                                     argObj->AsLclVarCommon()->SetLclNum(varDsc->lvFieldLclStart);
 
                                     if (varTypeIsEnregisterable(fieldVarDsc->TypeGet()) &&
-                                        (genTypeSize(fieldVarDsc->TypeGet()) == originalSize))
+                                        (varActualType(fieldVarDsc->GetType()) == varActualType(structBaseType)))
                                     {
                                         // Just use the existing field's type
-                                        argObj->gtType = fieldVarDsc->TypeGet();
+                                        argObj->SetType(fieldVarDsc->TypeGet());
                                     }
                                     else
                                     {
                                         // Can't use the existing field's type, so use GT_LCL_FLD to swizzle
                                         // to a new type
                                         argObj->ChangeOper(GT_LCL_FLD);
-                                        argObj->gtType = structBaseType;
+                                        argObj->SetType(structBaseType);
+
+                                        lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_LocalField));
                                     }
+
                                     assert(varTypeIsEnregisterable(argObj->TypeGet()));
                                     assert(copyBlkClass == NO_CLASS_HANDLE);
                                 }
                                 else
                                 {
                                     // use GT_LCL_FLD to swizzle the single field struct to a new type
-                                    lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_LocalField));
                                     argObj->ChangeOper(GT_LCL_FLD);
-                                    argObj->gtType = structBaseType;
+                                    argObj->SetType(structBaseType);
+
+                                    lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_LocalField));
                                 }
                             }
                             else

--- a/src/coreclr/src/jit/rationalize.cpp
+++ b/src/coreclr/src/jit/rationalize.cpp
@@ -714,8 +714,6 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, Compiler::Ge
                 break;
             }
 
-            noway_assert(comp->supportSIMDTypes());
-
             // TODO-1stClassStructs: This should be handled more generally for enregistered or promoted
             // structs that are passed or returned in a different register type than their enregistered
             // type(s).

--- a/src/coreclr/src/vm/jitinterface.cpp
+++ b/src/coreclr/src/vm/jitinterface.cpp
@@ -12691,6 +12691,12 @@ void ThrowExceptionForJit(HRESULT res)
             COMPlusThrow(kInvalidProgramException, (UINT) IDS_EE_JIT_COMPILER_ERROR);
             break;
 
+#if defined(CROSSGEN_COMPILE)
+        case CORJIT_SKIPPED:
+            ThrowHR(res);
+            break;
+#endif
+
         case CORJIT_BADCODE:
         default:
             COMPlusThrow(kInvalidProgramException);

--- a/src/coreclr/src/zap/zapimage.cpp
+++ b/src/coreclr/src/zap/zapimage.cpp
@@ -2188,14 +2188,17 @@ ZapImage::CompileStatus ZapImage::TryCompileMethodWorker(CORINFO_METHOD_HANDLE h
                 level = CORZAP_LOGLEVEL_INFO;
             }
 
-            m_zapper->Print(level, W("%s while compiling method %s\n"), message.GetUnicode(), zapInfo.m_currentMethodName.GetUnicode());
-
-            if ((result == COMPILE_FAILED) && (m_stats != NULL))
+            if (hrException != CORJIT_SKIPPED)
             {
-                if (!m_zapper->m_pOpt->m_compilerFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_IL_STUB))
-                    m_stats->m_failedMethods++;
-                else
-                    m_stats->m_failedILStubs++;
+                m_zapper->Print(level, W("%s while compiling method %s\n"), message.GetUnicode(), zapInfo.m_currentMethodName.GetUnicode());
+
+                if ((result == COMPILE_FAILED) && (m_stats != NULL))
+                {
+                    if (!m_zapper->m_pOpt->m_compilerFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_IL_STUB))
+                        m_stats->m_failedMethods++;
+                    else
+                        m_stats->m_failedILStubs++;
+                }
             }
         }
     }


### PR DESCRIPTION
win-x64 diff:
```
Total bytes of diff: -8564 (-0.027% of base)
    diff is an improvement.
Top file regressions (bytes):
          16 : System.Reflection.DispatchProxy.dasm (0.094% of base)
Top file improvements (bytes):
       -1486 : System.Linq.Parallel.dasm (-0.259% of base)
       -1472 : System.Private.Xml.dasm (-0.048% of base)
       -1078 : Newtonsoft.Json.dasm (-0.179% of base)
        -347 : System.Data.Common.dasm (-0.032% of base)
        -327 : Microsoft.CodeAnalysis.dasm (-0.044% of base)
        -327 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.010% of base)
        -318 : System.Net.Http.dasm (-0.053% of base)
        -300 : System.Linq.Expressions.dasm (-0.011% of base)
        -252 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.011% of base)
        -234 : System.Security.Cryptography.Pkcs.dasm (-0.077% of base)
        -219 : System.Private.CoreLib.dasm (-0.007% of base)
        -214 : System.Formats.Asn1.dasm (-0.334% of base)
        -205 : System.Console.dasm (-0.518% of base)
        -191 : Microsoft.CodeAnalysis.CSharp.dasm (-0.009% of base)
        -182 : Microsoft.Extensions.Logging.dasm (-1.177% of base)
        -151 : System.Formats.Cbor.dasm (-0.363% of base)
        -141 : System.Collections.Concurrent.dasm (-0.304% of base)
        -129 : System.Text.RegularExpressions.dasm (-0.070% of base)
        -118 : xunit.console.dasm (-0.172% of base)
        -114 : System.Reflection.Metadata.dasm (-0.036% of base)
47 total files with Code Size differences (46 improved, 1 regressed), 215 unchanged.
Top method regressions (bytes):
          18 (0.943% of base) : Microsoft.Extensions.DependencyInjection.dasm - ILEmitResolverBuilder:GenerateMethodBody(ServiceCallSite,ILGenerator):ILEmitResolverBuilderRuntimeContext:this
          18 (2.609% of base) : System.Formats.Asn1.dasm - AsnDecoder:ReadBitString(ReadOnlySpan`1,int,byref,byref,Nullable`1):ref
          13 (0.544% of base) : System.Reflection.DispatchProxy.dasm - ProxyBuilder:AddMethodImpl(MethodInfo):MethodBuilder:this
           7 (0.268% of base) : Microsoft.CodeAnalysis.dasm - <DescendantNodesAndTokensIntoTrivia>d__159:MoveNext():bool:this
           7 (4.430% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - KeywordTable:AddKeyword(ushort,bool,ubyte,bool,bool)
           7 (0.206% of base) : System.ComponentModel.Composition.dasm - MetadataViewGenerator:GenerateInterfaceViewProxyType(Type):Type
           7 (1.394% of base) : System.Linq.Expressions.dasm - LambdaCompiler:EmitDynamicExpression(Expression):this
           7 (1.403% of base) : System.Reflection.DispatchProxy.dasm - ProxyBuilder:Complete():this
           6 (0.504% of base) : System.Linq.Expressions.dasm - CompilerScope:EmitNewHoistedLocals(LambdaCompiler):this
           6 (1.240% of base) : System.Linq.Expressions.dasm - LambdaCompiler:EmitNewExpression(Expression):this
           4 (0.903% of base) : Microsoft.CodeAnalysis.dasm - SyntaxDiffer:RecordInsertNew(int):this
           2 (1.042% of base) : System.Formats.Asn1.dasm - AsnDecoder:TryReadPrimitiveOctetString(ReadOnlySpan`1,int,byref,byref,Nullable`1):bool
           2 (0.417% of base) : System.Formats.Asn1.dasm - AsnWriter:WriteConstructedCerOctetString(Asn1Tag,ReadOnlySpan`1):this
           2 (1.227% of base) : System.Linq.Expressions.dasm - LambdaCompiler:EmitGetArrayElement(Type):this
           2 (1.227% of base) : System.Linq.Expressions.dasm - LambdaCompiler:EmitSetArrayElement(Type):this
           1 (0.308% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:VisitWhileStatement(BoundWhileStatement):BoundNode:this
           1 (0.119% of base) : Microsoft.CodeAnalysis.dasm - <DescendantNodesOnly>d__157:MoveNext():bool:this
           1 (0.110% of base) : Microsoft.CodeAnalysis.dasm - <DescendantNodesAndTokensOnly>d__158:MoveNext():bool:this
           1 (0.397% of base) : System.ComponentModel.Composition.dasm - MetadataViewGenerator:GenerateLocalAssignmentFromDefaultAttribute(ILGenerator,ref,LocalBuilder)
           1 (0.483% of base) : System.Formats.Asn1.dasm - AsnDecoder:TryReadCharacterString(ReadOnlySpan`1,Span`1,int,int,byref,byref,Nullable`1):bool
Top method improvements (bytes):
        -390 (-33.333% of base) : System.Linq.Parallel.dasm - QueryOperator`1:GetEnumerator():IEnumerator`1:this (26 methods)
        -240 (-15.789% of base) : Newtonsoft.Json.dasm - JToken:op_Implicit(Nullable`1):JToken (16 methods)
        -186 (-5.003% of base) : System.Linq.Parallel.dasm - AssociativeAggregationOperator`3:Aggregate():Nullable`1:this (5 methods)
        -148 (-8.222% of base) : System.Console.dasm - ConsolePal:MoveBufferArea(int,int,int,int,int,int,ushort,int,int)
        -120 (-2.676% of base) : Newtonsoft.Json.dasm - JsonWriter:WriteValue(JsonWriter,int,Object)
        -105 (-2.280% of base) : Newtonsoft.Json.dasm - JsonWriter:WriteValueAsync(JsonWriter,int,Object,CancellationToken):Task
         -97 (-3.107% of base) : System.Data.Common.dasm - SqlSingleStorage:Aggregate(ref,int):Object:this
         -93 (-10.877% of base) : System.Net.Http.dasm - HttpMethod:.cctor()
         -87 (-2.869% of base) : xunit.console.dasm - ConsoleRunner:ExecuteAssembly(Object,XunitProjectAssembly,bool,bool,Nullable`1,Nullable`1,bool,bool,Nullable`1,bool,bool,XunitFilters,bool):XElement:this
         -64 (-6.066% of base) : System.Private.Xml.dasm - XmlILGenerator:CreateTypeInitializer(XmlQueryStaticData):this
         -63 (-8.203% of base) : System.Security.Cryptography.Pkcs.dasm - CmsSignature:DsaDerToIeee(ReadOnlyMemory`1,Span`1):bool
         -54 (-5.915% of base) : System.Private.Xml.dasm - XmlILVisitor:StartForBinding(QilIterator,OptimizerPatterns):this
         -52 (-4.924% of base) : System.Text.RegularExpressions.dasm - RegexCharClass:Canonicalize():this
         -51 (-20.319% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CodeGenerator:EmitSequencePointStatement(BoundSequencePointWithSpan):this
         -49 (-12.039% of base) : System.Console.dasm - ConsolePal:Clear()
         -49 (-3.673% of base) : System.Private.Xml.dasm - XmlILVisitor:NestedVisitEnsureCache(QilNode,Type):this
         -48 (-3.771% of base) : System.Linq.Parallel.dasm - AssociativeAggregationOperator`3:Aggregate():__Canon:this (2 methods)
         -48 (-5.304% of base) : System.Private.Xml.dasm - XmlILVisitor:VisitXsltInvokeLateBound(QilInvokeLateBound):QilNode:this
         -47 (-19.583% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - CodeGenerator:EmitSequencePointStatement(BoundSequencePointWithSpan):this
         -47 (-6.772% of base) : System.Private.Xml.dasm - XmlILGenerator:CreateHelperFunctions():this
Top method regressions (percentages):
           7 (4.430% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - KeywordTable:AddKeyword(ushort,bool,ubyte,bool,bool)
          18 (2.609% of base) : System.Formats.Asn1.dasm - AsnDecoder:ReadBitString(ReadOnlySpan`1,int,byref,byref,Nullable`1):ref
           7 (1.403% of base) : System.Reflection.DispatchProxy.dasm - ProxyBuilder:Complete():this
           7 (1.394% of base) : System.Linq.Expressions.dasm - LambdaCompiler:EmitDynamicExpression(Expression):this
           6 (1.240% of base) : System.Linq.Expressions.dasm - LambdaCompiler:EmitNewExpression(Expression):this
           2 (1.227% of base) : System.Linq.Expressions.dasm - LambdaCompiler:EmitGetArrayElement(Type):this
           2 (1.227% of base) : System.Linq.Expressions.dasm - LambdaCompiler:EmitSetArrayElement(Type):this
           2 (1.042% of base) : System.Formats.Asn1.dasm - AsnDecoder:TryReadPrimitiveOctetString(ReadOnlySpan`1,int,byref,byref,Nullable`1):bool
          18 (0.943% of base) : Microsoft.Extensions.DependencyInjection.dasm - ILEmitResolverBuilder:GenerateMethodBody(ServiceCallSite,ILGenerator):ILEmitResolverBuilderRuntimeContext:this
           4 (0.903% of base) : Microsoft.CodeAnalysis.dasm - SyntaxDiffer:RecordInsertNew(int):this
          13 (0.544% of base) : System.Reflection.DispatchProxy.dasm - ProxyBuilder:AddMethodImpl(MethodInfo):MethodBuilder:this
           6 (0.504% of base) : System.Linq.Expressions.dasm - CompilerScope:EmitNewHoistedLocals(LambdaCompiler):this
           1 (0.483% of base) : System.Formats.Asn1.dasm - AsnDecoder:TryReadCharacterString(ReadOnlySpan`1,Span`1,int,int,byref,byref,Nullable`1):bool
           2 (0.417% of base) : System.Formats.Asn1.dasm - AsnWriter:WriteConstructedCerOctetString(Asn1Tag,ReadOnlySpan`1):this
           1 (0.397% of base) : System.ComponentModel.Composition.dasm - MetadataViewGenerator:GenerateLocalAssignmentFromDefaultAttribute(ILGenerator,ref,LocalBuilder)
           1 (0.308% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:VisitWhileStatement(BoundWhileStatement):BoundNode:this
           7 (0.268% of base) : Microsoft.CodeAnalysis.dasm - <DescendantNodesAndTokensIntoTrivia>d__159:MoveNext():bool:this
           7 (0.206% of base) : System.ComponentModel.Composition.dasm - MetadataViewGenerator:GenerateInterfaceViewProxyType(Type):Type
           1 (0.119% of base) : Microsoft.CodeAnalysis.dasm - <DescendantNodesOnly>d__157:MoveNext():bool:this
           1 (0.110% of base) : Microsoft.CodeAnalysis.dasm - <DescendantNodesAndTokensOnly>d__158:MoveNext():bool:this
Top method improvements (percentages):
         -18 (-48.649% of base) : System.IO.Compression.dasm - ZipArchive:CreateEntry(String):ZipArchiveEntry:this
         -18 (-48.649% of base) : System.IO.Compression.ZipFile.dasm - ZipFileExtensions:CreateEntryFromFile(ZipArchive,String,String):ZipArchiveEntry
         -17 (-44.737% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - FilterStackSource:GetCallerIndex(int):int:this
         -17 (-44.737% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - FilterStackSource:GetNumberOfFoldedFrames(int):int:this
         -17 (-44.737% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - FilterStackSource:GetFrameIndex(int):int:this
         -17 (-40.476% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - CallTree:Sort(IComparer`1):this
         -18 (-40.000% of base) : System.IO.Compression.ZipFile.dasm - ZipFile:CreateFromDirectory(String,String)
         -18 (-38.298% of base) : Microsoft.Extensions.Logging.dasm - FilterLoggingBuilderExtensions:AddFilter(LoggerFilterOptions,Func`4):LoggerFilterOptions
         -29 (-34.940% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - EarlyWellKnownAttributeBinder:.ctor(Symbol,Binder):this
         -13 (-34.211% of base) : xunit.assert.dasm - Assert:False(bool,String)
         -13 (-34.211% of base) : xunit.assert.dasm - Assert:True(bool,String)
         -18 (-33.333% of base) : Microsoft.Extensions.Logging.dasm - <>c__DisplayClass0_0:<AddFilter>b__0(LoggerFilterOptions):this
        -390 (-33.333% of base) : System.Linq.Parallel.dasm - QueryOperator`1:GetEnumerator():IEnumerator`1:this (26 methods)
         -13 (-32.500% of base) : xunit.assert.dasm - Assert:False(bool)
         -13 (-32.500% of base) : xunit.assert.dasm - Assert:True(bool)
         -11 (-31.429% of base) : System.IO.Compression.dasm - ZipArchive:CreateEntry(String,int):ZipArchiveEntry:this
         -11 (-31.429% of base) : System.IO.Compression.ZipFile.dasm - ZipFileExtensions:CreateEntryFromFile(ZipArchive,String,String,int):ZipArchiveEntry
         -12 (-25.532% of base) : System.IO.Compression.ZipFile.dasm - ZipFile:CreateFromDirectory(String,String,int,bool)
         -18 (-25.000% of base) : System.Collections.Concurrent.dasm - ConcurrentDictionary`2:TryUpdate(__Canon,__Canon,__Canon):bool:this
         -36 (-24.658% of base) : xunit.performance.execution.dasm - BenchmarkTestFrameworkExecutor:RunTestCases(IEnumerable`1,IMessageSink,ITestFrameworkExecutionOptions):this
589 total methods with Code Size differences (569 improved, 20 regressed), 185877 unchanged.
```
alt-linux-x64 diff:
```
Total bytes of diff: -11660 (-0.026% of base)
    diff is an improvement.
Top file regressions (bytes):
          12 : System.Reflection.DispatchProxy.dasm (0.052% of base)
           8 : Microsoft.Extensions.Configuration.Json.dasm (0.136% of base)
Top file improvements (bytes):
       -1523 : System.Linq.Parallel.dasm (-0.244% of base)
       -1296 : System.Private.Xml.dasm (-0.033% of base)
       -1167 : Newtonsoft.Json.dasm (-0.145% of base)
       -1160 : System.Net.Http.dasm (-0.155% of base)
        -799 : System.Formats.Asn1.dasm (-1.076% of base)
        -706 : Microsoft.CodeAnalysis.dasm (-0.039% of base)
        -594 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.010% of base)
        -359 : System.Security.Cryptography.Pkcs.dasm (-0.102% of base)
        -358 : System.Data.Common.dasm (-0.026% of base)
        -333 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.008% of base)
        -300 : System.Linq.Expressions.dasm (-0.030% of base)
        -299 : Microsoft.CodeAnalysis.CSharp.dasm (-0.006% of base)
        -250 : System.Collections.Concurrent.dasm (-0.287% of base)
        -242 : Microsoft.Extensions.Logging.dasm (-1.081% of base)
        -213 : System.Console.dasm (-0.432% of base)
        -205 : System.Private.CoreLib.dasm (-0.005% of base)
        -158 : System.Formats.Cbor.dasm (-0.306% of base)
        -152 : xunit.performance.execution.dasm (-0.805% of base)
        -150 : System.Reflection.Metadata.dasm (-0.040% of base)
        -149 : System.Net.WebSockets.dasm (-0.246% of base)
49 total files with Code Size differences (47 improved, 2 regressed), 213 unchanged.
Top method regressions (bytes):
         116 (1.844% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SourceMethodSymbol:DecodeDllImportAttribute(byref):this (2 methods)
         106 (0.755% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceMethodSymbol:DecodeWellKnownAttributeAppliedToMethod(byref):this (2 methods)
          23 (2.596% of base) : System.Linq.Expressions.dasm - LambdaCompiler:EmitReferenceCoalesceWithoutConversion(BinaryExpression):this
          16 (4.384% of base) : System.Private.CoreLib.dasm - TimeSpanParse:TryParseExactTimeSpan(ReadOnlySpan`1,ReadOnlySpan`1,IFormatProvider,int,byref):bool
          14 (3.465% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - KeywordTable:AddKeyword(ushort,bool,ubyte,bool,bool) (2 methods)
          10 (1.751% of base) : System.Formats.Asn1.dasm - AsnWriter:WriteConstructedCerOctetString(Asn1Tag,ReadOnlySpan`1):this
          10 (9.091% of base) : System.Linq.Expressions.dasm - BoundConstants:EmitConstantsArray(LambdaCompiler)
           9 (1.525% of base) : System.Formats.Asn1.dasm - AsnWriter:WriteConstructedCerBitString(Asn1Tag,ReadOnlySpan`1,int):this
           9 (1.241% of base) : System.Reflection.DispatchProxy.dasm - ProxyBuilder:Complete():this
           9 (3.000% of base) : xunit.console.dasm - <>c__DisplayClass12_1:<RunProject>b__5():XElement:this
           8 (1.116% of base) : Microsoft.Extensions.Configuration.Json.dasm - JsonConfigurationFileParser:ParseStream(Stream):IDictionary`2:this
           8 (2.260% of base) : System.ComponentModel.Composition.dasm - MetadataViewGenerator:GenerateLocalAssignmentFromDefaultAttribute(ILGenerator,ref,LocalBuilder)
           8 (2.899% of base) : System.Linq.Expressions.dasm - CompilerScope:EmitClosureToVariable(LambdaCompiler,HoistedLocals):this
           8 (1.208% of base) : System.Linq.Expressions.dasm - LambdaCompiler:EmitNewExpression(Expression):this
           8 (0.305% of base) : xunit.console.dasm - ConsoleRunner:RunProject(XunitProject,bool,Nullable`1,Nullable`1,Nullable`1,bool,bool,Nullable`1,bool,bool,bool):int:this
           7 (0.146% of base) : System.ComponentModel.Composition.dasm - MetadataViewGenerator:GenerateInterfaceViewProxyType(Type):Type
           7 (0.212% of base) : System.Reflection.DispatchProxy.dasm - ProxyBuilder:AddMethodImpl(MethodInfo):MethodBuilder:this
           6 (0.242% of base) : Microsoft.Extensions.DependencyInjection.dasm - ILEmitResolverBuilder:GenerateMethodBody(ServiceCallSite,ILGenerator):ILEmitResolverBuilderRuntimeContext:this
           5 (0.419% of base) : System.Text.RegularExpressions.dasm - RegexNode:<ReduceAlternation>g__ReduceSingleLetterAndNestedAlternations|80_0():this
           5 (0.183% of base) : System.Text.RegularExpressions.dasm - RegexParser:ScanCharClass(bool,bool):RegexCharClass:this
Top method improvements (bytes):
        -859 (-5.316% of base) : System.Net.Http.dasm - KnownHeaders:.cctor()
        -621 (-39.655% of base) : System.Linq.Parallel.dasm - QueryOperator`1:GetEnumerator():IEnumerator`1:this (27 methods)
        -274 (-13.551% of base) : Newtonsoft.Json.dasm - JToken:op_Implicit(Nullable`1):JToken (16 methods)
        -176 (-3.014% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SyntaxTreeSemanticModel:GetMemberModel(CSharpSyntaxNode):MemberSemanticModel:this (2 methods)
        -158 (-7.502% of base) : System.Console.dasm - ConsolePal:MoveBufferArea(int,int,int,int,int,int,ushort,int,int)
        -148 (-2.443% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DocumentationCommentWalker:DefaultVisit(SyntaxNode):this (2 methods)
        -122 (-0.563% of base) : System.Net.WebSockets.dasm - <ReceiveAsyncPrivate>d__66`2:MoveNext():this (4 methods)
        -120 (-1.346% of base) : Microsoft.CodeAnalysis.dasm - DeltaMetadataWriter:CreateIndicesForNonTypeMembers(ITypeDefinition):this (2 methods)
        -108 (-0.656% of base) : System.Net.WebSockets.WebSocketProtocol.dasm - <ReceiveAsyncPrivate>d__62`2:MoveNext():this (3 methods)
        -102 (-8.299% of base) : System.Formats.Asn1.dasm - AsnDecoder:ReadEnumeratedValue(ReadOnlySpan`1,int,Type,byref,Nullable`1):Enum
        -100 (-15.625% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CodeGenerator:EmitSequencePointStatement(BoundSequencePointWithSpan):this (2 methods)
        -100 (-2.134% of base) : Newtonsoft.Json.dasm - JsonWriter:WriteValueAsync(JsonWriter,int,Object,CancellationToken):Task
         -99 (-2.175% of base) : Newtonsoft.Json.dasm - JsonWriter:WriteValue(JsonWriter,int,Object)
         -92 (-14.887% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - CodeGenerator:EmitSequencePointStatement(BoundSequencePointWithSpan):this (2 methods)
         -88 (-4.889% of base) : System.Private.Xml.dasm - XmlILVisitor:CreateSetIterator(QilBinary,String,Type,MethodInfo,MethodInfo):QilNode:this
         -84 (-7.650% of base) : System.Net.Http.dasm - HttpMethod:.cctor()
         -76 (-40.426% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - EarlyWellKnownAttributeBinder:.ctor(Symbol,Binder):this (2 methods)
         -74 (-8.605% of base) : System.Security.Cryptography.Pkcs.dasm - CmsSignature:DsaDerToIeee(ReadOnlyMemory`1,Span`1):bool
         -71 (-3.989% of base) : System.Private.Xml.dasm - XmlILVisitor:NestedVisitEnsureCache(QilNode,Type):this
         -68 (-7.745% of base) : System.Security.Cryptography.Pkcs.dasm - SignedCms:GetContent(ReadOnlyMemory`1,String):ReadOnlyMemory`1
Top method regressions (percentages):
          10 (9.091% of base) : System.Linq.Expressions.dasm - BoundConstants:EmitConstantsArray(LambdaCompiler)
          16 (4.384% of base) : System.Private.CoreLib.dasm - TimeSpanParse:TryParseExactTimeSpan(ReadOnlySpan`1,ReadOnlySpan`1,IFormatProvider,int,byref):bool
          14 (3.465% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - KeywordTable:AddKeyword(ushort,bool,ubyte,bool,bool) (2 methods)
           9 (3.000% of base) : xunit.console.dasm - <>c__DisplayClass12_1:<RunProject>b__5():XElement:this
           8 (2.899% of base) : System.Linq.Expressions.dasm - CompilerScope:EmitClosureToVariable(LambdaCompiler,HoistedLocals):this
          23 (2.596% of base) : System.Linq.Expressions.dasm - LambdaCompiler:EmitReferenceCoalesceWithoutConversion(BinaryExpression):this
           8 (2.260% of base) : System.ComponentModel.Composition.dasm - MetadataViewGenerator:GenerateLocalAssignmentFromDefaultAttribute(ILGenerator,ref,LocalBuilder)
           3 (2.128% of base) : System.Linq.Expressions.dasm - ILGen:EmitType(ILGenerator,Type)
         116 (1.844% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SourceMethodSymbol:DecodeDllImportAttribute(byref):this (2 methods)
          10 (1.751% of base) : System.Formats.Asn1.dasm - AsnWriter:WriteConstructedCerOctetString(Asn1Tag,ReadOnlySpan`1):this
           3 (1.579% of base) : Microsoft.Extensions.DependencyInjection.dasm - ILEmitResolverBuilder:VisitServiceScopeFactory(ServiceScopeFactoryCallSite,ILEmitResolverBuilderContext):Object:this
           9 (1.525% of base) : System.Formats.Asn1.dasm - AsnWriter:WriteConstructedCerBitString(Asn1Tag,ReadOnlySpan`1,int):this
           9 (1.241% of base) : System.Reflection.DispatchProxy.dasm - ProxyBuilder:Complete():this
           8 (1.208% of base) : System.Linq.Expressions.dasm - LambdaCompiler:EmitNewExpression(Expression):this
           8 (1.116% of base) : Microsoft.Extensions.Configuration.Json.dasm - JsonConfigurationFileParser:ParseStream(Stream):IDictionary`2:this
           2 (0.893% of base) : System.Linq.Expressions.dasm - LambdaCompiler:EmitGetArrayElement(Type):this
           2 (0.893% of base) : System.Linq.Expressions.dasm - LambdaCompiler:EmitSetArrayElement(Type):this
         106 (0.755% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceMethodSymbol:DecodeWellKnownAttributeAppliedToMethod(byref):this (2 methods)
           2 (0.662% of base) : System.Linq.Expressions.dasm - LambdaCompiler:EmitDelegateConstruction(LambdaCompiler):this
           4 (0.595% of base) : Microsoft.CodeAnalysis.dasm - PEModule:RegisterNoPiaLocalType(TypeDefinitionHandle,CustomAttributeHandle,int):this (2 methods)
Top method improvements (percentages):
         -76 (-40.426% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - EarlyWellKnownAttributeBinder:.ctor(Symbol,Binder):this (2 methods)
        -621 (-39.655% of base) : System.Linq.Parallel.dasm - QueryOperator`1:GetEnumerator():IEnumerator`1:this (27 methods)
         -32 (-39.024% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VBSemanticModel:ComputeDeclarationsInNode(SyntaxNode,bool,List`1,CancellationToken,Nullable`1):this (2 methods)
         -13 (-38.235% of base) : System.IO.Compression.dasm - ZipArchive:CreateEntry(String):ZipArchiveEntry:this
         -13 (-38.235% of base) : System.IO.Compression.ZipFile.dasm - ZipFileExtensions:CreateEntryFromFile(ZipArchive,String,String):ZipArchiveEntry
         -16 (-36.364% of base) : System.Net.WebSockets.dasm - WebSocketReceiveResult:.ctor(int,int,bool):this
         -12 (-34.286% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - FilterStackSource:GetCallerIndex(int):int:this
         -12 (-34.286% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - FilterStackSource:GetNumberOfFoldedFrames(int):int:this
         -12 (-34.286% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - FilterStackSource:GetFrameIndex(int):int:this
         -13 (-33.333% of base) : System.IO.Compression.ZipFile.dasm - ZipFile:CreateFromDirectory(String,String)
         -20 (-31.746% of base) : System.Drawing.Common.dasm - Graphics:EnumerateMetafile(Metafile,PointF,EnumerateMetafileProc):this
         -13 (-31.707% of base) : Microsoft.Extensions.Logging.dasm - FilterLoggingBuilderExtensions:AddFilter(LoggerFilterOptions,Func`4):LoggerFilterOptions
         -24 (-31.169% of base) : Newtonsoft.Json.dasm - JValue:.ctor(Object):this
         -12 (-30.769% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - CallTree:Sort(IComparer`1):this
         -14 (-30.435% of base) : Microsoft.Extensions.Logging.dasm - <>c__DisplayClass0_0:<AddFilter>b__0(LoggerFilterOptions):this
         -13 (-29.545% of base) : xunit.assert.dasm - Assert:False(bool)
         -13 (-29.545% of base) : xunit.assert.dasm - Assert:True(bool)
         -12 (-29.268% of base) : xunit.assert.dasm - Assert:False(bool,String)
         -12 (-29.268% of base) : xunit.assert.dasm - Assert:True(bool,String)
         -24 (-26.087% of base) : Newtonsoft.Json.dasm - JToken:op_Implicit(ref):JToken
605 total methods with Code Size differences (565 improved, 40 regressed), 185410 unchanged.
```
alt-arm64 diff:
```
Total bytes of diff: -11160 (-0.022% of base)
    diff is an improvement.
Top file regressions (bytes):
           4 : Microsoft.Extensions.Configuration.Json.dasm (0.057% of base)
           4 : System.ComponentModel.Composition.dasm (0.001% of base)
           4 : System.Reflection.DispatchProxy.dasm (0.016% of base)
Top file improvements (bytes):
       -2052 : System.Net.Http.dasm (-0.254% of base)
       -1472 : System.Private.Xml.dasm (-0.034% of base)
       -1260 : System.Linq.Parallel.dasm (-0.177% of base)
        -744 : Microsoft.CodeAnalysis.dasm (-0.038% of base)
        -736 : Newtonsoft.Json.dasm (-0.081% of base)
        -656 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.011% of base)
        -404 : System.Formats.Asn1.dasm (-0.477% of base)
        -384 : Microsoft.CodeAnalysis.CSharp.dasm (-0.007% of base)
        -280 : System.Collections.Concurrent.dasm (-0.261% of base)
        -272 : System.Security.Cryptography.Pkcs.dasm (-0.076% of base)
        -260 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.005% of base)
        -260 : System.Linq.Expressions.dasm (-0.023% of base)
        -236 : System.Net.WebSockets.dasm (-0.368% of base)
        -220 : System.Net.WebSockets.WebSocketProtocol.dasm (-0.434% of base)
        -216 : System.Private.CoreLib.dasm (-0.005% of base)
        -204 : Microsoft.Extensions.Logging.dasm (-0.766% of base)
        -184 : System.Data.Common.dasm (-0.012% of base)
        -140 : System.Formats.Cbor.dasm (-0.229% of base)
        -120 : xunit.performance.execution.dasm (-0.542% of base)
        -116 : System.Console.dasm (-0.198% of base)
49 total files with Code Size differences (46 improved, 3 regressed), 213 unchanged.
Top method regressions (bytes):
          20 (6.944% of base) : xunit.console.dasm - <>c__DisplayClass12_1:<RunProject>b__5():XElement:this
          16 (0.351% of base) : System.Text.Json.dasm - JsonSerializer:ReadValueCore(JsonSerializerOptions,byref,byref):__Canon (2 methods)
          16 (0.656% of base) : xunit.console.dasm - ConsoleRunner:RunProject(XunitProject,bool,Nullable`1,Nullable`1,Nullable`1,bool,bool,Nullable`1,bool,bool,bool):int:this
           8 (1.852% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - KeywordTable:AddKeyword(ushort,bool,ubyte,bool,bool) (2 methods)
           8 (0.331% of base) : Microsoft.Extensions.DependencyInjection.dasm - ILEmitResolverBuilder:GenerateMethodBody(ServiceCallSite,ILGenerator):ILEmitResolverBuilderRuntimeContext:this
           8 (0.180% of base) : System.ComponentModel.Composition.dasm - MetadataViewGenerator:GenerateInterfaceViewProxyType(Type):Type
           8 (1.105% of base) : System.Formats.Asn1.dasm - AsnWriter:WriteConstructedCerBitString(Asn1Tag,ReadOnlySpan`1,int):this
           8 (3.448% of base) : System.Linq.Expressions.dasm - LambdaCompiler:EmitGetArrayElement(Type):this
           8 (3.448% of base) : System.Linq.Expressions.dasm - LambdaCompiler:EmitSetArrayElement(Type):this
           4 (0.592% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - CallTree:FindTreeNode(int,RecursionGuard):CallTreeNode:this
           4 (1.111% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - <>c__DisplayClass119_0:<FastSerialization.IFastSerializable.FromStream>b__0():this
           4 (1.111% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - <>c__DisplayClass119_0:<FastSerialization.IFastSerializable.FromStream>b__1():this
           4 (1.515% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - <>c__DisplayClass23_0:<FastSerialization.IFastSerializable.FromStream>b__0():this
           4 (0.526% of base) : Microsoft.Extensions.Configuration.Json.dasm - JsonConfigurationFileParser:ParseStream(Stream):IDictionary`2:this
           4 (2.041% of base) : Microsoft.Extensions.DependencyInjection.dasm - ILEmitResolverBuilder:VisitConstant(ConstantCallSite,ILEmitResolverBuilderContext):Object:this
           4 (1.923% of base) : Microsoft.Extensions.DependencyInjection.dasm - ILEmitResolverBuilder:VisitServiceScopeFactory(ServiceScopeFactoryCallSite,ILEmitResolverBuilderContext):Object:this
           4 (0.735% of base) : Microsoft.Extensions.DependencyInjection.dasm - ILEmitResolverBuilder:VisitFactory(FactoryCallSite,ILEmitResolverBuilderContext):Object:this
           4 (0.952% of base) : Microsoft.Extensions.DependencyInjection.dasm - ILEmitResolverBuilder:AddConstant(ILEmitResolverBuilderContext,Object):this
           4 (1.136% of base) : System.ComponentModel.Composition.dasm - MetadataViewGenerator:GenerateLocalAssignmentFromDefaultAttribute(ILGenerator,ref,LocalBuilder)
           4 (2.941% of base) : System.Linq.Expressions.dasm - BoundConstants:EmitConstantsArray(LambdaCompiler)
Top method improvements (bytes):
       -1788 (-12.273% of base) : System.Net.Http.dasm - KnownHeaders:.cctor()
        -324 (-21.429% of base) : System.Linq.Parallel.dasm - QueryOperator`1:GetEnumerator():IEnumerator`1:this (27 methods)
        -220 (-1.026% of base) : System.Net.WebSockets.dasm - <ReceiveAsyncPrivate>d__66`2:MoveNext():this (4 methods)
        -220 (-1.343% of base) : System.Net.WebSockets.WebSocketProtocol.dasm - <ReceiveAsyncPrivate>d__62`2:MoveNext():this (3 methods)
        -192 (-8.496% of base) : Newtonsoft.Json.dasm - JToken:op_Implicit(Nullable`1):JToken (16 methods)
         -92 (-8.303% of base) : System.Net.Http.dasm - HttpMethod:.cctor()
         -80 (-11.236% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CodeGenerator:EmitSequencePointStatement(BoundSequencePointWithSpan):this (2 methods)
         -80 (-1.429% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DocumentationCommentWalker:DefaultVisit(SyntaxNode):this (2 methods)
         -72 (-0.870% of base) : Microsoft.CodeAnalysis.dasm - DeltaMetadataWriter:CreateIndicesForNonTypeMembers(ITypeDefinition):this (2 methods)
         -64 (-1.093% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SyntaxTreeSemanticModel:GetMemberModel(CSharpSyntaxNode):MemberSemanticModel:this (2 methods)
         -64 (-9.302% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - CodeGenerator:EmitSequencePointStatement(BoundSequencePointWithSpan):this (2 methods)
         -64 (-2.941% of base) : System.Console.dasm - ConsolePal:MoveBufferArea(int,int,int,int,int,int,ushort,int,int)
         -64 (-4.408% of base) : System.Private.Xml.dasm - XmlILGenerator:CreateTypeInitializer(XmlQueryStaticData):this
         -60 (-1.382% of base) : System.Private.Xml.dasm - XmlILVisitor:HandleFilterPatterns(QilLoop):bool:this
         -60 (-6.329% of base) : System.Security.Cryptography.Pkcs.dasm - SignedCms:GetContent(ReadOnlyMemory`1,String):ReadOnlyMemory`1
         -56 (-26.923% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - EarlyWellKnownAttributeBinder:.ctor(Symbol,Binder):this (2 methods)
         -56 (-9.859% of base) : System.Linq.Parallel.dasm - CountAggregationOperator`1:InternalAggregate(byref):int:this (2 methods)
         -56 (-9.859% of base) : System.Linq.Parallel.dasm - LongCountAggregationOperator`1:InternalAggregate(byref):long:this (2 methods)
         -56 (-4.204% of base) : System.Private.Xml.dasm - XmlILVisitor:StartForBinding(QilIterator,OptimizerPatterns):this
         -56 (-25.000% of base) : System.Security.Cryptography.Pkcs.dasm - AsnValueReader:ThrowIfNotEmpty():this
Top method regressions (percentages):
          20 (6.944% of base) : xunit.console.dasm - <>c__DisplayClass12_1:<RunProject>b__5():XElement:this
           8 (3.448% of base) : System.Linq.Expressions.dasm - LambdaCompiler:EmitGetArrayElement(Type):this
           8 (3.448% of base) : System.Linq.Expressions.dasm - LambdaCompiler:EmitSetArrayElement(Type):this
           4 (2.941% of base) : System.Linq.Expressions.dasm - BoundConstants:EmitConstantsArray(LambdaCompiler)
           4 (2.564% of base) : System.Linq.Expressions.dasm - ILGen:EmitType(ILGenerator,Type)
           4 (2.041% of base) : Microsoft.Extensions.DependencyInjection.dasm - ILEmitResolverBuilder:VisitConstant(ConstantCallSite,ILEmitResolverBuilderContext):Object:this
           4 (1.923% of base) : Microsoft.Extensions.DependencyInjection.dasm - ILEmitResolverBuilder:VisitServiceScopeFactory(ServiceScopeFactoryCallSite,ILEmitResolverBuilderContext):Object:this
           8 (1.852% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - KeywordTable:AddKeyword(ushort,bool,ubyte,bool,bool) (2 methods)
           4 (1.515% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - <>c__DisplayClass23_0:<FastSerialization.IFastSerializable.FromStream>b__0():this
           4 (1.136% of base) : System.ComponentModel.Composition.dasm - MetadataViewGenerator:GenerateLocalAssignmentFromDefaultAttribute(ILGenerator,ref,LocalBuilder)
           4 (1.111% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - <>c__DisplayClass119_0:<FastSerialization.IFastSerializable.FromStream>b__0():this
           4 (1.111% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - <>c__DisplayClass119_0:<FastSerialization.IFastSerializable.FromStream>b__1():this
           8 (1.105% of base) : System.Formats.Asn1.dasm - AsnWriter:WriteConstructedCerBitString(Asn1Tag,ReadOnlySpan`1,int):this
           4 (0.962% of base) : System.Private.CoreLib.dasm - TimeSpanParse:TryParseExactTimeSpan(ReadOnlySpan`1,ReadOnlySpan`1,IFormatProvider,int,byref):bool
           4 (0.952% of base) : Microsoft.Extensions.DependencyInjection.dasm - ILEmitResolverBuilder:AddConstant(ILEmitResolverBuilderContext,Object):this
           4 (0.735% of base) : Microsoft.Extensions.DependencyInjection.dasm - ILEmitResolverBuilder:VisitFactory(FactoryCallSite,ILEmitResolverBuilderContext):Object:this
          16 (0.656% of base) : xunit.console.dasm - ConsoleRunner:RunProject(XunitProject,bool,Nullable`1,Nullable`1,Nullable`1,bool,bool,Nullable`1,bool,bool,bool):int:this
           4 (0.592% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - CallTree:FindTreeNode(int,RecursionGuard):CallTreeNode:this
           4 (0.559% of base) : System.Linq.Expressions.dasm - LambdaCompiler:EmitNewExpression(Expression):this
           4 (0.541% of base) : System.Reflection.DispatchProxy.dasm - ProxyBuilder:Complete():this
Top method improvements (percentages):
         -56 (-26.923% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - EarlyWellKnownAttributeBinder:.ctor(Symbol,Binder):this (2 methods)
         -12 (-25.000% of base) : System.IO.Compression.dasm - ZipArchive:CreateEntry(String):ZipArchiveEntry:this
         -12 (-25.000% of base) : System.IO.Compression.ZipFile.dasm - ZipFileExtensions:CreateEntryFromFile(ZipArchive,String,String):ZipArchiveEntry
         -56 (-25.000% of base) : System.Security.Cryptography.Pkcs.dasm - AsnValueReader:ThrowIfNotEmpty():this
         -52 (-24.074% of base) : System.Security.Cryptography.Algorithms.dasm - AsnValueReader:ThrowIfNotEmpty():this
         -52 (-24.074% of base) : System.Security.Cryptography.Cng.dasm - AsnValueReader:ThrowIfNotEmpty():this
         -52 (-24.074% of base) : System.Security.Cryptography.X509Certificates.dasm - AsnValueReader:ThrowIfNotEmpty():this
         -24 (-23.077% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VBSemanticModel:ComputeDeclarationsInNode(SyntaxNode,bool,List`1,CancellationToken,Nullable`1):this (2 methods)
         -12 (-23.077% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - FilterStackSource:GetCallerIndex(int):int:this
         -12 (-23.077% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - FilterStackSource:GetNumberOfFoldedFrames(int):int:this
         -12 (-23.077% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - FilterStackSource:GetFrameIndex(int):int:this
         -12 (-21.429% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - CallTree:Sort(IComparer`1):this
         -12 (-21.429% of base) : System.IO.Compression.ZipFile.dasm - ZipFile:CreateFromDirectory(String,String)
        -324 (-21.429% of base) : System.Linq.Parallel.dasm - QueryOperator`1:GetEnumerator():IEnumerator`1:this (27 methods)
         -12 (-21.429% of base) : System.Net.WebSockets.dasm - WebSocketReceiveResult:.ctor(int,int,bool):this
         -12 (-20.000% of base) : Microsoft.Extensions.Logging.dasm - FilterLoggingBuilderExtensions:AddFilter(LoggerFilterOptions,Func`4):LoggerFilterOptions
         -12 (-18.750% of base) : Microsoft.Extensions.Logging.dasm - <>c__DisplayClass0_0:<AddFilter>b__0(LoggerFilterOptions):this
          -8 (-16.667% of base) : System.IO.Compression.dasm - ZipArchive:CreateEntry(String,int):ZipArchiveEntry:this
          -8 (-16.667% of base) : System.IO.Compression.ZipFile.dasm - ZipFileExtensions:CreateEntryFromFile(ZipArchive,String,String,int):ZipArchiveEntry
         -20 (-15.625% of base) : System.Text.Json.dasm - JsonClassInfo:CreatePropertyInfoForClassInfo(Type,Type,JsonConverter,JsonSerializerOptions):JsonPropertyInfo
602 total methods with Code Size differences (576 improved, 26 regressed), 185316 unchanged.
```
alt-arm32 diff:
```
Total bytes of diff: -1148 (-0.003% of base)
    diff is an improvement.
Top file improvements (bytes):
        -214 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.005% of base)
        -164 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.005% of base)
        -144 : System.Console.dasm (-0.351% of base)
         -78 : xunit.console.dasm (-0.118% of base)
         -74 : System.Net.Http.dasm (-0.013% of base)
         -72 : System.Text.RegularExpressions.dasm (-0.041% of base)
         -72 : xunit.runner.utility.netcoreapp10.dasm (-0.051% of base)
         -64 : System.Data.Common.dasm (-0.006% of base)
         -60 : Newtonsoft.Json.dasm (-0.010% of base)
         -54 : Microsoft.CodeAnalysis.CSharp.dasm (-0.001% of base)
         -32 : System.DirectoryServices.AccountManagement.dasm (-0.013% of base)
         -32 : System.Private.CoreLib.dasm (-0.001% of base)
         -32 : xunit.assert.dasm (-0.052% of base)
         -24 : xunit.performance.execution.dasm (-0.157% of base)
         -16 : System.Net.Requests.dasm (-0.015% of base)
         -10 : System.Net.Http.WinHttpHandler.dasm (-0.015% of base)
          -6 : System.Net.HttpListener.dasm (-0.003% of base)
17 total files with Code Size differences (17 improved, 0 regressed), 245 unchanged.
Top method improvements (bytes):
         -96 (-5.714% of base) : System.Console.dasm - ConsolePal:MoveBufferArea(int,int,int,int,int,int,ushort,int,int)
         -48 (-36.364% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - EarlyWellKnownAttributeBinder:.ctor(Symbol,Binder):this (2 methods)
         -44 (-7.051% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BinderBuilder:CreateBinderForProjectImports(SourceModuleSymbol,SyntaxTree):Binder (2 methods)
         -44 (-6.471% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BinderBuilder:CreateBinderForSourceFileImports(SourceModuleSymbol,SyntaxTree):Binder (2 methods)
         -42 (-1.504% of base) : xunit.console.dasm - ConsoleRunner:ExecuteAssembly(Object,XunitProjectAssembly,bool,bool,Nullable`1,Nullable`1,bool,bool,Nullable`1,bool,bool,XunitFilters,bool):XElement:this
         -40 (-9.852% of base) : System.Console.dasm - ConsolePal:Clear()
         -30 (-0.849% of base) : Newtonsoft.Json.dasm - JsonWriter:WriteValueAsync(JsonWriter,int,Object,CancellationToken):Task
         -30 (-0.890% of base) : Newtonsoft.Json.dasm - JsonWriter:WriteValue(JsonWriter,int,Object)
         -26 (-3.148% of base) : System.Text.RegularExpressions.dasm - RegexCharClass:Canonicalize():this
         -24 (-2.526% of base) : System.Net.Http.dasm - SocketsHttpHandler:ValidateAndNormalizeRequest(HttpRequestMessage):Exception:this
         -24 (-16.000% of base) : xunit.performance.execution.dasm - BenchmarkTestFrameworkExecutor:RunTestCases(IEnumerable`1,IMessageSink,ITestFrameworkExecutionOptions):this
         -22 (-11.224% of base) : xunit.runner.utility.netcoreapp10.dasm - AssemblyRunner:GetExecutionOptions(Nullable`1,Nullable`1,Nullable`1,Nullable`1):ITestFrameworkExecutionOptions:this
         -20 (-6.993% of base) : System.Private.CoreLib.dasm - TimeSpanParse:TryParseExactTimeSpan(ReadOnlySpan`1,ReadOnlySpan`1,IFormatProvider,int,byref):bool
         -18 (-1.576% of base) : System.Net.Http.dasm - Http2Connection:WriteHeaders(HttpRequestMessage,byref):this
         -18 (-1.175% of base) : System.Net.Http.dasm - Http3RequestStream:BufferHeaders(HttpRequestMessage):this
         -18 (-0.353% of base) : xunit.console.dasm - CommandLine:Parse(Predicate`1):XunitProject:this
         -18 (-1.320% of base) : xunit.console.dasm - ConsoleRunner:EntryPoint(ref):int:this
         -18 (-8.036% of base) : xunit.runner.utility.netcoreapp10.dasm - TestFrameworkOptions:ForDiscovery(TestAssemblyConfiguration):ITestFrameworkDiscoveryOptions
         -18 (-8.036% of base) : xunit.runner.utility.netcoreapp10.dasm - TestFrameworkOptions:ForExecution(TestAssemblyConfiguration):ITestFrameworkExecutionOptions
         -16 (-18.605% of base) : System.Data.Common.dasm - SqlByte:NotEquals(SqlByte,SqlByte):SqlBoolean
Top method improvements (percentages):
         -48 (-36.364% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - EarlyWellKnownAttributeBinder:.ctor(Symbol,Binder):this (2 methods)
         -10 (-33.333% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - FilterStackSource:GetCallerIndex(int):int:this
         -10 (-33.333% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - FilterStackSource:GetNumberOfFoldedFrames(int):int:this
         -10 (-33.333% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - FilterStackSource:GetFrameIndex(int):int:this
         -10 (-29.412% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - CallTree:Sort(IComparer`1):this
          -8 (-25.000% of base) : xunit.assert.dasm - Assert:False(bool,String)
          -8 (-25.000% of base) : xunit.assert.dasm - Assert:True(bool,String)
          -8 (-23.529% of base) : xunit.assert.dasm - Assert:False(bool)
          -8 (-23.529% of base) : xunit.assert.dasm - Assert:True(bool)
         -16 (-18.605% of base) : System.Data.Common.dasm - SqlByte:NotEquals(SqlByte,SqlByte):SqlBoolean
         -24 (-16.000% of base) : xunit.performance.execution.dasm - BenchmarkTestFrameworkExecutor:RunTestCases(IEnumerable`1,IMessageSink,ITestFrameworkExecutionOptions):this
         -12 (-14.634% of base) : System.Data.Common.dasm - SqlInt16:NotEquals(SqlInt16,SqlInt16):SqlBoolean
          -8 (-13.333% of base) : System.Text.RegularExpressions.dasm - RegexCharClass:AddRange(ushort,ushort):this
         -14 (-11.290% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - CallTree:GetSumByID():Dictionary`2:this
         -22 (-11.224% of base) : xunit.runner.utility.netcoreapp10.dasm - AssemblyRunner:GetExecutionOptions(Nullable`1,Nullable`1,Nullable`1,Nullable`1):ITestFrameworkExecutionOptions:this
         -40 (-9.852% of base) : System.Console.dasm - ConsolePal:Clear()
         -12 (-9.091% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - CallTree:SortInclusiveMetricDecending():this
         -10 (-8.929% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - <>c__DisplayClass23_1:<TransferInclusiveSamplesToList>b__0():this
         -18 (-8.036% of base) : xunit.runner.utility.netcoreapp10.dasm - TestFrameworkOptions:ForDiscovery(TestAssemblyConfiguration):ITestFrameworkDiscoveryOptions
         -18 (-8.036% of base) : xunit.runner.utility.netcoreapp10.dasm - TestFrameworkOptions:ForExecution(TestAssemblyConfiguration):ITestFrameworkExecutionOptions
86 total methods with Code Size differences (86 improved, 0 regressed), 185843 unchanged.
```

Regressions in `DecodeDllImportAttribute` and `DecodeWellKnownAttributeAppliedToMethod` are caused by changes in register allocation that results in spilling of a variable and the unspilling it in many places. 
`EmitReferenceCoalesceWithoutConversion`, `EmitClosureToVariable` and others have an interesting case where a promoted struct was previously copied to a temp, which made passing the struct in a register a single load instruction. This doesn't happen anymore and instead the promoted fields are live across a call and get spilled, then reloaded and packed, requiring 4 instructions instead of 1.
`KeywordTable:AddKeyword` has a struct with 4 byte fields that requires a bit more code to pack into a single register by using `LSH` and `OR`. But going through memory can be 2-3x slower. It may be useful to fallback to memory if there are more than 2 fields and the code is compiled for size rather than speed.


```C#
[MethodImpl(MethodImplOptions.NoInlining)]
static float? Add(float? a, float? b) => a + b;

float? s = 0;
foreach (float? f in floats) s = Add(s, f);
```
is 1.5x faster.