### PR TITLE
Simplify some cast sequences

### DIFF
--- a/src/coreclr/src/jit/_typeinfo.h
+++ b/src/coreclr/src/jit/_typeinfo.h
@@ -59,7 +59,7 @@ namespace
 {
 #endif //  _MSC_VER
 SELECTANY const ti_types g_jit_types_map[] = {
-#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf, howUsed) verType,
+#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf) verType,
 #include "typelist.h"
 #undef DEF_TP
 };

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -33,25 +33,25 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 /*****************************************************************************/
 
 const BYTE genTypeSizes[] = {
-#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf, howUsed) sz,
+#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf) sz,
 #include "typelist.h"
 #undef DEF_TP
 };
 
 const BYTE genTypeAlignments[] = {
-#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf, howUsed) al,
+#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf) al,
 #include "typelist.h"
 #undef DEF_TP
 };
 
 const BYTE genTypeStSzs[] = {
-#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf, howUsed) st,
+#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf) st,
 #include "typelist.h"
 #undef DEF_TP
 };
 
 const BYTE genActualTypes[] = {
-#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf, howUsed) jitType,
+#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf) jitType,
 #include "typelist.h"
 #undef DEF_TP
 };

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -3130,8 +3130,6 @@ public:
                        CORINFO_ARG_LIST_HANDLE varList,
                        CORINFO_SIG_INFO*       varSig);
 
-    static unsigned lvaTypeRefMask(var_types type);
-
     var_types lvaGetActualType(unsigned lclNum);
     var_types lvaGetRealType(unsigned lclNum);
 
@@ -10595,19 +10593,6 @@ XX                                                                           XX
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 */
-
-// Values used to mark the types a stack slot is used for
-
-const unsigned TYPE_REF_INT      = 0x01; // slot used as a 32-bit int
-const unsigned TYPE_REF_LNG      = 0x02; // slot used as a 64-bit long
-const unsigned TYPE_REF_FLT      = 0x04; // slot used as a 32-bit float
-const unsigned TYPE_REF_DBL      = 0x08; // slot used as a 64-bit float
-const unsigned TYPE_REF_PTR      = 0x10; // slot used as a 32-bit pointer
-const unsigned TYPE_REF_BYR      = 0x20; // slot used as a byref pointer
-const unsigned TYPE_REF_STC      = 0x40; // slot used as a struct
-const unsigned TYPE_REF_TYPEMASK = 0x7F; // bits that represent the type
-
-// const unsigned TYPE_REF_ADDR_TAKEN  = 0x80; // slots address was taken
 
 /*****************************************************************************
  *

--- a/src/coreclr/src/jit/compiler.hpp
+++ b/src/coreclr/src/jit/compiler.hpp
@@ -2309,27 +2309,6 @@ inline BOOL Compiler::lvaIsOriginalThisReadOnly()
  *  integer/address and a float value.
  */
 
-/* static */ inline unsigned Compiler::lvaTypeRefMask(var_types type)
-{
-    const static BYTE lvaTypeRefMasks[] = {
-#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf, howUsed) howUsed,
-#include "typelist.h"
-#undef DEF_TP
-    };
-
-    assert((unsigned)type < sizeof(lvaTypeRefMasks));
-    assert(lvaTypeRefMasks[type] != 0);
-
-    return lvaTypeRefMasks[type];
-}
-
-/*****************************************************************************
- *
- *  The following is used to detect the cases where the same local variable#
- *  is used both as a long/double value and a 32-bit value and/or both as an
- *  integer/address and a float value.
- */
-
 inline var_types Compiler::lvaGetActualType(unsigned lclNum)
 {
     return genActualType(lvaGetRealType(lclNum));

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -443,13 +443,13 @@ void emitterStats(FILE* fout)
 /*****************************************************************************/
 
 const unsigned short emitTypeSizes[] = {
-#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf, howUsed) sze,
+#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf) sze,
 #include "typelist.h"
 #undef DEF_TP
 };
 
 const unsigned short emitTypeActSz[] = {
-#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf, howUsed) asze,
+#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf) asze,
 #include "typelist.h"
 #undef DEF_TP
 };

--- a/src/coreclr/src/jit/typelist.h
+++ b/src/coreclr/src/jit/typelist.h
@@ -25,47 +25,46 @@
     st  - stack slots (slots are sizeof(int) bytes) (genTypeStSzs())
     al  - alignment
     tf  - flags
-    howUsed - If a variable is used (referenced) as the type
 
-DEF_TP(tn      ,nm        , jitType,     verType, sz,sze,asze, st,al, tf,            howUsed     )
+DEF_TP(tn      ,nm        , jitType,     verType, sz,sze,asze, st,al, tf)
 */
 
 // clang-format off
-DEF_TP(UNDEF   ,"<UNDEF>" , TYP_UNDEF,   TI_ERROR, 0,  0,  0,   0, 0, VTF_ANY,        0           )
-DEF_TP(VOID    ,"void"    , TYP_VOID,    TI_ERROR, 0,  0,  0,   0, 0, VTF_ANY,        0           )
+DEF_TP(UNDEF   ,"<UNDEF>" , TYP_UNDEF,   TI_ERROR, 0,  0,  0,   0, 0, VTF_ANY)
+DEF_TP(VOID    ,"void"    , TYP_VOID,    TI_ERROR, 0,  0,  0,   0, 0, VTF_ANY)
 
-DEF_TP(BOOL    ,"bool"    , TYP_INT,     TI_BYTE,  1,  1,  4,   1, 1, VTF_INT|VTF_UNS,TYPE_REF_INT)
-DEF_TP(BYTE    ,"byte"    , TYP_INT,     TI_BYTE,  1,  1,  4,   1, 1, VTF_INT,        TYPE_REF_INT)
-DEF_TP(UBYTE   ,"ubyte"   , TYP_INT,     TI_BYTE,  1,  1,  4,   1, 1, VTF_INT|VTF_UNS,TYPE_REF_INT)
+DEF_TP(BOOL    ,"bool"    , TYP_INT,     TI_BYTE,  1,  1,  4,   1, 1, VTF_INT|VTF_UNS)
+DEF_TP(BYTE    ,"byte"    , TYP_INT,     TI_BYTE,  1,  1,  4,   1, 1, VTF_INT)
+DEF_TP(UBYTE   ,"ubyte"   , TYP_INT,     TI_BYTE,  1,  1,  4,   1, 1, VTF_INT|VTF_UNS)
 
-DEF_TP(SHORT   ,"short"   , TYP_INT,     TI_SHORT, 2,  2,  4,   1, 2, VTF_INT,        TYPE_REF_INT)
-DEF_TP(USHORT  ,"ushort"  , TYP_INT,     TI_SHORT, 2,  2,  4,   1, 2, VTF_INT|VTF_UNS,TYPE_REF_INT)
+DEF_TP(SHORT   ,"short"   , TYP_INT,     TI_SHORT, 2,  2,  4,   1, 2, VTF_INT)
+DEF_TP(USHORT  ,"ushort"  , TYP_INT,     TI_SHORT, 2,  2,  4,   1, 2, VTF_INT|VTF_UNS)
 
-DEF_TP(INT     ,"int"     , TYP_INT,     TI_INT,   4,  4,  4,   1, 4, VTF_INT|VTF_I32,        TYPE_REF_INT)
-DEF_TP(UINT    ,"uint"    , TYP_INT,     TI_INT,   4,  4,  4,   1, 4, VTF_INT|VTF_UNS|VTF_I32,TYPE_REF_INT) // Only used in GT_CAST nodes
+DEF_TP(INT     ,"int"     , TYP_INT,     TI_INT,   4,  4,  4,   1, 4, VTF_INT|VTF_I32)
+DEF_TP(UINT    ,"uint"    , TYP_INT,     TI_INT,   4,  4,  4,   1, 4, VTF_INT|VTF_UNS|VTF_I32) // Only used in GT_CAST nodes
 
-DEF_TP(LONG    ,"long"    , TYP_LONG,    TI_LONG,  8, PS, PS,   2, 8, VTF_INT|VTF_I64,        TYPE_REF_LNG)
-DEF_TP(ULONG   ,"ulong"   , TYP_LONG,    TI_LONG,  8, PS, PS,   2, 8, VTF_INT|VTF_UNS|VTF_I64,TYPE_REF_LNG)       // Only used in GT_CAST nodes
+DEF_TP(LONG    ,"long"    , TYP_LONG,    TI_LONG,  8, PS, PS,   2, 8, VTF_INT|VTF_I64)
+DEF_TP(ULONG   ,"ulong"   , TYP_LONG,    TI_LONG,  8, PS, PS,   2, 8, VTF_INT|VTF_UNS|VTF_I64) // Only used in GT_CAST nodes
 
-DEF_TP(FLOAT   ,"float"   , TYP_FLOAT,   TI_FLOAT, 4,  4,  4,   1, 4, VTF_FLT,        TYPE_REF_FLT)
-DEF_TP(DOUBLE  ,"double"  , TYP_DOUBLE,  TI_DOUBLE,8,  8,  8,   2, 8, VTF_FLT,        TYPE_REF_DBL)
+DEF_TP(FLOAT   ,"float"   , TYP_FLOAT,   TI_FLOAT, 4,  4,  4,   1, 4, VTF_FLT)
+DEF_TP(DOUBLE  ,"double"  , TYP_DOUBLE,  TI_DOUBLE,8,  8,  8,   2, 8, VTF_FLT)
 
-DEF_TP(REF     ,"ref"     , TYP_REF,     TI_REF,  PS,GCS,GCS, PST,PS, VTF_ANY|VTF_GCR|VTF_I,TYPE_REF_PTR)
-DEF_TP(BYREF   ,"byref"   , TYP_BYREF,   TI_ERROR,PS,BRS,BRS, PST,PS, VTF_ANY|VTF_BYR|VTF_I,TYPE_REF_BYR)
-DEF_TP(STRUCT  ,"struct"  , TYP_STRUCT,  TI_STRUCT,0,  0,  0,   1, 4, VTF_S,          TYPE_REF_STC)
+DEF_TP(REF     ,"ref"     , TYP_REF,     TI_REF,  PS,GCS,GCS, PST,PS, VTF_ANY|VTF_GCR|VTF_I)
+DEF_TP(BYREF   ,"byref"   , TYP_BYREF,   TI_ERROR,PS,BRS,BRS, PST,PS, VTF_ANY|VTF_BYR|VTF_I)
+DEF_TP(STRUCT  ,"struct"  , TYP_STRUCT,  TI_STRUCT,0,  0,  0,   1, 4, VTF_S)
 
-DEF_TP(BLK     ,"blk"     , TYP_BLK,     TI_ERROR, 0,  0,  0,   1, 4, VTF_ANY,        0           ) // blob of memory
-DEF_TP(LCLBLK  ,"lclBlk"  , TYP_LCLBLK,  TI_ERROR, 0,  0,  0,   1, 4, VTF_ANY,        0           ) // preallocated memory for locspace
+DEF_TP(BLK     ,"blk"     , TYP_BLK,     TI_ERROR, 0,  0,  0,   1, 4, VTF_ANY) // blob of memory
+DEF_TP(LCLBLK  ,"lclBlk"  , TYP_LCLBLK,  TI_ERROR, 0,  0,  0,   1, 4, VTF_ANY) // preallocated memory for locspace
 
 #ifdef FEATURE_SIMD
 // Amd64: The size and alignment of SIMD vector varies at JIT time based on whether target arch supports AVX or SSE2.
-DEF_TP(SIMD8    ,"simd8"  , TYP_SIMD8,   TI_STRUCT, 8, 8,  8,   2, 8, VTF_S,          TYPE_REF_STC)
-DEF_TP(SIMD12   ,"simd12" , TYP_SIMD12,  TI_STRUCT,12,16, 16,   4,16, VTF_S,          TYPE_REF_STC)
-DEF_TP(SIMD16   ,"simd16" , TYP_SIMD16,  TI_STRUCT,16,16, 16,   4,16, VTF_S,          TYPE_REF_STC)
-DEF_TP(SIMD32   ,"simd32" , TYP_SIMD32,  TI_STRUCT,32,32, 32,   8,16, VTF_S,          TYPE_REF_STC)
+DEF_TP(SIMD8    ,"simd8"  , TYP_SIMD8,   TI_STRUCT, 8, 8,  8,   2, 8, VTF_S)
+DEF_TP(SIMD12   ,"simd12" , TYP_SIMD12,  TI_STRUCT,12,16, 16,   4,16, VTF_S)
+DEF_TP(SIMD16   ,"simd16" , TYP_SIMD16,  TI_STRUCT,16,16, 16,   4,16, VTF_S)
+DEF_TP(SIMD32   ,"simd32" , TYP_SIMD32,  TI_STRUCT,32,32, 32,   8,16, VTF_S)
 #endif // FEATURE_SIMD
 
-DEF_TP(UNKNOWN ,"unknown" ,TYP_UNKNOWN,  TI_ERROR, 0,  0,  0,   0, 0, VTF_ANY,        0           )
+DEF_TP(UNKNOWN ,"unknown" ,TYP_UNKNOWN,  TI_ERROR, 0,  0,  0,   0, 0, VTF_ANY)
 // clang-format on
 
 #undef GCS

--- a/src/coreclr/src/jit/utils.cpp
+++ b/src/coreclr/src/jit/utils.cpp
@@ -93,7 +93,7 @@ const signed char       opcodeSizes[] =
 // clang-format on
 
 const BYTE varTypeClassification[] = {
-#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf, howUsed) tf,
+#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf) tf,
 #include "typelist.h"
 #undef DEF_TP
 };
@@ -119,7 +119,7 @@ extern const BYTE opcodeArgKinds[] = {
 const char* varTypeName(var_types vt)
 {
     static const char* const varTypeNames[] = {
-#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf, howUsed) nm,
+#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf) nm,
 #include "typelist.h"
 #undef DEF_TP
     };

--- a/src/coreclr/src/jit/vartype.h
+++ b/src/coreclr/src/jit/vartype.h
@@ -22,7 +22,7 @@ enum var_types_classification
 
 enum var_types : BYTE
 {
-#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf, howUsed) TYP_##tn,
+#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf) TYP_##tn,
 #include "typelist.h"
 #undef DEF_TP
     TYP_COUNT
@@ -36,11 +36,9 @@ enum var_types : BYTE
 #ifdef TARGET_64BIT
 #define TYP_I_IMPL TYP_LONG
 #define TYP_U_IMPL TYP_ULONG
-#define TYPE_REF_IIM TYPE_REF_LNG
 #else
 #define TYP_I_IMPL TYP_INT
 #define TYP_U_IMPL TYP_UINT
-#define TYPE_REF_IIM TYPE_REF_INT
 #ifdef _PREFAST_
 // We silence this in the 32-bit build because for portability, we like to have asserts like this:
 // assert(op2->gtType == TYP_INT || op2->gtType == TYP_I_IMPL);


### PR DESCRIPTION
x64 diff
```
Total bytes of diff: -379 (-0.00% of base)
    diff is an improvement.
Top file regressions (bytes):
           2 : System.Text.Json.dasm (0.00% of base)
           1 : System.Private.Uri.dasm (0.00% of base)
Top file improvements (bytes):
        -110 : System.Private.CoreLib.dasm (-0.00% of base)
         -32 : System.Diagnostics.EventLog.dasm (-0.04% of base)
         -26 : System.Reflection.Metadata.dasm (-0.01% of base)
         -23 : Microsoft.CodeAnalysis.dasm (-0.00% of base)
         -23 : System.Data.OleDb.dasm (-0.01% of base)
         -19 : System.Private.DataContractSerialization.dasm (-0.00% of base)
         -15 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00% of base)
         -15 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.00% of base)
         -13 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
         -13 : System.Web.HttpUtility.dasm (-0.12% of base)
         -11 : Newtonsoft.Json.Bson.dasm (-0.01% of base)
         -11 : System.Net.Http.dasm (-0.00% of base)
          -9 : ILCompiler.Reflection.ReadyToRun.dasm (-0.01% of base)
          -8 : System.Net.HttpListener.dasm (-0.00% of base)
          -7 : System.Runtime.Serialization.Formatters.dasm (-0.01% of base)
          -6 : System.Net.Mail.dasm (-0.00% of base)
          -6 : System.Net.WebClient.dasm (-0.01% of base)
          -4 : System.Data.Common.dasm (-0.00% of base)
          -4 : System.Data.Odbc.dasm (-0.00% of base)
          -4 : System.Net.NetworkInformation.dasm (-0.01% of base)
29 total files with Code Size differences (27 improved, 2 regressed), 235 unchanged.
Top method regressions (bytes):
          13 ( 4.96% of base) : System.Reflection.Metadata.dasm - InstructionEncoder:Branch(ushort,LabelHandle):this
           4 ( 3.64% of base) : System.Private.CoreLib.dasm - DecCalc:Div96By32(byref,int):int
           3 ( 1.27% of base) : Microsoft.CodeAnalysis.dasm - ILBuilder:WriteOpCode(BlobBuilder,ushort)
           3 ( 2.78% of base) : System.Reflection.Metadata.dasm - InstructionEncoder:OpCode(ushort):this
           2 ( 0.29% of base) : System.Text.Json.dasm - JsonWriterHelper:EscapeNextChars(ushort,Span`1,byref)
           1 ( 1.49% of base) : System.Private.CoreLib.dasm - StandardFormat:.ctor(ushort,ubyte):this
           1 ( 0.67% of base) : System.Private.Uri.dasm - Uri:HexEscape(ushort):String
Top method improvements (bytes):
         -12 (-6.00% of base) : System.Diagnostics.EventLog.dasm - EventLogEntry:get_MachineName():String:this
          -8 (-0.38% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - TraceLog:FastSerialization.IFastSerializable.ToStream(Serializer):this
          -8 (-0.19% of base) : System.Data.OleDb.dasm - OleDbCommandBuilder:DeriveParametersFromStoredProcedure(OleDbConnection,OleDbCommand):ref
          -8 (-5.44% of base) : System.Diagnostics.EventLog.dasm - EventLogEntry:get_Source():String:this
          -8 (-4.49% of base) : System.Net.Http.dasm - MsQuicAddressHelpers:INetToIPEndPoint(SOCKADDR_INET):IPEndPoint
          -8 (-0.51% of base) : System.Net.HttpListener.dasm - HttpListener:AddPrefix(String):this
          -8 (-16.67% of base) : System.Private.CoreLib.dasm - UnmanagedMemoryAccessor:Write(long,ushort):this (2 methods)
          -7 (-1.10% of base) : System.Private.CoreLib.dasm - Utf8Parser:TryParseGuidN(ReadOnlySpan`1,byref,byref):bool
          -7 (-0.72% of base) : System.Private.CoreLib.dasm - Utf8Parser:TryParseGuidCore(ReadOnlySpan`1,byref,byref,int):bool
          -7 (-36.84% of base) : System.Private.CoreLib.dasm - BinaryPrimitives:ReverseEndianness(short):short
          -7 (-23.33% of base) : System.Private.DataContractSerialization.dasm - XmlStreamNodeWriter:WriteBytes(ushort,ushort):this
          -7 (-23.33% of base) : System.Private.DataContractSerialization.dasm - XmlStreamNodeWriter:WriteBytesAsync(ushort,ushort):Task:this
          -7 (-2.01% of base) : System.Web.HttpUtility.dasm - HttpEncoder:UrlEncodeNonAscii(ref,int,int):ref
          -6 (-1.21% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SlidingTextWindow:ScanUnicodeEscape(bool,byref,byref):ushort:this
          -6 (-0.95% of base) : System.Net.Mail.dasm - QEncodedStream:EncodeBytes(ref,int,int):int:this
          -6 (-1.45% of base) : System.Net.WebClient.dasm - WebClient:UrlEncodeBytesToBytesInternal(ref,int,int,bool):ref
          -6 (-30.00% of base) : System.Private.CoreLib.dasm - Char8:op_Explicit(ushort):Char8 (2 methods)
          -6 (-1.96% of base) : System.Private.CoreLib.dasm - WebUtility:GetEncodedBytes(ref,int,int,ref)
          -6 (-1.19% of base) : System.Web.HttpUtility.dasm - HttpEncoder:UrlEncode(ref,int,int):ref
          -5 (-3.09% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SyntaxIdentifierExtended:.ctor(ObjectReader):this
Top method regressions (percentages):
          13 ( 4.96% of base) : System.Reflection.Metadata.dasm - InstructionEncoder:Branch(ushort,LabelHandle):this
           4 ( 3.64% of base) : System.Private.CoreLib.dasm - DecCalc:Div96By32(byref,int):int
           3 ( 2.78% of base) : System.Reflection.Metadata.dasm - InstructionEncoder:OpCode(ushort):this
           1 ( 1.49% of base) : System.Private.CoreLib.dasm - StandardFormat:.ctor(ushort,ubyte):this
           3 ( 1.27% of base) : Microsoft.CodeAnalysis.dasm - ILBuilder:WriteOpCode(BlobBuilder,ushort)
           1 ( 0.67% of base) : System.Private.Uri.dasm - Uri:HexEscape(ushort):String
           2 ( 0.29% of base) : System.Text.Json.dasm - JsonWriterHelper:EscapeNextChars(ushort,Span`1,byref)
Top method improvements (percentages):
          -3 (-37.50% of base) : System.Private.CoreLib.dasm - Char8:op_Explicit(Char8):byte
          -7 (-36.84% of base) : System.Private.CoreLib.dasm - BinaryPrimitives:ReverseEndianness(short):short
          -4 (-36.36% of base) : System.Private.CoreLib.dasm - Char8:op_Explicit(byte):Char8
          -4 (-36.36% of base) : System.Private.CoreLib.dasm - Char8:op_Explicit(short):Char8
          -6 (-30.00% of base) : System.Private.CoreLib.dasm - Char8:op_Explicit(ushort):Char8 (2 methods)
          -7 (-23.33% of base) : System.Private.DataContractSerialization.dasm - XmlStreamNodeWriter:WriteBytes(ushort,ushort):this
          -7 (-23.33% of base) : System.Private.DataContractSerialization.dasm - XmlStreamNodeWriter:WriteBytesAsync(ushort,ushort):Task:this
          -4 (-18.18% of base) : System.Diagnostics.EventLog.dasm - EventLogEntry:CharFrom(ref,int):ushort:this
          -4 (-18.18% of base) : System.Private.CoreLib.dasm - BitConverter:ToChar(ref,int):ushort
          -4 (-18.18% of base) : System.Private.CoreLib.dasm - BitConverter:ToUInt16(ref,int):ushort
          -4 (-18.18% of base) : System.Private.CoreLib.dasm - UnmanagedMemoryAccessor:ReadChar(long):ushort:this
          -4 (-18.18% of base) : System.Private.CoreLib.dasm - UnmanagedMemoryAccessor:ReadUInt16(long):ushort:this
          -4 (-16.67% of base) : System.Private.CoreLib.dasm - Marshal:WriteInt16(long,int,ushort)
          -4 (-16.67% of base) : System.Private.CoreLib.dasm - Marshal:WriteInt16(Object,int,ushort)
          -4 (-16.67% of base) : System.Private.CoreLib.dasm - UnmanagedMemoryAccessor:Write(long,byte):this
          -8 (-16.67% of base) : System.Private.CoreLib.dasm - UnmanagedMemoryAccessor:Write(long,ushort):this (2 methods)
          -4 (-15.38% of base) : System.Private.CoreLib.dasm - Marshal:WriteInt16(long,ushort)
          -3 (-13.64% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceMemberContainerTypeSymbol:get_TypeKind():ubyte:this
          -3 (-13.64% of base) : System.Private.CoreLib.dasm - UnmanagedMemoryAccessor:ReadSByte(long):byte:this
          -3 (-13.64% of base) : System.Private.DataContractSerialization.dasm - XmlStreamNodeWriter:WriteByteAsync(ushort):Task:this
109 total methods with Code Size differences (102 improved, 7 regressed), 187595 unchanged.
```
x86 diff:
```
Total bytes of diff: -1098 (-0.00% of base)
    diff is an improvement.
Top file regressions (bytes):
           1 : System.Private.Uri.dasm (0.00% of base)
Top file improvements (bytes):
        -776 : System.Private.CoreLib.dasm (-0.03% of base)
         -51 : Microsoft.CodeAnalysis.dasm (-0.01% of base)
         -47 : System.Reflection.Metadata.dasm (-0.02% of base)
         -24 : System.Diagnostics.EventLog.dasm (-0.03% of base)
         -20 : System.Diagnostics.PerformanceCounter.dasm (-0.03% of base)
         -18 : System.Data.OleDb.dasm (-0.01% of base)
         -18 : System.Private.DataContractSerialization.dasm (-0.00% of base)
         -15 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
         -14 : System.Data.Common.dasm (-0.00% of base)
         -14 : System.Web.HttpUtility.dasm (-0.16% of base)
         -13 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.00% of base)
         -12 : ILCompiler.Reflection.ReadyToRun.dasm (-0.02% of base)
          -9 : Newtonsoft.Json.Bson.dasm (-0.01% of base)
          -9 : System.Net.Http.dasm (-0.00% of base)
          -6 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00% of base)
          -6 : System.Net.Mail.dasm (-0.00% of base)
          -6 : System.Net.WebClient.dasm (-0.02% of base)
          -6 : System.Runtime.Serialization.Formatters.dasm (-0.01% of base)
          -4 : System.Drawing.Common.dasm (-0.00% of base)
          -4 : System.Net.NetworkInformation.dasm (-0.02% of base)
29 total files with Code Size differences (28 improved, 1 regressed), 235 unchanged.
Top method regressions (bytes):
           8 ( 0.42% of base) : System.Data.Common.dasm - SqlDecimal:MpDiv(ReadOnlySpan`1,int,Span`1,int,Span`1,byref,Span`1,byref)
           7 ( 0.39% of base) : Microsoft.CodeAnalysis.dasm - PeWriter:WriteDirectory(Directory,BlobBuilder,int,int,int,int,BlobBuilder):this
           5 ( 5.75% of base) : System.Reflection.Metadata.dasm - InstructionEncoder:OpCode(ushort):this
           1 ( 0.83% of base) : System.Private.Uri.dasm - Uri:HexEscape(ushort):String
Top method improvements (bytes):
        -129 (-7.95% of base) : System.Private.CoreLib.dasm - TextInfo:ChangeCaseCommon(byref,byref,int):this (3 methods)
         -80 (-44.20% of base) : System.Private.CoreLib.dasm - CastHelpers:IsInstanceOfInterface(int,Object):Object
         -66 (-42.86% of base) : System.Private.CoreLib.dasm - CastHelpers:ChkCastInterface(int,Object):Object
         -50 (-20.41% of base) : System.Private.CoreLib.dasm - Array:Copy(Array,int,Array,int,int)
         -49 (-2.54% of base) : System.Private.CoreLib.dasm - DecCalc:DecAddSub(byref,byref,bool)
         -38 (-2.31% of base) : System.Private.CoreLib.dasm - TextInfo:ChangeCaseCommon(String):String:this (3 methods)
         -33 (-1.48% of base) : System.Private.CoreLib.dasm - Matrix4x4:Decompose(Matrix4x4,byref,byref,byref):bool
         -28 (-3.30% of base) : System.Private.CoreLib.dasm - DecCalc:ScaleResult(int,int,int):int
         -25 (-3.40% of base) : Microsoft.CodeAnalysis.dasm - EnumConstantHelper:OffsetValue(ConstantValue,int,byref):int
         -25 (-3.28% of base) : System.Private.CoreLib.dasm - ASCIIUtility:NarrowUtf16ToAscii_Sse2(int,int,int):int
         -21 (-9.29% of base) : System.Private.CoreLib.dasm - Marshal:UnsafeAddrOfPinnedArrayElement(ref,int):int (4 methods)
         -19 (-10.56% of base) : System.Data.Common.dasm - SqlDecimal:MpDiv1(Span`1,byref,int,byref)
         -18 (-7.44% of base) : System.Reflection.Metadata.dasm - InstructionEncoder:Branch(ushort,int):this
         -16 (-0.82% of base) : System.Private.CoreLib.dasm - Utf8Utility:TranscodeToUtf16(int,int,int,int,byref,byref):int
         -14 (-1.92% of base) : System.Private.CoreLib.dasm - Buffer:BlockCopy(Array,int,Array,int,int)
         -12 (-1.14% of base) : System.Diagnostics.PerformanceCounter.dasm - SharedPerformanceCounter:CreateInstance(int,int,String,int):int:this
         -12 (-0.92% of base) : System.Private.CoreLib.dasm - Utf8Utility:TranscodeToUtf8(int,int,int,int,byref,byref):int
         -11 (-1.54% of base) : System.Private.CoreLib.dasm - SafeBuffer:ReadArray(long,ref,int,int):this
         -10 (-6.76% of base) : System.Private.CoreLib.dasm - Array:Clear(Array,int,int)
          -9 (-5.03% of base) : System.Diagnostics.EventLog.dasm - EventLogEntry:get_MachineName():String:this
Top method regressions (percentages):
           5 ( 5.75% of base) : System.Reflection.Metadata.dasm - InstructionEncoder:OpCode(ushort):this
           1 ( 0.83% of base) : System.Private.Uri.dasm - Uri:HexEscape(ushort):String
           8 ( 0.42% of base) : System.Data.Common.dasm - SqlDecimal:MpDiv(ReadOnlySpan`1,int,Span`1,int,Span`1,byref,Span`1,byref)
           7 ( 0.39% of base) : Microsoft.CodeAnalysis.dasm - PeWriter:WriteDirectory(Directory,BlobBuilder,int,int,int,int,BlobBuilder):this
Top method improvements (percentages):
         -80 (-44.20% of base) : System.Private.CoreLib.dasm - CastHelpers:IsInstanceOfInterface(int,Object):Object
         -66 (-42.86% of base) : System.Private.CoreLib.dasm - CastHelpers:ChkCastInterface(int,Object):Object
          -4 (-36.36% of base) : System.Private.CoreLib.dasm - BigInteger:GetBlock(int):int:this
          -6 (-35.29% of base) : System.Private.CoreLib.dasm - BinaryPrimitives:ReverseEndianness(short):short
          -3 (-30.00% of base) : System.Private.CoreLib.dasm - Char8:op_Explicit(byte):Char8
          -3 (-30.00% of base) : System.Private.CoreLib.dasm - Char8:op_Explicit(short):Char8
          -6 (-30.00% of base) : System.Private.CoreLib.dasm - Char8:op_Explicit(ushort):Char8 (2 methods)
          -3 (-27.27% of base) : System.Private.CoreLib.dasm - Char8:op_Explicit(Char8):byte
          -6 (-25.00% of base) : System.Private.DataContractSerialization.dasm - XmlStreamNodeWriter:WriteBytes(ushort,ushort):this
          -6 (-25.00% of base) : System.Private.DataContractSerialization.dasm - XmlStreamNodeWriter:WriteBytesAsync(ushort,ushort):Task:this
          -3 (-23.08% of base) : System.Private.CoreLib.dasm - BitConverter:ToChar(ref,int):ushort
          -3 (-23.08% of base) : System.Private.CoreLib.dasm - BitConverter:ToUInt16(ref,int):ushort
          -3 (-23.08% of base) : System.Private.DataContractSerialization.dasm - XmlStreamNodeWriter:WriteByteAsync(ushort):Task:this
          -4 (-22.22% of base) : System.Private.CoreLib.dasm - ComInterfaceDispatch:GetInstance(int):__Canon
         -50 (-20.41% of base) : System.Private.CoreLib.dasm - Array:Copy(Array,int,Array,int,int)
          -3 (-18.75% of base) : System.Private.CoreLib.dasm - Marshal:WriteInt16(int,ushort)
          -3 (-16.67% of base) : System.Private.CoreLib.dasm - Marshal:WriteInt16(int,int,ushort)
          -3 (-16.67% of base) : System.Private.CoreLib.dasm - Marshal:WriteInt16(Object,int,ushort)
          -3 (-15.79% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceMemberContainerTypeSymbol:get_TypeKind():ubyte:this
          -3 (-15.79% of base) : System.Private.CoreLib.dasm - Convert:ToSByte(ubyte):byte
160 total methods with Code Size differences (156 improved, 4 regressed), 187441 unchanged.
```
arm64 diff:
```
Total bytes of diff: -968 (-0.00% of base)
    diff is an improvement.
Top file regressions (bytes):
           8 : System.Private.Uri.dasm (0.00% of base)
Top file improvements (bytes):
        -248 : System.Private.CoreLib.dasm (-0.00% of base)
        -144 : Microsoft.CodeAnalysis.dasm (-0.00% of base)
         -64 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.00% of base)
         -64 : System.Diagnostics.EventLog.dasm (-0.02% of base)
         -56 : System.Reflection.Metadata.dasm (-0.01% of base)
         -48 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00% of base)
         -48 : System.Data.OleDb.dasm (-0.01% of base)
         -48 : System.Private.DataContractSerialization.dasm (-0.00% of base)
         -32 : ILCompiler.Reflection.ReadyToRun.dasm (-0.01% of base)
         -32 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
         -32 : System.Web.HttpUtility.dasm (-0.09% of base)
         -24 : Newtonsoft.Json.Bson.dasm (-0.01% of base)
         -24 : System.Data.Common.dasm (-0.00% of base)
         -24 : System.Net.Http.dasm (-0.00% of base)
         -16 : System.Net.Mail.dasm (-0.00% of base)
         -16 : System.Net.WebClient.dasm (-0.01% of base)
         -16 : System.Runtime.Serialization.Formatters.dasm (-0.01% of base)
          -8 : System.Data.Odbc.dasm (-0.00% of base)
          -8 : System.Drawing.Common.dasm (-0.00% of base)
          -8 : System.Management.dasm (-0.00% of base)
23 total files with Code Size differences (22 improved, 1 regressed), 241 unchanged.
Top method regressions (bytes):
          32 ( 2.50% of base) : Microsoft.CodeAnalysis.dasm - ILBuilder:WriteOpCode(BlobBuilder,ushort) (4 methods)
          32 ( 3.15% of base) : System.Reflection.Metadata.dasm - InstructionEncoder:Branch(ushort,LabelHandle):this (2 methods)
           8 ( 2.27% of base) : System.Private.CoreLib.dasm - DecCalc:Div96By32(byref,int):int (2 methods)
           8 ( 1.47% of base) : System.Private.Uri.dasm - Uri:HexEscape(ushort):String (2 methods)
           8 ( 1.96% of base) : System.Reflection.Metadata.dasm - InstructionEncoder:OpCode(ushort):this (2 methods)
Top method improvements (bytes):
         -32 (-0.62% of base) : Microsoft.CodeAnalysis.dasm - EnumConstantHelper:OffsetValue(ConstantValue,int,byref):int (4 methods)
         -24 (-3.23% of base) : System.Diagnostics.EventLog.dasm - EventLogEntry:get_MachineName():String:this (2 methods)
         -16 (-4.55% of base) : Microsoft.CodeAnalysis.CSharp.dasm - NamedTypeSymbol:Microsoft.Cci.ITypeDefinition.get_Alignment():ushort:this (4 methods)
         -16 (-1.47% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SyntaxIdentifierExtended:.ctor(ObjectReader):this (4 methods)
         -16 (-0.42% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SlidingTextWindow:ScanUnicodeEscape(bool,byref,byref):ushort:this (4 methods)
         -16 (-0.39% of base) : Microsoft.CodeAnalysis.dasm - ILBuilder:EmitLoadArgumentOpcode(int):this (4 methods)
         -16 (-0.39% of base) : Microsoft.CodeAnalysis.dasm - ILBuilder:EmitLocalStore(LocalDefinition):this (4 methods)
         -16 (-0.35% of base) : Microsoft.CodeAnalysis.dasm - ILBuilder:EmitLocalLoad(LocalDefinition):this (4 methods)
         -16 (-0.38% of base) : Microsoft.CodeAnalysis.dasm - ILBuilder:EmitIntConstant(int):this (4 methods)
         -16 (-0.61% of base) : Microsoft.CodeAnalysis.dasm - ILBuilder:EmitLocalAddress(LocalDefinition):this (4 methods)
         -16 (-5.56% of base) : Microsoft.CodeAnalysis.dasm - SwitchBlock:get_TotalSize():int:this (4 methods)
         -16 (-0.66% of base) : Microsoft.CodeAnalysis.dasm - ILBuilder:EmitStoreArgumentOpcode(int):this (4 methods)
         -16 (-0.66% of base) : Microsoft.CodeAnalysis.dasm - ILBuilder:EmitLoadArgumentAddrOpcode(int):this (4 methods)
         -16 (-0.15% of base) : Microsoft.CodeAnalysis.dasm - PeWriter:WriteDirectory(Directory,BlobBuilder,int,int,int,int,BlobBuilder):this (4 methods)
         -16 (-2.86% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - _Closure$__:_Lambda$__0-0(VisualBasicSyntaxNode):int:this (4 methods)
         -16 (-11.11% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceMemberContainerTypeSymbol:get_TypeKind():ubyte:this (4 methods)
         -16 (-4.55% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - NamedTypeSymbol:get_ITypeDefinitionAlignment():ushort:this (4 methods)
         -16 (-2.78% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SynthesizedStringSwitchHashMethod:ComputeStringHash(String):int (4 methods)
         -16 (-0.22% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - TraceLog:FastSerialization.IFastSerializable.ToStream(Serializer):this (2 methods)
         -16 (-0.13% of base) : System.Data.OleDb.dasm - OleDbCommandBuilder:DeriveParametersFromStoredProcedure(OleDbConnection,OleDbCommand):ref (2 methods)
Top method regressions (percentages):
          32 ( 3.15% of base) : System.Reflection.Metadata.dasm - InstructionEncoder:Branch(ushort,LabelHandle):this (2 methods)
          32 ( 2.50% of base) : Microsoft.CodeAnalysis.dasm - ILBuilder:WriteOpCode(BlobBuilder,ushort) (4 methods)
           8 ( 2.27% of base) : System.Private.CoreLib.dasm - DecCalc:Div96By32(byref,int):int (2 methods)
           8 ( 1.96% of base) : System.Reflection.Metadata.dasm - InstructionEncoder:OpCode(ushort):this (2 methods)
           8 ( 1.47% of base) : System.Private.Uri.dasm - Uri:HexEscape(ushort):String (2 methods)
Top method improvements (percentages):
         -16 (-22.22% of base) : System.Private.CoreLib.dasm - BinaryPrimitives:ReverseEndianness(short):short (2 methods)
          -8 (-16.67% of base) : System.Private.CoreLib.dasm - Char8:op_Explicit(Char8):byte (2 methods)
          -8 (-14.29% of base) : System.Private.CoreLib.dasm - Char8:op_Explicit(byte):Char8 (2 methods)
          -8 (-14.29% of base) : System.Private.CoreLib.dasm - Char8:op_Explicit(short):Char8 (2 methods)
         -16 (-14.29% of base) : System.Private.CoreLib.dasm - Char8:op_Explicit(ushort):Char8 (4 methods)
         -16 (-14.29% of base) : System.Private.DataContractSerialization.dasm - XmlStreamNodeWriter:WriteBytes(ushort,ushort):this (2 methods)
         -16 (-14.29% of base) : System.Private.DataContractSerialization.dasm - XmlStreamNodeWriter:WriteBytesAsync(ushort,ushort):Task:this (2 methods)
         -16 (-11.11% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceMemberContainerTypeSymbol:get_TypeKind():ubyte:this (4 methods)
          -8 (-9.09% of base) : System.Private.CoreLib.dasm - BinaryWriter:Write(byte):this (2 methods)
          -8 (-8.33% of base) : System.Diagnostics.EventLog.dasm - EventLogEntry:CharFrom(ref,int):ushort:this (2 methods)
          -8 (-8.33% of base) : System.Private.CoreLib.dasm - BitConverter:ToChar(ref,int):ushort (2 methods)
          -8 (-8.33% of base) : System.Private.CoreLib.dasm - BitConverter:ToUInt16(ref,int):ushort (2 methods)
          -8 (-8.33% of base) : System.Private.CoreLib.dasm - Marshal:WriteInt16(long,int,ushort) (2 methods)
          -8 (-8.33% of base) : System.Private.CoreLib.dasm - Marshal:WriteInt16(Object,int,ushort) (2 methods)
          -8 (-8.33% of base) : System.Private.CoreLib.dasm - UnmanagedMemoryAccessor:ReadChar(long):ushort:this (2 methods)
          -8 (-8.33% of base) : System.Private.CoreLib.dasm - UnmanagedMemoryAccessor:ReadSByte(long):byte:this (2 methods)
          -8 (-8.33% of base) : System.Private.CoreLib.dasm - UnmanagedMemoryAccessor:ReadUInt16(long):ushort:this (2 methods)
          -8 (-8.33% of base) : System.Private.CoreLib.dasm - UnmanagedMemoryAccessor:Write(long,byte):this (2 methods)
         -16 (-8.33% of base) : System.Private.CoreLib.dasm - UnmanagedMemoryAccessor:Write(long,ushort):this (4 methods)
          -8 (-8.33% of base) : System.Private.DataContractSerialization.dasm - XmlStreamNodeWriter:WriteByteAsync(ushort):Task:this (2 methods)
99 total methods with Code Size differences (94 improved, 5 regressed), 187088 unchanged.
```
arm32 diff:
```
Total bytes of diff: -1352 (-0.00% of base)
    diff is an improvement.
Top file regressions (bytes):
           4 : System.Net.NetworkInformation.dasm (0.01% of base)
           4 : System.Net.Ping.dasm (0.01% of base)
           4 : System.Net.Primitives.dasm (0.00% of base)
           4 : System.Net.Sockets.dasm (0.00% of base)
           4 : System.Private.Uri.dasm (0.00% of base)
           4 : xunit.execution.dotnet.dasm (0.00% of base)
Top file improvements (bytes):
        -844 : System.Private.CoreLib.dasm (-0.01% of base)
        -152 : Microsoft.CodeAnalysis.dasm (-0.00% of base)
         -72 : System.Diagnostics.PerformanceCounter.dasm (-0.04% of base)
         -40 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.00% of base)
         -32 : System.Diagnostics.EventLog.dasm (-0.02% of base)
         -24 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00% of base)
         -24 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
         -24 : System.Data.OleDb.dasm (-0.00% of base)
         -24 : System.Private.DataContractSerialization.dasm (-0.00% of base)
         -24 : System.Reflection.Metadata.dasm (-0.00% of base)
         -24 : System.Web.HttpUtility.dasm (-0.10% of base)
         -16 : System.Data.Common.dasm (-0.00% of base)
         -12 : Newtonsoft.Json.Bson.dasm (-0.01% of base)
         -12 : System.Net.Http.dasm (-0.00% of base)
          -8 : ILCompiler.Reflection.ReadyToRun.dasm (-0.00% of base)
          -8 : System.Net.Mail.dasm (-0.00% of base)
          -8 : System.Net.WebClient.dasm (-0.01% of base)
          -8 : System.Runtime.Serialization.Formatters.dasm (-0.00% of base)
          -4 : System.Data.Odbc.dasm (-0.00% of base)
          -4 : System.Drawing.Common.dasm (-0.00% of base)
29 total files with Code Size differences (23 improved, 6 regressed), 235 unchanged.
Top method regressions (bytes):
          24 ( 1.55% of base) : System.Private.CoreLib.dasm - TextInfo:ChangeCaseCommon(byref,byref,int):this (4 methods)
          20 ( 3.03% of base) : System.Reflection.Metadata.dasm - InstructionEncoder:Branch(ushort,int):this (2 methods)
          16 ( 2.16% of base) : Microsoft.CodeAnalysis.dasm - ILBuilder:WriteOpCode(BlobBuilder,ushort) (4 methods)
           4 ( 0.24% of base) : ILCompiler.Reflection.ReadyToRun.dasm - DebugInfo:ParseNativeVarInfo(ref,int):this (2 methods)
           4 ( 4.55% of base) : System.Net.NetworkInformation.dasm - ByteOrder:HostToNetworkBytes(ushort,ref,int) (2 methods)
           4 ( 4.55% of base) : System.Net.Ping.dasm - ByteOrder:HostToNetworkBytes(ushort,ref,int) (2 methods)
           4 ( 4.55% of base) : System.Net.Primitives.dasm - ByteOrder:HostToNetworkBytes(ushort,ref,int) (2 methods)
           4 ( 4.55% of base) : System.Net.Sockets.dasm - ByteOrder:HostToNetworkBytes(ushort,ref,int) (2 methods)
           4 ( 1.05% of base) : System.Private.Uri.dasm - Uri:HexEscape(ushort):String (2 methods)
           4 ( 1.61% of base) : System.Reflection.Metadata.dasm - InstructionEncoder:OpCode(ushort):this (2 methods)
           4 ( 4.55% of base) : xunit.execution.dotnet.dasm - Pack:UInt16_To_BE(ushort,ref,int) (2 methods)
Top method improvements (bytes):
        -128 (-6.49% of base) : System.Private.CoreLib.dasm - DecCalc:ScaleResult(int,int,int):int (2 methods)
         -96 (-2.26% of base) : Microsoft.CodeAnalysis.dasm - EnumConstantHelper:OffsetValue(ConstantValue,int,byref):int (4 methods)
         -60 (-18.99% of base) : System.Private.CoreLib.dasm - CastHelpers:ChkCastInterface(int,Object):Object (2 methods)
         -56 (-1.38% of base) : System.Private.CoreLib.dasm - SafeBuffer:WriteArray(long,ref,int,int):this (4 methods)
         -44 (-13.10% of base) : System.Private.CoreLib.dasm - CastHelpers:IsInstanceOfInterface(int,Object):Object (2 methods)
         -36 (-1.18% of base) : System.Private.CoreLib.dasm - DecCalc:DecAddSub(byref,byref,bool) (2 methods)
         -32 (-1.22% of base) : System.Diagnostics.PerformanceCounter.dasm - SharedPerformanceCounter:CreateCategory(int,int,String,int):int:this (2 methods)
         -32 (-1.39% of base) : System.Diagnostics.PerformanceCounter.dasm - SharedPerformanceCounter:CreateInstance(int,int,String,int):int:this (2 methods)
         -32 (-1.01% of base) : System.Private.CoreLib.dasm - Matrix4x4:Decompose(Matrix4x4,byref,byref,byref):bool (2 methods)
         -32 (-1.07% of base) : System.Private.CoreLib.dasm - Utf8Utility:TranscodeToUtf16(int,int,int,int,byref,byref):int (2 methods)
         -32 (-0.79% of base) : System.Private.CoreLib.dasm - SafeBuffer:ReadArray(long,ref,int,int):this (4 methods)
         -24 (-5.00% of base) : System.Private.CoreLib.dasm - Array:Copy(Array,int,Array,int,int) (2 methods)
         -20 (-0.98% of base) : System.Private.CoreLib.dasm - Utf8Utility:TranscodeToUtf8(int,int,int,int,byref,byref):int (2 methods)
         -16 (-8.70% of base) : Microsoft.CodeAnalysis.dasm - SwitchBlock:get_TotalSize():int:this (4 methods)
         -16 (-4.35% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SynthesizedStringSwitchHashMethod:ComputeStringHash(String):int (4 methods)
         -16 (-0.99% of base) : System.Private.CoreLib.dasm - ASCIIUtility:WidenAsciiToUtf16_Sse2(int,int,int):int (2 methods)
         -16 (-20.00% of base) : System.Private.CoreLib.dasm - ComInterfaceDispatch:GetInstance(int):__Canon (4 methods)
         -16 (-2.53% of base) : System.Web.HttpUtility.dasm - HttpEncoder:UrlEncodeNonAscii(ref,int,int):ref (2 methods)
         -12 (-2.29% of base) : System.Diagnostics.EventLog.dasm - EventLogEntry:get_MachineName():String:this (2 methods)
         -12 (-1.96% of base) : System.Private.CoreLib.dasm - Array:Copy(Array,Array,int) (2 methods)
Top method regressions (percentages):
           4 ( 4.55% of base) : System.Net.NetworkInformation.dasm - ByteOrder:HostToNetworkBytes(ushort,ref,int) (2 methods)
           4 ( 4.55% of base) : System.Net.Ping.dasm - ByteOrder:HostToNetworkBytes(ushort,ref,int) (2 methods)
           4 ( 4.55% of base) : System.Net.Primitives.dasm - ByteOrder:HostToNetworkBytes(ushort,ref,int) (2 methods)
           4 ( 4.55% of base) : System.Net.Sockets.dasm - ByteOrder:HostToNetworkBytes(ushort,ref,int) (2 methods)
           4 ( 4.55% of base) : xunit.execution.dotnet.dasm - Pack:UInt16_To_BE(ushort,ref,int) (2 methods)
          20 ( 3.03% of base) : System.Reflection.Metadata.dasm - InstructionEncoder:Branch(ushort,int):this (2 methods)
          16 ( 2.16% of base) : Microsoft.CodeAnalysis.dasm - ILBuilder:WriteOpCode(BlobBuilder,ushort) (4 methods)
           4 ( 1.61% of base) : System.Reflection.Metadata.dasm - InstructionEncoder:OpCode(ushort):this (2 methods)
          24 ( 1.55% of base) : System.Private.CoreLib.dasm - TextInfo:ChangeCaseCommon(byref,byref,int):this (4 methods)
           4 ( 1.05% of base) : System.Private.Uri.dasm - Uri:HexEscape(ushort):String (2 methods)
           4 ( 0.24% of base) : ILCompiler.Reflection.ReadyToRun.dasm - DebugInfo:ParseNativeVarInfo(ref,int):this (2 methods)
Top method improvements (percentages):
          -8 (-25.00% of base) : System.Private.CoreLib.dasm - BigInteger:GetBlock(int):int:this (2 methods)
          -8 (-22.22% of base) : System.Private.CoreLib.dasm - BinaryPrimitives:ReverseEndianness(short):short (2 methods)
          -4 (-20.00% of base) : System.Private.CoreLib.dasm - Char8:op_Explicit(byte):Char8 (2 methods)
          -4 (-20.00% of base) : System.Private.CoreLib.dasm - Char8:op_Explicit(short):Char8 (2 methods)
          -8 (-20.00% of base) : System.Private.CoreLib.dasm - Char8:op_Explicit(ushort):Char8 (4 methods)
         -16 (-20.00% of base) : System.Private.CoreLib.dasm - ComInterfaceDispatch:GetInstance(int):__Canon (4 methods)
         -60 (-18.99% of base) : System.Private.CoreLib.dasm - CastHelpers:ChkCastInterface(int,Object):Object (2 methods)
         -44 (-13.10% of base) : System.Private.CoreLib.dasm - CastHelpers:IsInstanceOfInterface(int,Object):Object (2 methods)
          -8 (-12.50% of base) : System.Private.DataContractSerialization.dasm - XmlStreamNodeWriter:WriteBytes(ushort,ushort):this (2 methods)
          -8 (-12.50% of base) : System.Private.DataContractSerialization.dasm - XmlStreamNodeWriter:WriteBytesAsync(ushort,ushort):Task:this (2 methods)
          -8 (-11.11% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceMemberContainerTypeSymbol:get_TypeKind():ubyte:this (4 methods)
          -4 (-11.11% of base) : System.Private.CoreLib.dasm - Char8:op_Explicit(Char8):byte (2 methods)
         -16 (-8.70% of base) : Microsoft.CodeAnalysis.dasm - SwitchBlock:get_TotalSize():int:this (4 methods)
          -4 (-8.33% of base) : System.Private.CoreLib.dasm - BinaryWriter:Write(byte):this (2 methods)
          -4 (-7.14% of base) : System.Diagnostics.EventLog.dasm - EventLogEntry:CharFrom(ref,int):ushort:this (2 methods)
          -4 (-7.14% of base) : System.Private.CoreLib.dasm - BitConverter:ToChar(ref,int):ushort (2 methods)
          -4 (-7.14% of base) : System.Private.CoreLib.dasm - BitConverter:ToUInt16(ref,int):ushort (2 methods)
          -4 (-7.14% of base) : System.Private.CoreLib.dasm - Marshal:WriteInt16(int,int,ushort) (2 methods)
          -4 (-7.14% of base) : System.Private.CoreLib.dasm - Marshal:WriteInt16(Object,int,ushort) (2 methods)
          -4 (-7.14% of base) : System.Private.DataContractSerialization.dasm - XmlStreamNodeWriter:WriteByteAsync(ushort):Task:this (2 methods)
154 total methods with Code Size differences (143 improved, 11 regressed), 186923 unchanged.
```
Regressions caused by interactions with CSE (removing a cast may cause other equivalent casts no longer being CSEd due to low profitability) and/or LSRA (different register choices affecting encoding or non contained zero constants causing spilling of other registers).