### PR TITLE
Move x86 vararg morphing to IndirectArgMorphVisitor

### DIFF
--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -5227,8 +5227,6 @@ private:
 
     GenTree* fgMorphIntoHelperCall(GenTree* tree, int helper, GenTreeCall::Use* args, bool morphArgs = true);
 
-    GenTree* fgMorphStackArgForVarArgs(unsigned lclNum, var_types varType, unsigned lclOffs);
-
     // A "MorphAddrContext" carries information from the surrounding context.  If we are evaluating a byref address,
     // it is useful to know whether the address will be immediately dereferenced, or whether the address value will
     // be used, perhaps by passing it as an argument to a called method.  This affects how null checking is done:
@@ -5475,9 +5473,10 @@ private:
     // promoted, create new promoted struct temps.
     void fgRetypeImplicitByRefArgs();
 
-#if (defined(TARGET_AMD64) && !defined(UNIX_AMD64_ABI)) || defined(TARGET_ARM64)
-    // Rewrite appearances of implicit byrefs (manifest the implied additional level of indirection).
-    void fgMorphImplicitByRefArgs(Statement* stmt);
+#if (defined(TARGET_AMD64) && !defined(UNIX_AMD64_ABI)) || defined(TARGET_ARM64) || defined(TARGET_X86)
+    // Rewrite appearances of implicit byrefs (manifest the implied additional level of indirection)
+    // or stack args of x86 varargs methods.
+    void fgMorphIndirectArgs(Statement* stmt);
 #endif
 
     // Clear up annotations for any struct promotion temps created for implicit byrefs.

--- a/src/coreclr/src/jit/lclmorph.cpp
+++ b/src/coreclr/src/jit/lclmorph.cpp
@@ -1874,7 +1874,7 @@ public:
         }
 
         indir->AsIndir()->SetAddr(addr);
-        indir->gtFlags |= GTF_GLOB_REF | GTF_IND_TGTANYWHERE;
+        indir->gtFlags |= GTF_GLOB_REF | GTF_IND_TGTANYWHERE | GTF_IND_NONFAULTING;
 
         INDEBUG(m_stmtModified = true;)
     }

--- a/src/coreclr/src/jit/lclmorph.cpp
+++ b/src/coreclr/src/jit/lclmorph.cpp
@@ -1544,27 +1544,13 @@ public:
 
     void VisitStmt(Statement* stmt)
     {
-#ifdef DEBUG
-        if (m_compiler->verbose)
-        {
-            printf("IndirectArgMorphVisitor visiting statement:\n");
-            m_compiler->gtDispStmt(stmt);
-            m_stmtModified = false;
-        }
-#endif
-
         WalkTree(stmt->GetRootNodePointer(), nullptr);
 
 #ifdef DEBUG
-        if (m_compiler->verbose)
+        if (m_compiler->verbose && m_stmtModified)
         {
-            if (m_stmtModified)
-            {
-                printf("IndirectArgMorphVisitor modified statement:\n");
-                m_compiler->gtDispStmt(stmt);
-            }
-
-            printf("\n");
+            printf("IndirectArgMorphVisitor modified statement:\n");
+            m_compiler->gtDispTree(stmt->GetRootNode());
         }
 #endif
     }
@@ -1791,6 +1777,8 @@ public:
                     }
                 }
             }
+
+            INDEBUG(m_stmtModified = true;)
         }
         else if (lclVarDsc->lvIsStructField && m_compiler->lvaIsImplicitByRefLocal(lclVarDsc->lvParentLcl))
         {
@@ -1832,9 +1820,9 @@ public:
                 // TGTANYWHERE
                 tree->gtFlags |= GTF_GLOB_REF | GTF_IND_NONFAULTING | GTF_IND_TGTANYWHERE;
             }
-        }
 
-        INDEBUG(m_stmtModified = true;)
+            INDEBUG(m_stmtModified = true;)
+        }
     }
 #elif defined(TARGET_X86)
     void MorphVarargsStackArgAddr(GenTreeLclVarCommon* lclNode)

--- a/src/coreclr/src/jit/lclmorph.cpp
+++ b/src/coreclr/src/jit/lclmorph.cpp
@@ -1778,10 +1778,7 @@ public:
                         tree->AsObj()->SetAddr(addr);
                         tree->AsObj()->gtBlkOpGcUnsafe = false;
                         tree->AsObj()->gtBlkOpKind     = GenTreeBlk::BlkOpKindInvalid;
-                        // TODO-Cleanup: This should not be needed, OBJ is an unary operator and nobody
-                        // is supposed to try to access gtOp2. OperIsBlkOp does it.
-                        tree->AsObj()->SetData(nullptr);
-                        tree->gtFlags = GTF_GLOB_REF | GTF_IND_NONFAULTING;
+                        tree->gtFlags                  = GTF_GLOB_REF | GTF_IND_NONFAULTING;
                     }
                     else
                     {
@@ -1882,9 +1879,6 @@ public:
 
             indir->ChangeOper(GT_OBJ);
             indir->AsObj()->SetLayout(layout);
-            // TODO-Cleanup: This should not be needed, OBJ is an unary operator and nobody
-            // is supposed to try to access gtOp2. OperIsBlkOp does it.
-            indir->AsObj()->SetData(nullptr);
         }
         else
         {

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -15115,6 +15115,16 @@ void Compiler::fgMorphStmts(BasicBlock* block, bool* lnot, bool* loadw)
         fgMorphStmt = stmt;
         compCurStmt = stmt;
 
+#ifdef DEBUG
+        unsigned oldHash = verbose ? gtHashValue(stmt->GetRootNode()) : DUMMY_INIT(~0);
+
+        if (verbose)
+        {
+            printf("\nfgMorphTree " FMT_BB ", " FMT_STMT " (before)\n", block->bbNum, stmt->GetID());
+            gtDispTree(stmt->GetRootNode());
+        }
+#endif
+
 #if (defined(TARGET_AMD64) && !defined(UNIX_AMD64_ABI)) || defined(TARGET_ARM64) || defined(TARGET_X86)
         if (fgGlobalMorph)
         {
@@ -15123,16 +15133,6 @@ void Compiler::fgMorphStmts(BasicBlock* block, bool* lnot, bool* loadw)
 #endif
 
         GenTree* oldTree = stmt->GetRootNode();
-
-#ifdef DEBUG
-        unsigned oldHash = verbose ? gtHashValue(oldTree) : DUMMY_INIT(~0);
-
-        if (verbose)
-        {
-            printf("\nfgMorphTree " FMT_BB ", " FMT_STMT " (before)\n", block->bbNum, stmt->GetID());
-            gtDispTree(oldTree);
-        }
-#endif
 
         /* Morph this statement tree */
 

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -5457,56 +5457,6 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
     return tree;
 }
 
-#ifdef TARGET_X86
-/*****************************************************************************
- *
- *  Wrap fixed stack arguments for varargs functions to go through varargs
- *  cookie to access them, except for the cookie itself.
- *
- * Non-x86 platforms are allowed to access all arguments directly
- * so we don't need this code.
- *
- */
-GenTree* Compiler::fgMorphStackArgForVarArgs(unsigned lclNum, var_types varType, unsigned lclOffs)
-{
-    /* For the fixed stack arguments of a varargs function, we need to go
-        through the varargs cookies to access them, except for the
-        cookie itself */
-
-    LclVarDsc* varDsc = &lvaTable[lclNum];
-
-    if (varDsc->lvIsParam && !varDsc->lvIsRegArg && lclNum != lvaVarargsHandleArg)
-    {
-        // Create a node representing the local pointing to the base of the args
-        GenTree* ptrArg =
-            gtNewOperNode(GT_SUB, TYP_I_IMPL, gtNewLclvNode(lvaVarargsBaseOfStkArgs, TYP_I_IMPL),
-                          gtNewIconNode(varDsc->lvStkOffs - codeGen->intRegState.rsCalleeRegArgCount * REGSIZE_BYTES -
-                                        lclOffs));
-
-        // Access the argument through the local
-        GenTree* tree;
-        if (varType == TYP_STRUCT)
-        {
-            tree = gtNewObjNode(varDsc->lvVerTypeInfo.GetClassHandle(), ptrArg);
-        }
-        else
-        {
-            tree = gtNewOperNode(GT_IND, varType, ptrArg);
-        }
-        tree->gtFlags |= GTF_IND_TGTANYWHERE;
-
-        if (varDsc->lvAddrExposed)
-        {
-            tree->gtFlags |= GTF_GLOB_REF;
-        }
-
-        return fgMorphTree(tree);
-    }
-
-    return NULL;
-}
-#endif
-
 /*****************************************************************************
  *
  *  Transform the given GT_LCL_VAR tree for code generation.
@@ -5524,17 +5474,6 @@ GenTree* Compiler::fgMorphLocalVar(GenTree* tree, bool forceRemorph)
     {
         tree->gtFlags |= GTF_GLOB_REF;
     }
-
-#ifdef TARGET_X86
-    if (info.compIsVarArgs)
-    {
-        GenTree* newTree = fgMorphStackArgForVarArgs(lclNum, varType, 0);
-        if (newTree != nullptr)
-        {
-            return newTree;
-        }
-    }
-#endif // TARGET_X86
 
     /* If not during the global morphing phase bail */
 
@@ -8845,18 +8784,6 @@ GenTree* Compiler::fgMorphLeaf(GenTree* tree)
         {
             tree->gtFlags |= GTF_GLOB_REF;
         }
-
-#ifdef TARGET_X86
-        if (info.compIsVarArgs)
-        {
-            GenTree* newTree = fgMorphStackArgForVarArgs(tree->AsLclFld()->GetLclNum(), tree->TypeGet(),
-                                                         tree->AsLclFld()->GetLclOffs());
-            if (newTree != nullptr)
-            {
-                return newTree;
-            }
-        }
-#endif // TARGET_X86
     }
     else if (tree->gtOper == GT_FTN_ADDR)
     {
@@ -15188,10 +15115,10 @@ void Compiler::fgMorphStmts(BasicBlock* block, bool* lnot, bool* loadw)
         fgMorphStmt = stmt;
         compCurStmt = stmt;
 
-#if (defined(TARGET_AMD64) && !defined(UNIX_AMD64_ABI)) || defined(TARGET_ARM64)
+#if (defined(TARGET_AMD64) && !defined(UNIX_AMD64_ABI)) || defined(TARGET_ARM64) || defined(TARGET_X86)
         if (fgGlobalMorph)
         {
-            fgMorphImplicitByRefArgs(stmt);
+            fgMorphIndirectArgs(stmt);
         }
 #endif
 


### PR DESCRIPTION
No x86 fx diffs but vararg.dll shows some improvements due to containment no longer being blocked by spurious exception side effects.