### PR TITLE
  Handle OBJ(ADDR(LCL_FLD)) in fgMorphMultiregStructArg

### DIFF
--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -5468,7 +5468,6 @@ private:
 #endif // FEATURE_SIMD
     GenTree* fgMorphArrayIndex(GenTree* tree);
     GenTree* fgMorphCast(GenTree* tree);
-    GenTreeFieldList* fgMorphLclArgToFieldlist(GenTreeLclVarCommon* lcl);
     void fgInitArgInfo(GenTreeCall* call);
     GenTreeCall* fgMorphArgs(GenTreeCall* call);
 
@@ -9823,8 +9822,11 @@ public:
 
 #endif // defined(UNIX_AMD64_ABI)
 
+#if FEATURE_MULTIREG_ARGS
     void fgMorphMultiregStructArgs(GenTreeCall* call);
     GenTree* fgMorphMultiregStructArg(GenTree* arg, fgArgTabEntry* fgEntryPtr);
+    GenTreeFieldList* fgMorphLclArgToFieldlist(GenTreeLclVarCommon* lcl);
+#endif
 
     bool killGCRefs(GenTree* tree);
 

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -3460,9 +3460,12 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
         argSlots++;
     }
 
+#if FEATURE_MULTIREG_ARGS
     // Note that this name is a bit of a misnomer - it indicates that there are struct args
     // that occupy more than a single slot that are passed by value (not necessarily in regs).
     bool hasMultiregStructArgs = false;
+#endif
+
     for (args = call->gtCallArgs; args != nullptr; args = args->GetNext(), argIndex++)
     {
         GenTree**      parentArgx = &args->NodeRef();
@@ -3979,10 +3982,12 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
         call->fgArgInfo->EvalArgsToTemps();
     }
 
+#if FEATURE_MULTIREG_ARGS
     if (hasMultiregStructArgs)
     {
         fgMorphMultiregStructArgs(call);
     }
+#endif
 
 #ifdef DEBUG
     if (verbose)
@@ -3998,6 +4003,7 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
 #pragma warning(pop)
 #endif
 
+#if FEATURE_MULTIREG_ARGS
 //-----------------------------------------------------------------------------
 // fgMorphMultiregStructArgs:  Locate the TYP_STRUCT arguments and
 //                             call fgMorphMultiregStructArg on each of them.
@@ -4195,7 +4201,6 @@ GenTree* Compiler::fgMorphMultiregStructArg(GenTree* arg, fgArgTabEntry* fgEntry
         return arg;
     }
 
-#if FEATURE_MULTIREG_ARGS
     // Examine 'arg' and setup argValue objClass and structSize
     //
     CORINFO_CLASS_HANDLE objClass = gtGetStructHandleIfPresent(arg);
@@ -4659,8 +4664,6 @@ GenTree* Compiler::fgMorphMultiregStructArg(GenTree* arg, fgArgTabEntry* fgEntry
 
     arg = newArg; // consider calling fgMorphTree(newArg);
 
-#endif // FEATURE_MULTIREG_ARGS
-
     return arg;
 }
 
@@ -4690,6 +4693,7 @@ GenTreeFieldList* Compiler::fgMorphLclArgToFieldlist(GenTreeLclVarCommon* lcl)
     }
     return fieldList;
 }
+#endif // FEATURE_MULTIREG_ARGS
 
 //------------------------------------------------------------------------
 // fgMakeOutgoingStructArgCopy: make a copy of a struct variable if necessary,

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -4568,33 +4568,6 @@ GenTree* Compiler::fgMorphMultiregStructArg(GenTree* arg, fgArgTabEntry* fgEntry
             // The allocated size of our LocalVar must be at least as big as lastOffset
             assert(varDsc->lvSize() >= lastOffset);
 
-            if (varDsc->HasGCPtr())
-            {
-                // alignment of the baseOffset is required
-                noway_assert((baseOffset % TARGET_POINTER_SIZE) == 0);
-#ifndef UNIX_AMD64_ABI
-                noway_assert(elemSize == TARGET_POINTER_SIZE);
-#endif
-                unsigned     baseIndex = baseOffset / TARGET_POINTER_SIZE;
-                ClassLayout* layout    = varDsc->GetLayout();
-                for (unsigned inx = 0; (inx < elemCount); inx++)
-                {
-                    // The GC information must match what we setup using 'objClass'
-                    if (layout->IsGCPtr(baseIndex + inx) || varTypeGCtype(type[inx]))
-                    {
-                        noway_assert(type[inx] == layout->GetGCPtrType(baseIndex + inx));
-                    }
-                }
-            }
-            else //  this varDsc contains no GC pointers
-            {
-                for (unsigned inx = 0; inx < elemCount; inx++)
-                {
-                    // The GC information must match what we setup using 'objClass'
-                    noway_assert(!varTypeIsGC(type[inx]));
-                }
-            }
-
             //
             // We create a list of GT_LCL_FLDs nodes to pass this struct
             //


### PR DESCRIPTION
arm64 diff:
```
Total bytes of diff: -704 (-0.00% of base)
    diff is an improvement.
Top file improvements (bytes):
        -256 : System.Security.Cryptography.Algorithms.dasm (-0.03% of base)
        -176 : System.Security.Cryptography.Pkcs.dasm (-0.02% of base)
         -80 : System.Transactions.Local.dasm (-0.02% of base)
         -48 : System.Security.Cryptography.Cng.dasm (-0.01% of base)
         -32 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00% of base)
         -32 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.00% of base)
         -32 : System.ServiceProcess.ServiceController.dasm (-0.04% of base)
         -16 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
         -16 : System.Console.dasm (-0.01% of base)
         -16 : System.Private.CoreLib.dasm (-0.00% of base)
10 total files with Code Size differences (10 improved, 0 regressed), 224 unchanged.
Top method improvements (bytes):
         -80 (-4.20% of base) : System.Security.Cryptography.Algorithms.dasm - RSAKeyFormatHelper:FromPkcs1PrivateKey(ReadOnlyMemory`1,byref,byref) (2 methods)
         -64 (-2.65% of base) : System.Transactions.Local.dasm - InternalEnlistment:get_EnlistmentTraceId():EnlistmentTraceIdentifier:this (2 methods)
         -32 (-0.44% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CSharpCompilation:AddDebugSourceDocumentsForChecksumDirectives(PEModuleBuilder,SyntaxTree,DiagnosticBag) (4 methods)
         -32 (-0.47% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VisualBasicCompilation:AddDebugSourceDocumentsForChecksumDirectives(PEModuleBuilder,SyntaxTree,DiagnosticBag) (4 methods)
         -32 (-1.69% of base) : System.Security.Cryptography.Algorithms.dasm - DSAKeyFormatHelper:ReadDsaPrivateKey(ReadOnlyMemory`1,byref,byref) (2 methods)
         -32 (-1.19% of base) : System.Security.Cryptography.Algorithms.dasm - KeyFormatHelper:ReadSubjectPublicKeyInfo(ref,ReadOnlyMemory`1,KeyReader`1,byref,byref) (4 methods)
         -32 (-1.20% of base) : System.Security.Cryptography.Algorithms.dasm - KeyFormatHelper:ReadPkcs8(ref,ReadOnlyMemory`1,KeyReader`1,byref,byref) (4 methods)
         -32 (-0.70% of base) : System.Security.Cryptography.Algorithms.dasm - AsnValueReader:ProcessConstructedBitString(ReadOnlySpan`1,Span`1,BitStringCopyAction,bool,byref,byref):int:this (2 methods)
         -32 (-0.72% of base) : System.Security.Cryptography.Algorithms.dasm - AsnValueReader:CopyConstructedOctetString(ReadOnlySpan`1,Span`1,bool,bool,byref):int:this (2 methods)
         -32 (-0.72% of base) : System.Security.Cryptography.Cng.dasm - AsnValueReader:CopyConstructedOctetString(ReadOnlySpan`1,Span`1,bool,bool,byref):int:this (2 methods)
         -32 (-1.19% of base) : System.Security.Cryptography.Pkcs.dasm - KeyFormatHelper:ReadSubjectPublicKeyInfo(ref,ReadOnlyMemory`1,KeyReader`1,byref,byref) (4 methods)
         -32 (-1.20% of base) : System.Security.Cryptography.Pkcs.dasm - KeyFormatHelper:ReadPkcs8(ref,ReadOnlyMemory`1,KeyReader`1,byref,byref) (4 methods)
         -32 (-0.75% of base) : System.Security.Cryptography.Pkcs.dasm - Pkcs12Info:Decode(ReadOnlyMemory`1,byref,bool):Pkcs12Info (2 methods)
         -32 (-0.70% of base) : System.Security.Cryptography.Pkcs.dasm - AsnValueReader:ProcessConstructedBitString(ReadOnlySpan`1,Span`1,BitStringCopyAction,bool,byref,byref):int:this (2 methods)
         -32 (-0.72% of base) : System.Security.Cryptography.Pkcs.dasm - AsnValueReader:CopyConstructedOctetString(ReadOnlySpan`1,Span`1,bool,bool,byref):int:this (2 methods)
         -16 (-0.78% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - CtfTraceEventSource:Process():bool:this (2 methods)
         -16 (-1.34% of base) : System.Console.dasm - ConsolePal:get_Title():String (2 methods)
         -16 (-3.57% of base) : System.Private.CoreLib.dasm - CompareInfo:GetSortVersion():SortVersion:this (2 methods)
         -16 (-0.84% of base) : System.Security.Cryptography.Algorithms.dasm - ECCng:GetPrimeCurveBlob(byref,bool):ref (2 methods)
         -16 (-0.84% of base) : System.Security.Cryptography.Cng.dasm - ECCng:GetPrimeCurveBlob(byref,bool):ref (2 methods)
Top method improvements (percentages):
         -80 (-4.20% of base) : System.Security.Cryptography.Algorithms.dasm - RSAKeyFormatHelper:FromPkcs1PrivateKey(ReadOnlyMemory`1,byref,byref) (2 methods)
         -16 (-3.64% of base) : System.Transactions.Local.dasm - EnlistmentTraceIdentifier:op_Equality(EnlistmentTraceIdentifier,EnlistmentTraceIdentifier):bool (2 methods)
         -16 (-3.57% of base) : System.Private.CoreLib.dasm - CompareInfo:GetSortVersion():SortVersion:this (2 methods)
         -64 (-2.65% of base) : System.Transactions.Local.dasm - InternalEnlistment:get_EnlistmentTraceId():EnlistmentTraceIdentifier:this (2 methods)
         -32 (-1.69% of base) : System.Security.Cryptography.Algorithms.dasm - DSAKeyFormatHelper:ReadDsaPrivateKey(ReadOnlyMemory`1,byref,byref) (2 methods)
         -16 (-1.64% of base) : System.Security.Cryptography.Pkcs.dasm - ManagedKeyAgreePal:get_RecipientIdentifier():SubjectIdentifier:this (2 methods)
         -16 (-1.34% of base) : System.Console.dasm - ConsolePal:get_Title():String (2 methods)
         -16 (-1.26% of base) : System.ServiceProcess.ServiceController.dasm - ServiceController:GetServiceDisplayName(SafeServiceHandle,String):String:this (2 methods)
         -32 (-1.20% of base) : System.Security.Cryptography.Algorithms.dasm - KeyFormatHelper:ReadPkcs8(ref,ReadOnlyMemory`1,KeyReader`1,byref,byref) (4 methods)
         -32 (-1.20% of base) : System.Security.Cryptography.Pkcs.dasm - KeyFormatHelper:ReadPkcs8(ref,ReadOnlyMemory`1,KeyReader`1,byref,byref) (4 methods)
         -32 (-1.19% of base) : System.Security.Cryptography.Algorithms.dasm - KeyFormatHelper:ReadSubjectPublicKeyInfo(ref,ReadOnlyMemory`1,KeyReader`1,byref,byref) (4 methods)
         -32 (-1.19% of base) : System.Security.Cryptography.Pkcs.dasm - KeyFormatHelper:ReadSubjectPublicKeyInfo(ref,ReadOnlyMemory`1,KeyReader`1,byref,byref) (4 methods)
         -16 (-1.02% of base) : System.ServiceProcess.ServiceController.dasm - ServiceController:GetServiceKeyName(SafeServiceHandle,String):String:this (2 methods)
         -16 (-0.84% of base) : System.Security.Cryptography.Algorithms.dasm - ECCng:GetPrimeCurveBlob(byref,bool):ref (2 methods)
         -16 (-0.84% of base) : System.Security.Cryptography.Cng.dasm - ECCng:GetPrimeCurveBlob(byref,bool):ref (2 methods)
         -16 (-0.78% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - CtfTraceEventSource:Process():bool:this (2 methods)
         -32 (-0.75% of base) : System.Security.Cryptography.Pkcs.dasm - Pkcs12Info:Decode(ReadOnlyMemory`1,byref,bool):Pkcs12Info (2 methods)
         -32 (-0.72% of base) : System.Security.Cryptography.Algorithms.dasm - AsnValueReader:CopyConstructedOctetString(ReadOnlySpan`1,Span`1,bool,bool,byref):int:this (2 methods)
         -32 (-0.72% of base) : System.Security.Cryptography.Cng.dasm - AsnValueReader:CopyConstructedOctetString(ReadOnlySpan`1,Span`1,bool,bool,byref):int:this (2 methods)
         -32 (-0.72% of base) : System.Security.Cryptography.Pkcs.dasm - AsnValueReader:CopyConstructedOctetString(ReadOnlySpan`1,Span`1,bool,bool,byref):int:this (2 methods)
24 total methods with Code Size differences (24 improved, 0 regressed), 183616 unchanged.
```