### PR TITLE
Remove unnecessary LSH source casts

### DIFF
--- a/src/coreclr/src/jit/vartype.h
+++ b/src/coreclr/src/jit/vartype.h
@@ -323,6 +323,19 @@ inline bool varTypeIsValidHfaType(T vt)
 #endif // !FEATURE_HFA
 }
 
+extern const BYTE genTypeSizes[TYP_COUNT];
+
+inline unsigned varTypeSize(var_types type)
+{
+    assert(type < _countof(genTypeSizes));
+    return genTypeSizes[type];
+}
+
+inline unsigned varTypeBitSize(var_types type)
+{
+    return varTypeSize(type) * 8;
+}
+
 /*****************************************************************************/
 #endif // _VARTYPE_H_
 /*****************************************************************************/


### PR DESCRIPTION
x64:
```
Total bytes of diff: -194 (-0.00% of base)
    diff is an improvement.
Top file improvements (bytes):
         -66 : System.Private.Xml.dasm (-0.00% of base)
         -56 : System.Private.CoreLib.dasm (-0.00% of base)
         -18 : System.Reflection.Metadata.dasm (-0.01% of base)
         -12 : System.Runtime.Numerics.dasm (-0.02% of base)
         -11 : System.Data.Common.dasm (-0.00% of base)
          -9 : System.Text.Json.dasm (-0.00% of base)
          -8 : xunit.execution.dotnet.dasm (-0.00% of base)
          -4 : Microsoft.Diagnostics.FastSerialization.dasm (-0.01% of base)
          -3 : System.Private.DataContractSerialization.dasm (-0.00% of base)
          -2 : System.DirectoryServices.AccountManagement.dasm (-0.00% of base)
          -2 : System.DirectoryServices.Protocols.dasm (-0.00% of base)
          -2 : System.Windows.Extensions.dasm (-0.01% of base)
          -1 : System.DirectoryServices.dasm (-0.00% of base)
13 total files with Code Size differences (13 improved, 0 regressed), 221 unchanged.
Top method regressions (bytes):
           1 ( 0.20% of base) : System.Private.Xml.dasm - BigNumber:op_Explicit(BigNumber):double
           1 ( 0.15% of base) : System.Runtime.Numerics.dasm - BigIntegerCalculator:Divide(long,int,long,int,long,int)
           1 ( 8.33% of base) : System.Runtime.Numerics.dasm - NumericsHelpers:MakeUlong(int,int):long
Top method improvements (bytes):
         -27 (-1.93% of base) : System.Private.CoreLib.dasm - DecCalc:ScaleResult(long,int,int):int
         -14 (-1.25% of base) : System.Private.Xml.dasm - XsltInput:ReadAttribute(byref):bool:this
          -7 (-3.55% of base) : System.Private.Xml.dasm - XsltInput:SetRecordEnd(byref):this
          -7 (-2.10% of base) : System.Private.Xml.dasm - XsltInput:FillupCharacterEntityRecord(byref):this
          -6 (-0.90% of base) : System.Private.CoreLib.dasm - DecCalc:InternalRound(byref,int,int)
          -6 (-0.96% of base) : System.Private.Xml.dasm - XslLoadException:.ctor(SerializationInfo,StreamingContext):this
          -6 (-1.53% of base) : System.Private.Xml.dasm - ContextInfo:SaveExtendedLineInfo(XsltInput):this
          -6 (-3.87% of base) : System.Text.Json.dasm - MetadataDb:Append(ubyte,int,int):this
          -5 (-6.41% of base) : System.Reflection.Metadata.dasm - HandleComparer:Compare(Handle,Handle):int:this
          -5 (-1.68% of base) : System.Runtime.Numerics.dasm - BigInteger:Equals(long):bool:this (2 methods)
          -5 (-1.48% of base) : System.Runtime.Numerics.dasm - BigInteger:CompareTo(long):int:this (2 methods)
          -4 (-0.19% of base) : System.Data.Common.dasm - SqlDecimal:MpDiv(ReadOnlySpan`1,int,Span`1,int,Span`1,byref,Span`1,byref)
          -4 (-0.74% of base) : System.Private.CoreLib.dasm - DecCalc:VarDecMod(byref,byref)
          -4 (-6.78% of base) : System.Private.Xml.dasm - SourceLineInfo:.ctor(String,int,int,int,int):this
          -4 (-1.04% of base) : System.Runtime.Numerics.dasm - BigInteger:op_Explicit(BigInteger):long (2 methods)
          -3 (-1.62% of base) : System.Data.Common.dasm - SqlDecimal:MpDiv1(Span`1,byref,int,byref)
          -3 (-0.58% of base) : System.Private.CoreLib.dasm - DecCalc:GetHashCode(byref):int
          -3 (-15.00% of base) : System.Private.CoreLib.dasm - PowerOvfl:.ctor(int,int,int):this
          -3 (-1.46% of base) : System.Private.CoreLib.dasm - DateTime:.ctor(long,int):this
          -3 (-0.21% of base) : System.Private.CoreLib.dasm - DateTime:.ctor(int,int,int,int,int,int,int):this (2 methods)
Top method regressions (percentages):
           1 ( 8.33% of base) : System.Runtime.Numerics.dasm - NumericsHelpers:MakeUlong(int,int):long
           1 ( 0.20% of base) : System.Private.Xml.dasm - BigNumber:op_Explicit(BigNumber):double
           1 ( 0.15% of base) : System.Runtime.Numerics.dasm - BigIntegerCalculator:Divide(long,int,long,int,long,int)
Top method improvements (percentages):
          -3 (-17.65% of base) : System.Private.Xml.dasm - Location:.ctor(int,int):this
          -3 (-17.65% of base) : System.Text.Json.dasm - DbRow:.ctor(ubyte,int,int):this
          -2 (-16.67% of base) : System.Data.Common.dasm - SqlDecimal:DWL(int,int):long
          -3 (-15.00% of base) : System.Private.CoreLib.dasm - PowerOvfl:.ctor(int,int,int):this
          -1 (-11.11% of base) : System.Reflection.Metadata.dasm - MetadataReader:TreatmentAndRowId(ubyte,int):int
          -4 (-6.78% of base) : System.Private.Xml.dasm - SourceLineInfo:.ctor(String,int,int,int,int):this
          -2 (-6.67% of base) : System.Windows.Extensions.dasm - SoundPlayer:mmioFOURCC(ushort,ushort,ushort,ushort):int
          -2 (-6.45% of base) : System.Private.CoreLib.dasm - BinaryPrimitives:ReverseEndianness(long):long (2 methods)
          -5 (-6.41% of base) : System.Reflection.Metadata.dasm - HandleComparer:Compare(Handle,Handle):int:this
          -3 (-5.00% of base) : System.Private.DataContractSerialization.dasm - UniqueId:UnsafeGetInt64(long):long:this
          -2 (-5.00% of base) : System.Reflection.Metadata.dasm - MetadataTokens:Handle(ubyte,int):EntityHandle
          -2 (-4.26% of base) : Microsoft.Diagnostics.FastSerialization.dasm - SegmentedMemoryStreamReader:ReadInt64():long:this
          -2 (-4.26% of base) : Microsoft.Diagnostics.FastSerialization.dasm - MemoryStreamReader:ReadInt64():long:this
          -1 (-4.17% of base) : System.DirectoryServices.dasm - AdsValueHelper:get_LowInt64():long:this
          -3 (-4.00% of base) : System.Private.Xml.dasm - EmptyElementEndTag:get_Start():Location:this
          -6 (-3.87% of base) : System.Text.Json.dasm - MetadataDb:Append(ubyte,int,int):this
          -2 (-3.85% of base) : xunit.execution.dotnet.dasm - Pack:BE_To_UInt64(ref):long
          -2 (-3.85% of base) : xunit.execution.dotnet.dasm - Pack:LE_To_UInt64(ref):long
          -2 (-3.57% of base) : xunit.execution.dotnet.dasm - Pack:BE_To_UInt64(ref,int):long
          -2 (-3.57% of base) : xunit.execution.dotnet.dasm - Pack:LE_To_UInt64(ref,int):long
56 total methods with Code Size differences (53 improved, 3 regressed), 184094 unchanged.
```
arm64:
```
Total bytes of diff: -1600 (-0.00% of base)
    diff is an improvement.
Top file improvements (bytes):
        -400 : System.Text.Json.dasm (-0.03% of base)
        -368 : System.Private.CoreLib.dasm (-0.00% of base)
        -240 : System.Private.Xml.dasm (-0.00% of base)
        -112 : System.Runtime.Numerics.dasm (-0.06% of base)
         -96 : System.IO.FileSystem.dasm (-0.04% of base)
         -56 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
         -56 : System.Data.Common.dasm (-0.00% of base)
         -40 : System.Reflection.Metadata.dasm (-0.00% of base)
         -32 : System.Security.Cryptography.Algorithms.dasm (-0.00% of base)
         -32 : xunit.execution.dotnet.dasm (-0.00% of base)
         -24 : System.DirectoryServices.dasm (-0.00% of base)
         -24 : System.Security.Cryptography.X509Certificates.dasm (-0.01% of base)
         -16 : Microsoft.CodeAnalysis.dasm (-0.00% of base)
         -16 : Microsoft.Diagnostics.FastSerialization.dasm (-0.01% of base)
         -16 : Newtonsoft.Json.Bson.dasm (-0.01% of base)
         -16 : System.DirectoryServices.Protocols.dasm (-0.01% of base)
         -16 : System.Security.Principal.Windows.dasm (-0.01% of base)
          -8 : System.DirectoryServices.AccountManagement.dasm (-0.00% of base)
          -8 : System.Net.Primitives.dasm (-0.00% of base)
          -8 : System.Private.DataContractSerialization.dasm (-0.00% of base)
22 total files with Code Size differences (22 improved, 0 regressed), 212 unchanged.
Top method improvements (bytes):
        -192 (-0.72% of base) : System.Text.Json.dasm - ObjectDefaultConverter`1:OnTryRead(byref,Type,JsonSerializerOptions,byref,byref):bool:this (4 methods)
         -72 (-1.85% of base) : System.Private.CoreLib.dasm - DecCalc:ScaleResult(long,int,int):int (2 methods)
         -48 (-1.63% of base) : System.Text.Json.dasm - JsonClassInfo:GetProperty(ReadOnlySpan`1,byref):JsonPropertyInfo:this (2 methods)
         -48 (-5.04% of base) : System.Text.Json.dasm - JsonClassInfo:GetKey(ReadOnlySpan`1):long (2 methods)
         -48 (-1.96% of base) : System.Text.Json.dasm - JsonPropertyInfo:DeterminePropertyName():this (2 methods)
         -48 (-1.11% of base) : System.Text.Json.dasm - JsonSerializer:LookupProperty(Object,byref,JsonSerializerOptions,byref,byref):JsonPropertyInfo (2 methods)
         -32 (-0.69% of base) : System.Data.Common.dasm - SqlDecimal:MpDiv(ReadOnlySpan`1,int,Span`1,int,Span`1,byref,Span`1,byref) (2 methods)
         -32 (-1.81% of base) : System.Private.CoreLib.dasm - DecCalc:InternalRound(byref,int,int) (2 methods)
         -32 (-0.97% of base) : System.Private.Xml.dasm - XsltInput:ReadAttribute(byref):bool:this (2 methods)
         -32 (-7.55% of base) : System.Security.Cryptography.Algorithms.dasm - DES:QuadWordFromBigEndian(ref):long (2 methods)
         -16 (-5.88% of base) : Microsoft.CodeAnalysis.dasm - AssemblyVersion:ToInteger():long:this (4 methods)
         -16 (-1.08% of base) : System.DirectoryServices.dasm - AttributeMetadata:.ctor(long,bool,DirectoryServer,Hashtable):this (2 methods)
         -16 (-0.72% of base) : System.Private.CoreLib.dasm - DecCalc:VarDecMul(byref,byref) (2 methods)
         -16 (-0.32% of base) : System.Private.CoreLib.dasm - DecCalc:VarDecDiv(byref,byref) (2 methods)
         -16 (-0.88% of base) : System.Private.CoreLib.dasm - DecCalc:VarDecMod(byref,byref) (2 methods)
         -16 (-0.81% of base) : System.Private.CoreLib.dasm - DecCalc:VarDecModFull(byref,byref,int) (2 methods)
         -16 (-5.00% of base) : System.Private.CoreLib.dasm - BinaryPrimitives:ReverseEndianness(long):long (4 methods)
         -16 (-11.76% of base) : System.Private.Xml.dasm - SourceLineInfo:.ctor(String,int,int,int,int):this (2 methods)
         -16 (-0.79% of base) : System.Private.Xml.dasm - XslLoadException:.ctor(SerializationInfo,StreamingContext):this (2 methods)
         -16 (-2.56% of base) : System.Private.Xml.dasm - XsltInput:SetRecordEnd(byref):this (2 methods)
Top method improvements (percentages):
          -8 (-14.29% of base) : System.Reflection.Metadata.dasm - MetadataReader:TreatmentAndRowId(ubyte,int):int (2 methods)
          -8 (-12.50% of base) : System.Data.Common.dasm - SqlDecimal:DWL(int,int):long (2 methods)
          -8 (-12.50% of base) : System.Runtime.Numerics.dasm - NumericsHelpers:MakeUlong(int,int):long (2 methods)
         -16 (-11.76% of base) : System.Private.Xml.dasm - SourceLineInfo:.ctor(String,int,int,int,int):this (2 methods)
          -8 (-11.11% of base) : System.IO.FileSystem.dasm - FILE_TIME:ToTicks():long:this (2 methods)
          -8 (-11.11% of base) : System.Private.Xml.dasm - Location:.ctor(int,int):this (2 methods)
          -8 (-11.11% of base) : System.Text.Json.dasm - DbRow:.ctor(ubyte,int,int):this (2 methods)
          -8 (-10.00% of base) : System.Private.CoreLib.dasm - PowerOvfl:.ctor(int,int,int):this (2 methods)
         -16 (-7.69% of base) : System.Reflection.Metadata.dasm - HandleComparer:Compare(Handle,Handle):int:this (2 methods)
         -32 (-7.55% of base) : System.Security.Cryptography.Algorithms.dasm - DES:QuadWordFromBigEndian(ref):long (2 methods)
          -8 (-7.14% of base) : System.Windows.Extensions.dasm - SoundPlayer:mmioFOURCC(ushort,ushort,ushort,ushort):int (2 methods)
          -8 (-6.67% of base) : System.DirectoryServices.dasm - AdsValueHelper:get_LowInt64():long:this (2 methods)
          -8 (-6.67% of base) : System.Security.Cryptography.X509Certificates.dasm - FILETIME:ToDateTime():DateTime:this (2 methods)
         -16 (-5.88% of base) : Microsoft.CodeAnalysis.dasm - AssemblyVersion:ToInteger():long:this (4 methods)
          -8 (-5.26% of base) : System.IO.FileSystem.dasm - FILE_TIME:ToDateTimeOffset():DateTimeOffset:this (2 methods)
         -48 (-5.04% of base) : System.Text.Json.dasm - JsonClassInfo:GetKey(ReadOnlySpan`1):long (2 methods)
          -8 (-5.00% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - ActivityComputer:GetClrIORawID(TraceEvent,long):long (2 methods)
          -8 (-5.00% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - ActivityComputer:GetClrRawID(TraceEvent,long):long (2 methods)
         -16 (-5.00% of base) : System.Private.CoreLib.dasm - BinaryPrimitives:ReverseEndianness(long):long (4 methods)
          -8 (-4.76% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - ActivityComputer:GetTimerRawID(TraceEvent,int):long (2 methods)
117 total methods with Code Size differences (117 improved, 0 regressed), 183523 unchanged.
```