### PR TITLE
Do not promote block init of DNER locals

### DIFF
--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -9146,6 +9146,12 @@ GenTree* Compiler::fgMorphPromoteLocalInitBlock(LclVarDsc* destLclVar, GenTree* 
     assert(varTypeIsStruct(destLclVar->GetType()));
     assert(destLclVar->lvPromoted);
 
+    if (destLclVar->lvDoNotEnregister && (destLclVar->GetPromotedFieldCount() > 1))
+    {
+        JITDUMP(" dest is already DNER and has more than one field.\n");
+        return nullptr;
+    }
+
     if (destLclVar->lvAddrExposed && destLclVar->lvContainsHoles)
     {
         JITDUMP(" dest is address exposed and contains holes.\n");


### PR DESCRIPTION
x64:
```
Total bytes of diff: -10116 (-0.03% of base)
    diff is an improvement.
Top file improvements (bytes):
       -1356 : System.Net.Http.dasm (-0.23% of base)
       -1308 : System.Drawing.Common.dasm (-0.41% of base)
        -761 : System.Reflection.Metadata.dasm (-0.24% of base)
        -718 : System.Private.CoreLib.dasm (-0.02% of base)
        -712 : Microsoft.CodeAnalysis.CSharp.dasm (-0.03% of base)
        -493 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.02% of base)
        -375 : System.Data.Common.dasm (-0.03% of base)
        -338 : Newtonsoft.Json.dasm (-0.05% of base)
        -333 : Microsoft.CodeAnalysis.dasm (-0.04% of base)
        -322 : System.Net.Security.dasm (-0.18% of base)
        -264 : System.Memory.dasm (-0.32% of base)
        -215 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.01% of base)
        -194 : System.Drawing.Primitives.dasm (-0.51% of base)
        -185 : System.Net.HttpListener.dasm (-0.09% of base)
        -170 : System.Reflection.MetadataLoadContext.dasm (-0.09% of base)
        -139 : System.Text.Json.dasm (-0.03% of base)
        -136 : System.Linq.Parallel.dasm (-0.02% of base)
        -121 : System.Collections.Immutable.dasm (-0.06% of base)
        -117 : System.Net.Mail.dasm (-0.06% of base)
        -116 : System.Net.Http.WinHttpHandler.dasm (-0.17% of base)
72 total files with Code Size differences (72 improved, 0 regressed), 162 unchanged.
Top method improvements (bytes):
        -630 (-3.20% of base) : System.Net.Http.dasm - Huffman:.cctor()
        -173 (-12.08% of base) : Microsoft.CodeAnalysis.CSharp.dasm - UnopEasyOut:TypeToIndex(TypeSymbol):Nullable`1
        -170 (-11.84% of base) : Microsoft.CodeAnalysis.CSharp.dasm - BinopEasyOut:TypeToIndex(TypeSymbol):Nullable`1
        -168 (-2.40% of base) : Newtonsoft.Json.dasm - JToken:op_Explicit(JToken):Nullable`1 (17 methods)
        -103 (-7.05% of base) : System.Reflection.MetadataLoadContext.dasm - RoType:GetMemberImpl(String,int,int):ref:this
         -69 (-3.47% of base) : Microsoft.CodeAnalysis.dasm - SyntaxDiffer:GetNextAction():DiffAction:this
         -65 (-1.91% of base) : System.Net.WebClient.dasm - <UploadBitsAsync>d__152:MoveNext():this
         -52 (-4.51% of base) : System.Private.CoreLib.dasm - RuntimeType:GetMember(String,int,int):ref:this
         -50 (-2.32% of base) : System.Private.CoreLib.dasm - Matrix4x4:Decompose(Matrix4x4,byref,byref,byref):bool
         -46 (-17.69% of base) : System.Text.RegularExpressions.dasm - RegexCharClass:Analyze(String):CharClassAnalysisResults
         -43 (-2.88% of base) : System.Memory.dasm - SequenceReader`1:TryPeek(long,byref):bool:this (2 methods)
         -42 (-1.46% of base) : System.Text.Json.dasm - JsonNode:DeepCopy(JsonElement):JsonNode
         -40 (-5.13% of base) : System.Net.Security.dasm - NetEventSource:WriteEvent(int,String,int,int,int,int,int,int,int):this
         -38 (-2.10% of base) : System.Memory.dasm - BuffersExtensions:CopyToMultiSegment(byref,Span`1) (3 methods)
         -36 (-3.23% of base) : System.Private.Xml.Linq.dasm - XElement:op_Explicit(XElement):Nullable`1 (12 methods)
         -35 (-11.22% of base) : Newtonsoft.Json.dasm - JsonValidatingReader:GetCurrentNodeSchemaType():Nullable`1:this
         -35 (-1.91% of base) : System.Console.dasm - ConsolePal:MoveBufferArea(int,int,int,int,int,int,ushort,int,int)
         -35 (-5.09% of base) : System.Private.CoreLib.dasm - SorterGenericArray:InsertionSort(int,int):this
         -34 (-1.85% of base) : System.Net.Http.dasm - <WriteRequestContentAsync>d__30:MoveNext():this
         -34 (-0.40% of base) : System.Net.Security.dasm - <ForceAuthenticationAsync>d__177`1:MoveNext():this (3 methods)
Top method improvements (percentages):
         -11 (-33.33% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SynthesizedContainer:get_Layout():TypeLayout:this
         -11 (-33.33% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ImplicitNamedTypeSymbol:get_Layout():TypeLayout:this
         -11 (-33.33% of base) : Microsoft.CodeAnalysis.CSharp.dasm - AnonymousTypeTemplateSymbol:get_Layout():TypeLayout:this
         -11 (-33.33% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SynthesizedContainer:get_Layout():TypeLayout:this
         -11 (-33.33% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AnonymousTypeOrDelegateTemplateSymbol:get_Layout():TypeLayout:this
         -11 (-33.33% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - ImplicitNamedTypeSymbol:get_Layout():TypeLayout:this
          -8 (-28.57% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - RecursionGuard:get_Entry():RecursionGuard
          -6 (-25.00% of base) : System.Private.CoreLib.dasm - Vector2:get_Zero():Vector2
          -7 (-24.14% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - StackSource:get_SamplingRate():Nullable`1:this
          -8 (-22.22% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DimensionSize:ConstantSize(int):DimensionSize
          -8 (-21.05% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - ControlFlowPass:ReachableState():LocalState:this
          -6 (-18.75% of base) : System.Private.CoreLib.dasm - Nullable`1:op_Implicit(ushort):Nullable`1
          -6 (-18.18% of base) : System.Data.Common.dasm - SqlInt16:op_Implicit(short):SqlInt16
          -8 (-18.18% of base) : System.Drawing.Primitives.dasm - RectangleF:get_Location():PointF:this
         -26 (-17.81% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Scanner:ScanXmlChar(int):XmlCharResult:this
          -8 (-17.78% of base) : System.Drawing.Primitives.dasm - RectangleF:get_Size():SizeF:this
         -46 (-17.69% of base) : System.Text.RegularExpressions.dasm - RegexCharClass:Analyze(String):CharClassAnalysisResults
          -3 (-15.79% of base) : System.Linq.dasm - CopyPosition:get_Start():CopyPosition
          -8 (-15.38% of base) : System.Drawing.Primitives.dasm - SizeF:op_Explicit(SizeF):PointF
         -14 (-14.74% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - KeywordTable:TokenOpPrec(ushort):ubyte
1069 total methods with Code Size differences (1069 improved, 0 regressed), 183081 unchanged.
```
arm64
```
Total bytes of diff: -18416 (-0.02% of base)
    diff is an improvement.
Top file improvements (bytes):
       -2400 : Microsoft.CodeAnalysis.CSharp.dasm (-0.02% of base)
       -2064 : System.Net.Http.dasm (-0.11% of base)
       -1568 : System.Drawing.Common.dasm (-0.15% of base)
       -1464 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.01% of base)
       -1360 : Microsoft.CodeAnalysis.dasm (-0.03% of base)
        -920 : System.Private.CoreLib.dasm (-0.01% of base)
        -776 : System.Reflection.Metadata.dasm (-0.07% of base)
        -696 : Newtonsoft.Json.dasm (-0.03% of base)
        -688 : System.Net.Security.dasm (-0.11% of base)
        -640 : System.Data.Common.dasm (-0.02% of base)
        -448 : System.Net.HttpListener.dasm (-0.06% of base)
        -368 : System.Net.Http.WinHttpHandler.dasm (-0.16% of base)
        -344 : System.Net.Mail.dasm (-0.05% of base)
        -288 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
        -288 : System.Linq.Parallel.dasm (-0.02% of base)
        -240 : System.Threading.Tasks.Parallel.dasm (-0.17% of base)
        -232 : System.Text.Json.dasm (-0.02% of base)
        -224 : System.Net.Sockets.dasm (-0.03% of base)
        -216 : System.Reflection.MetadataLoadContext.dasm (-0.03% of base)
        -208 : System.Linq.dasm (-0.03% of base)
71 total files with Code Size differences (71 improved, 0 regressed), 163 unchanged.
Top method improvements (bytes):
        -840 (-2.12% of base) : System.Net.Http.dasm - Huffman:.cctor() (2 methods)
        -464 (-9.70% of base) : Microsoft.CodeAnalysis.CSharp.dasm - BinopEasyOut:TypeToIndex(TypeSymbol):Nullable`1 (4 methods)
        -464 (-9.70% of base) : Microsoft.CodeAnalysis.CSharp.dasm - UnopEasyOut:TypeToIndex(TypeSymbol):Nullable`1 (4 methods)
        -288 (-1.25% of base) : Newtonsoft.Json.dasm - JToken:op_Explicit(JToken):Nullable`1 (34 methods)
        -208 (-2.87% of base) : Microsoft.CodeAnalysis.dasm - SyntaxDiffer:GetNextAction():DiffAction:this (4 methods)
        -128 (-4.78% of base) : System.Net.Security.dasm - NetEventSource:WriteEvent(int,String,int,int,int,int,int,int,int):this (2 methods)
        -112 (-2.23% of base) : System.Reflection.MetadataLoadContext.dasm - RoType:GetMemberImpl(String,int,int):ref:this (2 methods)
         -96 (-3.92% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ConversionsBase:MostSpecificConversionOperator(Func`2,ImmutableArray`1):Nullable`1 (4 methods)
         -96 (-1.85% of base) : Microsoft.CodeAnalysis.dasm - CommonReferenceManager`2:GetInitialReferenceBindingsToProcess(ImmutableArray`1,ImmutableArray`1,ImmutableArray`1,ArrayBuilder`1,int,ArrayBuilder`1):this (4 methods)
         -96 (-0.41% of base) : System.Linq.Parallel.dasm - HashJoinQueryOperatorEnumerator`7:MoveNext(byref,byref):bool:this (24 methods)
         -96 (-2.96% of base) : System.Private.CoreLib.dasm - RuntimeType:GetMember(String,int,int):ref:this (2 methods)
         -96 (-4.84% of base) : System.Threading.Tasks.Parallel.dasm - ParallelEtwProvider:ParallelLoopBegin(int,int,int,int,long,long):this (2 methods)
         -80 (-3.70% of base) : Microsoft.CodeAnalysis.CSharp.dasm - OverloadResolution:CorrespondsToAnyParameter(ImmutableArray`1,bool,AnalyzedArguments,int,byref):Nullable`1 (4 methods)
         -80 (-5.81% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LanguageParser:IsPossibleTypedIdentifierStart(SyntaxToken,SyntaxToken,bool):Nullable`1 (4 methods)
         -80 (-1.45% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - ConversionEasyOut:ClassifyPredefinedConversion(TypeSymbol,TypeSymbol):Nullable`1 (4 methods)
         -80 (-1.41% of base) : System.Memory.dasm - SequenceReader`1:TryPeek(long,byref):bool:this (6 methods)
         -80 (-3.83% of base) : System.Net.Http.dasm - NetEventSource:WriteEvent(int,int,int,int,String,String):this (2 methods)
         -80 (-0.86% of base) : System.Net.WebClient.dasm - <UploadBitsAsync>d__152:MoveNext():this (2 methods)
         -80 (-4.67% of base) : System.Threading.Tasks.Parallel.dasm - ParallelEtwProvider:ParallelInvokeBegin(int,int,int,int,int):this (2 methods)
         -72 (-11.11% of base) : System.Text.RegularExpressions.dasm - RegexCharClass:Analyze(String):CharClassAnalysisResults (2 methods)
Top method improvements (percentages):
         -32 (-22.22% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SynthesizedContainer:get_Layout():TypeLayout:this (4 methods)
         -32 (-22.22% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ImplicitNamedTypeSymbol:get_Layout():TypeLayout:this (4 methods)
         -32 (-22.22% of base) : Microsoft.CodeAnalysis.CSharp.dasm - AnonymousTypeTemplateSymbol:get_Layout():TypeLayout:this (4 methods)
         -32 (-22.22% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SynthesizedContainer:get_Layout():TypeLayout:this (4 methods)
         -32 (-22.22% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AnonymousTypeOrDelegateTemplateSymbol:get_Layout():TypeLayout:this (4 methods)
         -32 (-22.22% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - ImplicitNamedTypeSymbol:get_Layout():TypeLayout:this (4 methods)
         -32 (-16.67% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - ControlFlowPass:ReachableState():LocalState:this (4 methods)
         -32 (-16.67% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DimensionSize:ConstantSize(int):DimensionSize (4 methods)
          -8 (-14.29% of base) : System.Linq.dasm - CopyPosition:get_Start():CopyPosition (2 methods)
          -8 (-12.50% of base) : Microsoft.CodeAnalysis.CSharp.dasm - PreciseAbstractFlowPass`1:AllBitsSet():LocalState:this (2 methods)
         -16 (-12.50% of base) : Microsoft.CodeAnalysis.dasm - SubsystemVersion:get_None():SubsystemVersion (4 methods)
         -16 (-12.50% of base) : Microsoft.CodeAnalysis.dasm - Location:get_SourceSpan():TextSpan:this (4 methods)
          -8 (-12.50% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AbstractFlowPass`1:AllBitsSet():LocalState:this (2 methods)
         -32 (-12.50% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - ControlFlowPass:UnreachableState():LocalState:this (4 methods)
          -8 (-12.50% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - RecursionGuard:get_Entry():RecursionGuard (2 methods)
          -8 (-12.50% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - StackSource:get_SamplingRate():Nullable`1:this (2 methods)
          -8 (-11.11% of base) : System.Linq.Parallel.dasm - PairOutputKeyBuilder`2:Combine(int,int):Pair`2:this (2 methods)
          -8 (-11.11% of base) : System.Private.CoreLib.dasm - Range:EndAt(Index):Range (2 methods)
          -8 (-11.11% of base) : System.Reflection.Metadata.dasm - ModuleDefinitionHandle:op_Implicit(ModuleDefinitionHandle):Handle (2 methods)
         -72 (-11.11% of base) : System.Text.RegularExpressions.dasm - RegexCharClass:Analyze(String):CharClassAnalysisResults (2 methods)
937 total methods with Code Size differences (937 improved, 0 regressed), 182703 unchanged.
```