### PR TITLE
Handle more local indirs in MorphLocalIndir

### DIFF
--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -539,6 +539,11 @@ public:
     unsigned char lvFldOffset;
     unsigned char lvFldOrdinal;
 
+    bool IsPromoted() const
+    {
+        return lvPromoted;
+    }
+
     unsigned GetPromotedFieldCount() const
     {
         assert(lvPromoted);

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -10182,6 +10182,7 @@ void Compiler::gtDispTree(GenTree*     tree,
             break;
 
         case GT_FIELD:
+            printf("[+%u]", tree->AsField()->GetOffset());
             if (FieldSeqStore::IsPseudoField(tree->AsField()->gtFldHnd))
             {
                 printf(" #PseudoField:0x%x", tree->AsField()->gtFldOffset);
@@ -11916,10 +11917,11 @@ GenTree* Compiler::gtFoldBoxNullable(GenTree* tree)
     {
         CORINFO_CLASS_HANDLE nullableHnd = gtGetStructHandle(arg->AsOp()->gtOp1);
         CORINFO_FIELD_HANDLE fieldHnd    = info.compCompHnd->getFieldInClass(nullableHnd, 0);
+        unsigned             fieldOffset = info.compCompHnd->getFieldOffset(fieldHnd);
 
         // Replace the box with an access of the nullable 'hasValue' field.
         JITDUMP("\nSuccess: replacing BOX_NULLABLE(&x) [%06u] with x.hasValue\n", dspTreeID(op));
-        GenTree* newOp = gtNewFieldRef(TYP_BOOL, fieldHnd, arg, 0);
+        GenTree* newOp = gtNewFieldRef(TYP_BOOL, fieldHnd, arg, fieldOffset);
 
         if (op == op1)
         {

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -3608,6 +3608,11 @@ public:
         }
     }
 
+    unsigned GetOffset() const
+    {
+        return gtFldOffset;
+    }
+
 #ifdef FEATURE_READYTORUN_COMPILER
     void* GetR2RFieldLookupAddr() const
     {

--- a/src/coreclr/src/jit/vartype.h
+++ b/src/coreclr/src/jit/vartype.h
@@ -111,6 +111,12 @@ inline bool varTypeIsUnsigned(T vt)
     return ((varTypeClassification[TypeGet(vt)] & (VTF_UNS)) != 0);
 }
 
+inline var_types_classification varTypeKind(var_types type)
+{
+    return static_cast<var_types_classification>(varTypeClassification[type] &
+                                                 (VTF_INT | VTF_FLT | VTF_GCR | VTF_BYR | VTF_S));
+}
+
 // If "vt" is an unsigned integral type, returns the corresponding signed integral type, otherwise
 // return "vt".
 inline var_types varTypeUnsignedToSigned(var_types vt)


### PR DESCRIPTION
x64:
```
Total bytes of diff: -1050 (-0.00% of base)
    diff is an improvement.
Top file regressions (bytes):
          22 : Microsoft.CodeAnalysis.CSharp.dasm (0.00% of base)
           3 : Microsoft.CodeAnalysis.dasm (0.00% of base)
Top file improvements (bytes):
        -710 : System.Data.Common.dasm (-0.06% of base)
        -161 : System.Private.CoreLib.dasm (-0.00% of base)
        -154 : System.Configuration.ConfigurationManager.dasm (-0.05% of base)
         -42 : System.Reflection.Metadata.dasm (-0.01% of base)
          -5 : System.Net.HttpListener.dasm (-0.00% of base)
          -3 : System.Diagnostics.PerformanceCounter.dasm (-0.00% of base)
8 total files with Code Size differences (6 improved, 2 regressed), 256 unchanged.
Top method regressions (bytes):
           6 ( 0.29% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:CheckPropertyValueKind(BoundExpression,ubyte,DiagnosticBag):bool:this
           4 ( 1.53% of base) : System.Data.Common.dasm - SqlString:NotEquals(SqlString,SqlString):SqlBoolean
           3 ( 0.15% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:CheckViability(Symbol,int,int,TypeSymbol,bool,byref,ConsList`1):SingleLookupResult:this
           3 ( 1.36% of base) : Microsoft.CodeAnalysis.CSharp.dasm - OverloadResolution:TypeArgumentsAccessible(ImmutableArray`1,byref):bool:this
           3 ( 0.19% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:BindEventAssignment(AssignmentExpressionSyntax,BoundEventAccess,BoundExpression,int,DiagnosticBag):BoundExpression:this
           3 ( 0.89% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:CanAddLookupSymbolInfo(Symbol,int,TypeSymbol):bool:this
           3 ( 0.84% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:IsConstructorAccessible(MethodSymbol,byref,bool):bool:this
           3 ( 1.82% of base) : Microsoft.CodeAnalysis.dasm - PEModuleBuilder`9:GetFakeSymbolTokenForIL(IReference,SyntaxNode,DiagnosticBag):int:this
           3 (12.00% of base) : System.Private.CoreLib.dasm - Span`1:Fill(byte):this
           3 ( 2.48% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:Equals(Nullable`1,Nullable`1):bool:this
           3 ( 0.61% of base) : System.Reflection.Metadata.dasm - SignatureDecoder`2:DecodeMethodSignature(byref):MethodSignature`1:this
           2 ( 0.79% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:IndexOf(ref,Nullable`1,int,int):int:this
           2 ( 0.79% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:LastIndexOf(ref,Nullable`1,int,int):int:this
           1 ( 0.08% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ForEachLoopBinder:SatisfiesForEachPattern(byref,DiagnosticBag):bool:this
           1 ( 0.20% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:BindEventAccess(CSharpSyntaxNode,BoundExpression,EventSymbol,DiagnosticBag,ubyte,bool):BoundExpression:this
           1 ( 0.11% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Lexer:ScanDirectiveToken(byref):bool:this
           1 ( 0.09% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:AddConfigurationSection(String,String,ConfigurationSection):this
           1 ( 0.03% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:CopyConfigDefinitionsRecursive(ConfigDefinitionUpdates,XmlUtil,XmlUtilWriter,bool,LocationUpdates,SectionUpdates,bool,String,int,int):bool:this
           1 ( 0.22% of base) : System.Private.CoreLib.dasm - WorkStealingQueue:TrySteal(byref):Object:this
           1 ( 1.89% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:GetHashCode(Nullable`1):int:this
Top method improvements (bytes):
         -70 (-1.80% of base) : System.Data.Common.dasm - SqlDecimalStorage:Aggregate(ref,int):Object:this
         -66 (-1.93% of base) : System.Data.Common.dasm - SqlDoubleStorage:Aggregate(ref,int):Object:this
         -56 (-1.69% of base) : System.Data.Common.dasm - SqlInt16Storage:Aggregate(ref,int):Object:this
         -55 (-1.54% of base) : System.Data.Common.dasm - SqlInt64Storage:Aggregate(ref,int):Object:this
         -55 (-1.45% of base) : System.Data.Common.dasm - SqlMoneyStorage:Aggregate(ref,int):Object:this
         -55 (-1.55% of base) : System.Data.Common.dasm - SqlSingleStorage:Aggregate(ref,int):Object:this
         -54 (-1.63% of base) : System.Data.Common.dasm - SqlInt32Storage:Aggregate(ref,int):Object:this
         -54 (-1.62% of base) : System.Data.Common.dasm - SqlByteStorage:Aggregate(ref,int):Object:this
         -48 (-2.97% of base) : System.Private.CoreLib.dasm - Task:RunContinuations(Object):this
         -37 (-4.23% of base) : System.Data.Common.dasm - SqlDateTimeStorage:Aggregate(ref,int):Object:this
         -31 (-18.79% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:AreLocationAttributesModified(SectionRecord,ConfigurationSection):bool:this
         -22 (-0.99% of base) : System.Configuration.ConfigurationManager.dasm - BaseConfigurationRecord:ResolveLocationSections():this
         -22 (-7.83% of base) : System.Data.Common.dasm - SqlDecimal:Sign(SqlDecimal):SqlInt32
         -21 (-3.63% of base) : System.Data.Common.dasm - SqlBooleanStorage:Aggregate(ref,int):Object:this
         -19 (-7.25% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:AreDeclarationAttributesModified(FactoryRecord,ConfigurationSection):bool
         -18 (-0.66% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:UpdateRecords():this
         -18 (-9.78% of base) : System.Data.Common.dasm - SqlDecimal:CompareTo(SqlDecimal):int:this
         -17 (-10.30% of base) : System.Configuration.ConfigurationManager.dasm - SectionRecord:AddFileInput(SectionInput):this
         -15 (-6.25% of base) : System.Reflection.Metadata.dasm - StandaloneSignature:GetKind():int:this
         -14 (-9.46% of base) : System.Data.Common.dasm - SqlDouble:CompareTo(SqlDouble):int:this
Top method regressions (percentages):
           3 (12.00% of base) : System.Private.CoreLib.dasm - Span`1:Fill(byte):this
           3 ( 2.48% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:Equals(Nullable`1,Nullable`1):bool:this
           1 ( 1.89% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:GetHashCode(Nullable`1):int:this
           3 ( 1.82% of base) : Microsoft.CodeAnalysis.dasm - PEModuleBuilder`9:GetFakeSymbolTokenForIL(IReference,SyntaxNode,DiagnosticBag):int:this
           4 ( 1.53% of base) : System.Data.Common.dasm - SqlString:NotEquals(SqlString,SqlString):SqlBoolean
           3 ( 1.36% of base) : Microsoft.CodeAnalysis.CSharp.dasm - OverloadResolution:TypeArgumentsAccessible(ImmutableArray`1,byref):bool:this
           3 ( 0.89% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:CanAddLookupSymbolInfo(Symbol,int,TypeSymbol):bool:this
           3 ( 0.84% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:IsConstructorAccessible(MethodSymbol,byref,bool):bool:this
           2 ( 0.79% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:IndexOf(ref,Nullable`1,int,int):int:this
           2 ( 0.79% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:LastIndexOf(ref,Nullable`1,int,int):int:this
           3 ( 0.61% of base) : System.Reflection.Metadata.dasm - SignatureDecoder`2:DecodeMethodSignature(byref):MethodSignature`1:this
           6 ( 0.29% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:CheckPropertyValueKind(BoundExpression,ubyte,DiagnosticBag):bool:this
           1 ( 0.22% of base) : System.Private.CoreLib.dasm - WorkStealingQueue:TrySteal(byref):Object:this
           1 ( 0.20% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:BindEventAccess(CSharpSyntaxNode,BoundExpression,EventSymbol,DiagnosticBag,ubyte,bool):BoundExpression:this
           3 ( 0.19% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:BindEventAssignment(AssignmentExpressionSyntax,BoundEventAccess,BoundExpression,int,DiagnosticBag):BoundExpression:this
           3 ( 0.15% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:CheckViability(Symbol,int,int,TypeSymbol,bool,byref,ConsList`1):SingleLookupResult:this
           1 ( 0.12% of base) : System.Reflection.Metadata.dasm - PropertyDefinition:GetAccessors():PropertyAccessors:this
           1 ( 0.11% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Lexer:ScanDirectiveToken(byref):bool:this
           1 ( 0.09% of base) : System.Reflection.Metadata.dasm - EventDefinition:GetAccessors():EventAccessors:this
           1 ( 0.09% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:AddConfigurationSection(String,String,ConfigurationSection):this
Top method improvements (percentages):
          -7 (-33.33% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:GetHashCode(bool):int:this
          -6 (-27.27% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:Equals(bool,bool):bool:this
          -7 (-22.58% of base) : System.Private.CoreLib.dasm - FrameworkEventSource:ThreadPoolEnqueueWorkObject(Object):this
          -7 (-22.58% of base) : System.Private.CoreLib.dasm - FrameworkEventSource:ThreadPoolDequeueWorkObject(Object):this
          -9 (-21.95% of base) : System.Private.CoreLib.dasm - GenericComparer`1:Compare(bool,bool):int:this
          -7 (-21.88% of base) : System.Data.Common.dasm - SqlDecimal:op_Inequality(SqlDecimal,SqlDecimal):SqlBoolean
          -7 (-21.88% of base) : System.Data.Common.dasm - SqlDouble:op_Inequality(SqlDouble,SqlDouble):SqlBoolean
          -7 (-21.88% of base) : System.Data.Common.dasm - SqlGuid:op_Inequality(SqlGuid,SqlGuid):SqlBoolean
          -7 (-21.88% of base) : System.Data.Common.dasm - SqlGuid:NotEquals(SqlGuid,SqlGuid):SqlBoolean
          -7 (-21.88% of base) : System.Data.Common.dasm - SqlInt64:op_Inequality(SqlInt64,SqlInt64):SqlBoolean
          -7 (-21.88% of base) : System.Data.Common.dasm - SqlMoney:op_Inequality(SqlMoney,SqlMoney):SqlBoolean
          -7 (-20.59% of base) : System.Private.CoreLib.dasm - Convert:ToString(bool):String
          -7 (-20.59% of base) : System.Private.CoreLib.dasm - Convert:ToString(bool,IFormatProvider):String
         -31 (-18.79% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:AreLocationAttributesModified(SectionRecord,ConfigurationSection):bool:this
         -10 (-17.24% of base) : System.Private.CoreLib.dasm - TplEventSource:RunningContinuationList(int,int,Object):this
          -7 (-16.67% of base) : System.Private.CoreLib.dasm - FrameworkEventSource:ThreadTransferReceiveObj(Object,int,String):this
          -7 (-14.29% of base) : System.Private.CoreLib.dasm - StringBuilder:Append(bool):StringBuilder:this
         -14 (-12.96% of base) : System.Data.Common.dasm - SqlGuid:CompareTo(SqlGuid):int:this
          -7 (-12.50% of base) : System.Private.CoreLib.dasm - StringBuilder:Insert(int,bool):StringBuilder:this
         -17 (-10.30% of base) : System.Configuration.ConfigurationManager.dasm - SectionRecord:AddFileInput(SectionInput):this
95 total methods with Code Size differences (73 improved, 22 regressed), 187609 unchanged.
```
x86:
```
Total bytes of diff: -859 (-0.00% of base)
    diff is an improvement.
Top file regressions (bytes):
          59 : System.CodeDom.dasm (0.05% of base)
          13 : System.Reflection.Metadata.dasm (0.00% of base)
          10 : Microsoft.CodeAnalysis.CSharp.dasm (0.00% of base)
           6 : System.Diagnostics.PerformanceCounter.dasm (0.01% of base)
           1 : Microsoft.CodeAnalysis.dasm (0.00% of base)
Top file improvements (bytes):
        -664 : System.Data.Common.dasm (-0.07% of base)
        -163 : System.Private.CoreLib.dasm (-0.01% of base)
        -116 : System.Configuration.ConfigurationManager.dasm (-0.05% of base)
          -5 : System.Net.HttpListener.dasm (-0.00% of base)
9 total files with Code Size differences (4 improved, 5 regressed), 255 unchanged.
Top method regressions (bytes):
          59 ( 5.85% of base) : System.CodeDom.dasm - VBCodeGenerator:QuoteSnippetString(String):String:this
          59 (11.66% of base) : System.Data.Common.dasm - SqlBooleanStorage:Aggregate(ref,int):Object:this
          50 ( 5.63% of base) : System.Reflection.Metadata.dasm - PropertyDefinition:GetAccessors():PropertyAccessors:this
          15 ( 0.37% of base) : System.Configuration.ConfigurationManager.dasm - BaseConfigurationRecord:ScanFactoriesRecursive(XmlUtil,String,Hashtable):this
           6 ( 1.88% of base) : System.Diagnostics.PerformanceCounter.dasm - PerformanceDataRegistryKey:GetValue(String,bool):ref:this
           5 ( 0.38% of base) : System.Configuration.ConfigurationManager.dasm - BaseConfigurationRecord:ScanLocationSection(XmlUtil):this
           4 ( 0.09% of base) : System.Private.CoreLib.dasm - GenericArraySortHelper`1:PickPivotAndPartition(Span`1):int (12 methods)
           3 ( 0.72% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:BindEventAccess(CSharpSyntaxNode,BoundExpression,EventSymbol,DiagnosticBag,ubyte,bool):BoundExpression:this
           3 ( 8.57% of base) : System.Private.CoreLib.dasm - Span`1:Fill(byte):this
           3 ( 0.69% of base) : System.Reflection.Metadata.dasm - SignatureDecoder`2:DecodeMethodSignature(byref):MethodSignature`1:this
           2 ( 0.13% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:CheckPropertyValueKind(BoundExpression,ubyte,DiagnosticBag):bool:this
           2 ( 1.14% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:IndexOf(ref,Nullable`1,int,int):int:this
           2 ( 1.14% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:LastIndexOf(ref,Nullable`1,int,int):int:this
           1 ( 0.06% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:CheckViability(Symbol,int,int,TypeSymbol,bool,byref,ConsList`1):SingleLookupResult:this
           1 ( 0.58% of base) : Microsoft.CodeAnalysis.CSharp.dasm - OverloadResolution:TypeArgumentsAccessible(ImmutableArray`1,byref):bool:this
           1 ( 0.09% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ForEachLoopBinder:SatisfiesForEachPattern(byref,DiagnosticBag):bool:this
           1 ( 0.08% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:BindEventAssignment(AssignmentExpressionSyntax,BoundEventAccess,BoundExpression,int,DiagnosticBag):BoundExpression:this
           1 ( 0.37% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:CanAddLookupSymbolInfo(Symbol,int,TypeSymbol):bool:this
           1 ( 0.37% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:IsConstructorAccessible(MethodSymbol,byref,bool):bool:this
           1 ( 0.12% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Lexer:ScanDirectiveToken(byref):bool:this
Top method improvements (bytes):
         -57 (-1.66% of base) : System.Data.Common.dasm - SqlDecimalStorage:Aggregate(ref,int):Object:this
         -57 (-1.76% of base) : System.Data.Common.dasm - SqlDoubleStorage:Aggregate(ref,int):Object:this
         -57 (-1.78% of base) : System.Data.Common.dasm - SqlInt16Storage:Aggregate(ref,int):Object:this
         -57 (-1.81% of base) : System.Data.Common.dasm - SqlInt32Storage:Aggregate(ref,int):Object:this
         -57 (-1.61% of base) : System.Data.Common.dasm - SqlInt64Storage:Aggregate(ref,int):Object:this
         -57 (-1.53% of base) : System.Data.Common.dasm - SqlMoneyStorage:Aggregate(ref,int):Object:this
         -57 (-1.69% of base) : System.Data.Common.dasm - SqlSingleStorage:Aggregate(ref,int):Object:this
         -57 (-1.74% of base) : System.Data.Common.dasm - SqlByteStorage:Aggregate(ref,int):Object:this
         -44 (-2.68% of base) : System.Private.CoreLib.dasm - Task:RunContinuations(Object):this
         -29 (-18.83% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:AreLocationAttributesModified(SectionRecord,ConfigurationSection):bool:this
         -26 (-15.85% of base) : System.Data.Common.dasm - SqlDateTime:CompareTo(SqlDateTime):int:this
         -22 (-12.50% of base) : System.Data.Common.dasm - SqlDecimal:CompareTo(SqlDecimal):int:this
         -22 (-21.15% of base) : System.Data.Common.dasm - SqlGuid:CompareTo(SqlGuid):int:this
         -22 (-15.28% of base) : System.Data.Common.dasm - SqlInt32:CompareTo(SqlInt32):int:this
         -22 (-15.28% of base) : System.Data.Common.dasm - SqlSingle:CompareTo(SqlSingle):int:this
         -16 (-6.93% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:AreDeclarationAttributesModified(FactoryRecord,ConfigurationSection):bool
         -15 (-10.64% of base) : System.Configuration.ConfigurationManager.dasm - SectionRecord:AddFileInput(SectionInput):this
         -14 (-0.81% of base) : System.Configuration.ConfigurationManager.dasm - BaseConfigurationRecord:ResolveLocationSections():this
         -12 (-0.58% of base) : System.Data.Common.dasm - BinaryNode:BinaryCompare(Object,Object,int,int,CompareInfo):int:this
         -12 (-5.33% of base) : System.Private.CoreLib.dasm - TimerQueueTimer:CallCallback(bool):this
Top method regressions (percentages):
          59 (11.66% of base) : System.Data.Common.dasm - SqlBooleanStorage:Aggregate(ref,int):Object:this
           3 ( 8.57% of base) : System.Private.CoreLib.dasm - Span`1:Fill(byte):this
          59 ( 5.85% of base) : System.CodeDom.dasm - VBCodeGenerator:QuoteSnippetString(String):String:this
          50 ( 5.63% of base) : System.Reflection.Metadata.dasm - PropertyDefinition:GetAccessors():PropertyAccessors:this
           6 ( 1.88% of base) : System.Diagnostics.PerformanceCounter.dasm - PerformanceDataRegistryKey:GetValue(String,bool):ref:this
           2 ( 1.14% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:IndexOf(ref,Nullable`1,int,int):int:this
           2 ( 1.14% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:LastIndexOf(ref,Nullable`1,int,int):int:this
           1 ( 0.93% of base) : Microsoft.CodeAnalysis.dasm - PEModuleBuilder`9:GetFakeSymbolTokenForIL(IReference,SyntaxNode,DiagnosticBag):int:this
           3 ( 0.72% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:BindEventAccess(CSharpSyntaxNode,BoundExpression,EventSymbol,DiagnosticBag,ubyte,bool):BoundExpression:this
           3 ( 0.69% of base) : System.Reflection.Metadata.dasm - SignatureDecoder`2:DecodeMethodSignature(byref):MethodSignature`1:this
           1 ( 0.58% of base) : Microsoft.CodeAnalysis.CSharp.dasm - OverloadResolution:TypeArgumentsAccessible(ImmutableArray`1,byref):bool:this
           5 ( 0.38% of base) : System.Configuration.ConfigurationManager.dasm - BaseConfigurationRecord:ScanLocationSection(XmlUtil):this
           1 ( 0.37% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:IsConstructorAccessible(MethodSymbol,byref,bool):bool:this
          15 ( 0.37% of base) : System.Configuration.ConfigurationManager.dasm - BaseConfigurationRecord:ScanFactoriesRecursive(XmlUtil,String,Hashtable):this
           1 ( 0.37% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:CanAddLookupSymbolInfo(Symbol,int,TypeSymbol):bool:this
           1 ( 0.24% of base) : System.Private.CoreLib.dasm - WorkStealingQueue:TrySteal(byref):Object:this
           2 ( 0.13% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:CheckPropertyValueKind(BoundExpression,ubyte,DiagnosticBag):bool:this
           1 ( 0.12% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Lexer:ScanDirectiveToken(byref):bool:this
           1 ( 0.09% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ForEachLoopBinder:SatisfiesForEachPattern(byref,DiagnosticBag):bool:this
           4 ( 0.09% of base) : System.Private.CoreLib.dasm - GenericArraySortHelper`1:PickPivotAndPartition(Span`1):int (12 methods)
Top method improvements (percentages):
          -8 (-33.33% of base) : System.Private.CoreLib.dasm - FrameworkEventSource:ThreadPoolEnqueueWorkObject(Object):this
          -8 (-33.33% of base) : System.Private.CoreLib.dasm - FrameworkEventSource:ThreadPoolDequeueWorkObject(Object):this
          -8 (-30.77% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:GetHashCode(bool):int:this
          -9 (-25.71% of base) : System.Data.Common.dasm - SqlGuid:op_Inequality(SqlGuid,SqlGuid):SqlBoolean
          -9 (-24.32% of base) : System.Data.Common.dasm - SqlGuid:NotEquals(SqlGuid,SqlGuid):SqlBoolean
          -6 (-24.00% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:Equals(bool,bool):bool:this
          -9 (-23.08% of base) : System.Private.CoreLib.dasm - FrameworkEventSource:ThreadTransferReceiveObj(Object,int,String):this
          -8 (-22.86% of base) : System.Private.CoreLib.dasm - Convert:ToString(bool):String
          -8 (-22.86% of base) : System.Private.CoreLib.dasm - Convert:ToString(bool,IFormatProvider):String
         -22 (-21.15% of base) : System.Data.Common.dasm - SqlGuid:CompareTo(SqlGuid):int:this
          -8 (-19.51% of base) : System.Private.CoreLib.dasm - StringBuilder:Append(bool):StringBuilder:this
          -9 (-19.15% of base) : System.Private.CoreLib.dasm - GenericComparer`1:Compare(bool,bool):int:this
         -29 (-18.83% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:AreLocationAttributesModified(SectionRecord,ConfigurationSection):bool:this
          -9 (-17.31% of base) : System.Private.CoreLib.dasm - FrameworkEventSource:ThreadTransferSendObj(Object,int,String,bool,int,int):this
          -8 (-16.67% of base) : System.Data.Common.dasm - SqlInt32:NotEquals(SqlInt32,SqlInt32):SqlBoolean
          -9 (-16.36% of base) : System.Data.Common.dasm - SqlDouble:op_Inequality(SqlDouble,SqlDouble):SqlBoolean
          -9 (-16.36% of base) : System.Data.Common.dasm - SqlInt32:op_Inequality(SqlInt32,SqlInt32):SqlBoolean
          -9 (-16.36% of base) : System.Data.Common.dasm - SqlInt64:op_Inequality(SqlInt64,SqlInt64):SqlBoolean
          -9 (-16.36% of base) : System.Data.Common.dasm - SqlMoney:op_Inequality(SqlMoney,SqlMoney):SqlBoolean
          -9 (-16.36% of base) : System.Data.Common.dasm - SqlSingle:op_Inequality(SqlSingle,SqlSingle):SqlBoolean
96 total methods with Code Size differences (74 improved, 22 regressed), 187505 unchanged.
```
arm64:
```
Total bytes of diff: -1324 (-0.00% of base)
    diff is an improvement.
Top file improvements (bytes):
        -844 : System.Data.Common.dasm (-0.02% of base)
        -208 : System.Configuration.ConfigurationManager.dasm (-0.02% of base)
        -128 : System.Private.CoreLib.dasm (-0.00% of base)
         -80 : System.Reflection.Metadata.dasm (-0.01% of base)
         -40 : System.Text.Json.dasm (-0.00% of base)
         -16 : System.Net.HttpListener.dasm (-0.00% of base)
          -8 : System.Diagnostics.PerformanceCounter.dasm (-0.00% of base)
7 total files with Code Size differences (7 improved, 0 regressed), 257 unchanged.
Top method regressions (bytes):
          16 ( 0.33% of base) : System.Private.CoreLib.dasm - Task:RunContinuations(Object):this (2 methods)
          16 ( 0.49% of base) : System.Reflection.Metadata.dasm - SignatureDecoder`2:DecodeMethodSignature(byref):MethodSignature`1:this (4 methods)
           8 ( 0.05% of base) : System.Configuration.ConfigurationManager.dasm - BaseConfigurationRecord:ScanFactoriesRecursive(XmlUtil,String,Hashtable):this (2 methods)
           8 ( 9.09% of base) : System.Private.CoreLib.dasm - Span`1:Fill(byte):this (2 methods)
           8 ( 1.06% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:IndexOf(ref,Nullable`1,int,int):int:this (2 methods)
           8 ( 1.05% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:LastIndexOf(ref,Nullable`1,int,int):int:this (2 methods)
Top method improvements (bytes):
        -116 (-1.43% of base) : System.Data.Common.dasm - SqlDoubleStorage:Aggregate(ref,int):Object:this (2 methods)
         -64 (-0.75% of base) : System.Data.Common.dasm - SqlMoneyStorage:Aggregate(ref,int):Object:this (2 methods)
         -56 (-0.70% of base) : System.Data.Common.dasm - SqlInt64Storage:Aggregate(ref,int):Object:this (2 methods)
         -56 (-3.18% of base) : System.Data.Common.dasm - SqlBooleanStorage:Aggregate(ref,int):Object:this (2 methods)
         -48 (-10.91% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:AreLocationAttributesModified(SectionRecord,ConfigurationSection):bool:this (2 methods)
         -48 (-0.54% of base) : System.Data.Common.dasm - SqlDecimalStorage:Aggregate(ref,int):Object:this (2 methods)
         -40 (-0.52% of base) : System.Data.Common.dasm - SqlInt16Storage:Aggregate(ref,int):Object:this (2 methods)
         -40 (-0.52% of base) : System.Data.Common.dasm - SqlInt32Storage:Aggregate(ref,int):Object:this (2 methods)
         -40 (-0.47% of base) : System.Data.Common.dasm - SqlSingleStorage:Aggregate(ref,int):Object:this (2 methods)
         -40 (-0.52% of base) : System.Data.Common.dasm - SqlByteStorage:Aggregate(ref,int):Object:this (2 methods)
         -40 (-0.75% of base) : System.Text.Json.dasm - JsonPropertyInfo`1:GetMemberAndWriteJsonExtensionData(Object,byref,Utf8JsonWriter):bool:this (42 methods)
         -24 (-0.35% of base) : System.Configuration.ConfigurationManager.dasm - BaseConfigurationRecord:ResolveLocationSections():this (2 methods)
         -24 (-3.45% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:AreDeclarationAttributesModified(FactoryRecord,ConfigurationSection):bool (2 methods)
         -24 (-5.17% of base) : System.Configuration.ConfigurationManager.dasm - SectionRecord:AddFileInput(SectionInput):this (2 methods)
         -24 (-5.88% of base) : System.Data.Common.dasm - SqlString:NotEquals(SqlString,SqlString):SqlBoolean (2 methods)
         -16 (-1.82% of base) : System.Configuration.ConfigurationManager.dasm - BaseConfigurationRecord:ResolveOverrideModeFromParent(String,byref):int:this (2 methods)
         -16 (-1.67% of base) : System.Configuration.ConfigurationManager.dasm - ConfigDefinitionUpdates:FindLocationUpdates(OverrideModeSetting,bool):LocationUpdates:this (2 methods)
         -16 (-0.22% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:UpdateRecords():this (2 methods)
         -16 (-1.61% of base) : System.Configuration.ConfigurationManager.dasm - SectionInformation:set_OverrideModeDefault(int):this (2 methods)
         -16 (-2.08% of base) : System.Configuration.ConfigurationManager.dasm - SectionRecord:AddLocationInputImpl(SectionInput,bool):this (2 methods)
Top method regressions (percentages):
           8 ( 9.09% of base) : System.Private.CoreLib.dasm - Span`1:Fill(byte):this (2 methods)
           8 ( 1.06% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:IndexOf(ref,Nullable`1,int,int):int:this (2 methods)
           8 ( 1.05% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:LastIndexOf(ref,Nullable`1,int,int):int:this (2 methods)
          16 ( 0.49% of base) : System.Reflection.Metadata.dasm - SignatureDecoder`2:DecodeMethodSignature(byref):MethodSignature`1:this (4 methods)
          16 ( 0.33% of base) : System.Private.CoreLib.dasm - Task:RunContinuations(Object):this (2 methods)
           8 ( 0.05% of base) : System.Configuration.ConfigurationManager.dasm - BaseConfigurationRecord:ScanFactoriesRecursive(XmlUtil,String,Hashtable):this (2 methods)
Top method improvements (percentages):
         -16 (-11.11% of base) : System.Data.Common.dasm - SqlDecimal:op_Inequality(SqlDecimal,SqlDecimal):SqlBoolean (2 methods)
         -16 (-11.11% of base) : System.Data.Common.dasm - SqlGuid:op_Inequality(SqlGuid,SqlGuid):SqlBoolean (2 methods)
         -16 (-11.11% of base) : System.Data.Common.dasm - SqlGuid:NotEquals(SqlGuid,SqlGuid):SqlBoolean (2 methods)
          -8 (-11.11% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:Equals(bool,bool):bool:this (2 methods)
         -48 (-10.91% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:AreLocationAttributesModified(SectionRecord,ConfigurationSection):bool:this (2 methods)
          -8 (-10.00% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:GetHashCode(bool):int:this (2 methods)
         -16 (-9.09% of base) : System.Private.CoreLib.dasm - FrameworkEventSource:ThreadTransferSendObj(Object,int,String,bool,int,int):this (2 methods)
         -16 (-7.69% of base) : System.Data.Common.dasm - SqlDouble:op_Inequality(SqlDouble,SqlDouble):SqlBoolean (2 methods)
         -16 (-7.69% of base) : System.Data.Common.dasm - SqlInt64:op_Inequality(SqlInt64,SqlInt64):SqlBoolean (2 methods)
         -16 (-7.69% of base) : System.Data.Common.dasm - SqlInt64:NotEquals(SqlInt64,SqlInt64):SqlBoolean (2 methods)
         -16 (-7.69% of base) : System.Data.Common.dasm - SqlMoney:op_Inequality(SqlMoney,SqlMoney):SqlBoolean (2 methods)
         -16 (-7.69% of base) : System.Data.Common.dasm - SqlMoney:NotEquals(SqlMoney,SqlMoney):SqlBoolean (2 methods)
          -8 (-7.69% of base) : System.Private.CoreLib.dasm - FrameworkEventSource:ThreadPoolEnqueueWorkObject(Object):this (2 methods)
          -8 (-7.69% of base) : System.Private.CoreLib.dasm - FrameworkEventSource:ThreadPoolDequeueWorkObject(Object):this (2 methods)
         -16 (-7.14% of base) : System.Data.Common.dasm - SqlDouble:NotEquals(SqlDouble,SqlDouble):SqlBoolean (2 methods)
          -8 (-6.25% of base) : System.Private.CoreLib.dasm - Convert:ToString(bool):String (2 methods)
          -8 (-6.25% of base) : System.Private.CoreLib.dasm - Convert:ToString(bool,IFormatProvider):String (2 methods)
          -8 (-6.25% of base) : System.Private.CoreLib.dasm - FrameworkEventSource:ThreadTransferReceiveObj(Object,int,String):this (2 methods)
          -8 (-6.25% of base) : System.Private.CoreLib.dasm - GenericComparer`1:Compare(bool,bool):int:this (2 methods)
         -24 (-5.88% of base) : System.Data.Common.dasm - SqlString:NotEquals(SqlString,SqlString):SqlBoolean (2 methods)
77 total methods with Code Size differences (71 improved, 6 regressed), 187110 unchanged.
```
arm32:
```
Total bytes of diff: -1744 (-0.00% of base)
    diff is an improvement.
Top file improvements (bytes):
        -980 : System.Data.Common.dasm (-0.04% of base)
        -232 : System.Configuration.ConfigurationManager.dasm (-0.03% of base)
        -220 : System.Private.CoreLib.dasm (-0.00% of base)
        -156 : System.Reflection.Metadata.dasm (-0.02% of base)
         -96 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00% of base)
         -20 : System.Net.HttpListener.dasm (-0.00% of base)
         -16 : System.Diagnostics.PerformanceCounter.dasm (-0.01% of base)
         -16 : System.Text.Encodings.Web.dasm (-0.03% of base)
          -8 : Microsoft.CodeAnalysis.dasm (-0.00% of base)
9 total files with Code Size differences (9 improved, 0 regressed), 255 unchanged.
Top method regressions (bytes):
          12 ( 0.20% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:CopyConfigDefinitionsRecursive(ConfigDefinitionUpdates,XmlUtil,XmlUtilWriter,bool,LocationUpdates,SectionUpdates,bool,String,int,int):bool:this (2 methods)
           8 ( 1.79% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:IndexOf(ref,Nullable`1,int,int):int:this (2 methods)
           8 ( 1.77% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:LastIndexOf(ref,Nullable`1,int,int):int:this (2 methods)
           4 ( 0.04% of base) : System.Configuration.ConfigurationManager.dasm - BaseConfigurationRecord:ScanFactoriesRecursive(XmlUtil,String,Hashtable):this (2 methods)
           4 ( 7.14% of base) : System.Private.CoreLib.dasm - Span`1:Fill(byte):this (2 methods)
Top method improvements (bytes):
         -76 (-1.05% of base) : System.Data.Common.dasm - SqlSingleStorage:Aggregate(ref,int):Object:this (2 methods)
         -64 (-0.88% of base) : System.Data.Common.dasm - SqlDoubleStorage:Aggregate(ref,int):Object:this (2 methods)
         -64 (-0.89% of base) : System.Data.Common.dasm - SqlInt64Storage:Aggregate(ref,int):Object:this (2 methods)
         -60 (-0.93% of base) : System.Data.Common.dasm - SqlInt16Storage:Aggregate(ref,int):Object:this (2 methods)
         -60 (-0.93% of base) : System.Data.Common.dasm - SqlInt32Storage:Aggregate(ref,int):Object:this (2 methods)
         -60 (-0.79% of base) : System.Data.Common.dasm - SqlMoneyStorage:Aggregate(ref,int):Object:this (2 methods)
         -60 (-0.93% of base) : System.Data.Common.dasm - SqlByteStorage:Aggregate(ref,int):Object:this (2 methods)
         -56 (-0.72% of base) : System.Data.Common.dasm - SqlDecimalStorage:Aggregate(ref,int):Object:this (2 methods)
         -48 (-14.12% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:AreLocationAttributesModified(SectionRecord,ConfigurationSection):bool:this (2 methods)
         -44 (-7.64% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:AreDeclarationAttributesModified(FactoryRecord,ConfigurationSection):bool (2 methods)
         -40 (-14.08% of base) : System.Data.Common.dasm - SqlGuid:CompareTo(SqlGuid):int:this (2 methods)
         -36 (-3.14% of base) : System.Data.Common.dasm - SqlBooleanStorage:Aggregate(ref,int):Object:this (2 methods)
         -32 (-7.69% of base) : System.Configuration.ConfigurationManager.dasm - SectionRecord:AddFileInput(SectionInput):this (2 methods)
         -28 (-0.55% of base) : System.Configuration.ConfigurationManager.dasm - BaseConfigurationRecord:ResolveLocationSections():this (2 methods)
         -28 (-3.74% of base) : System.Configuration.ConfigurationManager.dasm - SectionInformation:set_OverrideModeDefault(int):this (2 methods)
         -24 (-6.82% of base) : System.Data.Common.dasm - SqlDateTime:CompareTo(SqlDateTime):int:this (2 methods)
         -24 (-5.26% of base) : System.Data.Common.dasm - SqlDecimal:CompareTo(SqlDecimal):int:this (2 methods)
         -24 (-16.22% of base) : System.Data.Common.dasm - SqlGuid:op_Inequality(SqlGuid,SqlGuid):SqlBoolean (2 methods)
         -24 (-16.22% of base) : System.Data.Common.dasm - SqlGuid:NotEquals(SqlGuid,SqlGuid):SqlBoolean (2 methods)
         -24 (-15.00% of base) : System.Data.Common.dasm - SqlInt32:op_Inequality(SqlInt32,SqlInt32):SqlBoolean (2 methods)
Top method regressions (percentages):
           4 ( 7.14% of base) : System.Private.CoreLib.dasm - Span`1:Fill(byte):this (2 methods)
           8 ( 1.79% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:IndexOf(ref,Nullable`1,int,int):int:this (2 methods)
           8 ( 1.77% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:LastIndexOf(ref,Nullable`1,int,int):int:this (2 methods)
          12 ( 0.20% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:CopyConfigDefinitionsRecursive(ConfigDefinitionUpdates,XmlUtil,XmlUtilWriter,bool,LocationUpdates,SectionUpdates,bool,String,int,int):bool:this (2 methods)
           4 ( 0.04% of base) : System.Configuration.ConfigurationManager.dasm - BaseConfigurationRecord:ScanFactoriesRecursive(XmlUtil,String,Hashtable):this (2 methods)
Top method improvements (percentages):
         -16 (-30.77% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:Equals(bool,bool):bool:this (2 methods)
         -12 (-21.43% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:GetHashCode(bool):int:this (2 methods)
         -16 (-18.18% of base) : System.Private.CoreLib.dasm - GenericComparer`1:Compare(bool,bool):int:this (2 methods)
         -16 (-16.67% of base) : System.Private.CoreLib.dasm - FrameworkEventSource:ThreadTransferReceiveObj(Object,int,String):this (2 methods)
         -24 (-16.22% of base) : System.Data.Common.dasm - SqlGuid:op_Inequality(SqlGuid,SqlGuid):SqlBoolean (2 methods)
         -24 (-16.22% of base) : System.Data.Common.dasm - SqlGuid:NotEquals(SqlGuid,SqlGuid):SqlBoolean (2 methods)
         -24 (-15.00% of base) : System.Data.Common.dasm - SqlInt32:op_Inequality(SqlInt32,SqlInt32):SqlBoolean (2 methods)
         -24 (-15.00% of base) : System.Data.Common.dasm - SqlSingle:op_Inequality(SqlSingle,SqlSingle):SqlBoolean (2 methods)
         -24 (-14.29% of base) : System.Data.Common.dasm - SqlInt32:NotEquals(SqlInt32,SqlInt32):SqlBoolean (2 methods)
         -48 (-14.12% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:AreLocationAttributesModified(SectionRecord,ConfigurationSection):bool:this (2 methods)
         -40 (-14.08% of base) : System.Data.Common.dasm - SqlGuid:CompareTo(SqlGuid):int:this (2 methods)
         -24 (-12.50% of base) : System.Data.Common.dasm - SqlSingle:NotEquals(SqlSingle,SqlSingle):SqlBoolean (2 methods)
         -12 (-12.50% of base) : System.Private.CoreLib.dasm - Convert:ToString(bool):String (2 methods)
         -12 (-12.50% of base) : System.Private.CoreLib.dasm - Convert:ToString(bool,IFormatProvider):String (2 methods)
         -16 (-11.11% of base) : System.Private.CoreLib.dasm - StringBuilder:Append(bool):StringBuilder:this (2 methods)
         -16 (-10.53% of base) : System.Private.CoreLib.dasm - StringBuilder:Insert(int,bool):StringBuilder:this (2 methods)
         -24 (-7.89% of base) : System.Data.Common.dasm - SqlInt32:CompareTo(SqlInt32):int:this (2 methods)
         -24 (-7.89% of base) : System.Data.Common.dasm - SqlSingle:CompareTo(SqlSingle):int:this (2 methods)
         -32 (-7.69% of base) : System.Configuration.ConfigurationManager.dasm - SectionRecord:AddFileInput(SectionInput):this (2 methods)
         -44 (-7.64% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:AreDeclarationAttributesModified(FactoryRecord,ConfigurationSection):bool (2 methods)
93 total methods with Code Size differences (88 improved, 5 regressed), 186984 unchanged.
```
Improvements tend to come from handling cases that other JIT code misses (e.g. `bool`/`ubyte` mismatches or promoted struct fields accessed via `IND` instead of `FIELD`).

Regressions tend to be caused by differences in xarch `STORE_LCL_VAR/FLD` lowering (e.g. `mov byte ptr [esp], 0` turns into `xor eax, eax; mov dword ptr [esp], eax`), sometimes by redundant casts not being eliminated (e.g. `Span.Fill(byte)`) and sometimes by changes in register allocation. On x86 `SqlBooleanStorage:Aggregate` has a problem with register allocation because `LocalAddressVisitor` produces small int typed `LCL_VAR` nodes which restrict registers to byte. `LCL_VAR`s should probably have type `TYP_INT` but the JIT seems rather inconsistent in this regard so this should be addressed separately.

Fixes runtime/620