### PR TITLE
A few cast improvements

### DIFF
--- a/src/coreclr/src/jit/codegen.h
+++ b/src/coreclr/src/jit/codegen.h
@@ -64,6 +64,7 @@ private:
 
     // Bit mask used in U8 -> double conversion to adjust the result.
     CORINFO_FIELD_HANDLE u8ToDblBitmask;
+    CORINFO_FIELD_HANDLE u8ToFltBitmask;
 
     // Generates SSE2 code for the given tree as "Operand BitWiseOp BitMask"
     void genSSE2BitwiseOp(GenTree* treeNode);

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -95,16 +95,17 @@ CodeGenInterface::CodeGenInterface(Compiler* theCompiler)
 
 /*****************************************************************************/
 
-CodeGen::CodeGen(Compiler* theCompiler) : CodeGenInterface(theCompiler)
-{
+CodeGen::CodeGen(Compiler* theCompiler)
+    : CodeGenInterface(theCompiler)
 #if defined(TARGET_XARCH)
-    negBitmaskFlt  = nullptr;
-    negBitmaskDbl  = nullptr;
-    absBitmaskFlt  = nullptr;
-    absBitmaskDbl  = nullptr;
-    u8ToDblBitmask = nullptr;
-#endif // defined(TARGET_XARCH)
-
+    , negBitmaskFlt(nullptr)
+    , negBitmaskDbl(nullptr)
+    , absBitmaskFlt(nullptr)
+    , absBitmaskDbl(nullptr)
+    , u8ToDblBitmask(nullptr)
+    , u8ToFltBitmask(nullptr)
+#endif
+{
 #if defined(FEATURE_PUT_STRUCT_ARG_STK) && !defined(TARGET_X86)
     m_stkArgVarNum = BAD_VAR_NUM;
 #endif

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -409,7 +409,7 @@ struct GenTree
 
     void SetType(var_types type)
     {
-        assert((TYP_UNDEF < type) && (type < TYP_UNKNOWN));
+        assert(((TYP_UNDEF < type) && (type < TYP_UNKNOWN)) && (type != TYP_UINT) && (type != TYP_ULONG));
         gtType = type;
     }
 

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -6117,3 +6117,67 @@ GenTree* Lowering::LowerBitCast(GenTreeUnOp* bitcast)
 
     return next;
 }
+
+//------------------------------------------------------------------------
+// LowerCast: Lower GT_CAST nodes.
+//
+// Arguments:
+//    cast - GT_CAST node to be lowered
+//
+// Return Value:
+//    The next node to lower.
+//
+GenTree* Lowering::LowerCast(GenTreeCast* cast)
+{
+    GenTree*  src     = cast->GetOp(0);
+    var_types dstType = cast->GetCastType();
+    var_types srcType = src->GetType();
+
+    if (!cast->gtOverflow() && varTypeIsIntegral(dstType) && varTypeIsIntegral(srcType) &&
+#ifndef TARGET_64BIT
+        (srcType != TYP_LONG) &&
+#endif
+        (varTypeSize(dstType) <= varTypeSize(srcType)) && IsContainableMemoryOp(src))
+    {
+        // This is a narrowing cast with an in memory load source, we can remove it and retype the load.
+
+        // TODO-MIKE-Cleanup: fgMorphCast does something similar but more restrictive. It's not clear
+        // if there are any advantages in doing such a transform earlier (in fact there may be one
+        // disatvantage - retyping nodes may prevent them from being CSEd) so it should be deleted.
+
+        if (dstType == TYP_UINT)
+        {
+            dstType = TYP_INT;
+        }
+        else if (dstType == TYP_ULONG)
+        {
+            dstType = TYP_LONG;
+        }
+
+        if (src->OperIs(GT_LCL_VAR))
+        {
+            src->ChangeOper(GT_LCL_FLD);
+        }
+
+        src->SetType(dstType);
+
+        LIR::Use use;
+
+        if (BlockRange().TryGetUse(cast, &use))
+        {
+            use.ReplaceWith(comp, src);
+        }
+        else
+        {
+            src->SetUnusedValue();
+        }
+
+        GenTree* next = cast->gtNext;
+        BlockRange().Remove(cast);
+        return next;
+    }
+
+    ContainCheckCast(cast);
+
+    return cast->gtNext;
+}

--- a/src/coreclr/src/jit/lowerarmarch.cpp
+++ b/src/coreclr/src/jit/lowerarmarch.cpp
@@ -405,22 +405,6 @@ void Lowering::ContainBlockStoreAddress(GenTreeBlk* blkNode, unsigned size, GenT
 }
 
 //------------------------------------------------------------------------
-// LowerCast: Lower GT_CAST nodes.
-//
-// Arguments:
-//    cast - GT_CAST node to be lowered
-//
-// Return Value:
-//    The next node to lower.
-//
-GenTree* Lowering::LowerCast(GenTreeCast* cast)
-{
-    ContainCheckCast(cast);
-
-    return cast->gtNext;
-}
-
-//------------------------------------------------------------------------
 // LowerRotate: Lower GT_ROL and GT_ROR nodes.
 //
 // Arguments:

--- a/src/coreclr/src/jit/lowerxarch.cpp
+++ b/src/coreclr/src/jit/lowerxarch.cpp
@@ -563,22 +563,6 @@ void Lowering::LowerPutArgStk(GenTreePutArgStk* putArgStk)
 #endif // FEATURE_PUT_STRUCT_ARG_STK
 }
 
-//------------------------------------------------------------------------
-// LowerCast: Lower GT_CAST nodes.
-//
-// Arguments:
-//    cast - GT_CAST node to be lowered
-//
-// Return Value:
-//    The next node to lower.
-//
-GenTree* Lowering::LowerCast(GenTreeCast* cast)
-{
-    ContainCheckCast(cast);
-
-    return cast->gtNext;
-}
-
 #ifdef FEATURE_SIMD
 //----------------------------------------------------------------------------------------------
 // Lowering::LowerSIMD: Perform containment analysis for a SIMD intrinsic node.

--- a/src/coreclr/src/jit/lowerxarch.cpp
+++ b/src/coreclr/src/jit/lowerxarch.cpp
@@ -2954,8 +2954,8 @@ void Lowering::ContainCheckCast(GenTreeCast* cast)
         // The source of cvtsi2sd and similar instructions can be a memory operand but it must
         // be 4 or 8 bytes in size so it cannot be a small int. It's likely possible to make a
         // "normalize on store" local reg-optional but it's probably not worth the extra work.
-        // Also, ULONG to DOUBLE casts require checking the sign of the source so allowing a
-        // memory operand would result in 2 loads instead of 1.
+        // Also, ULONG to DOUBLE/FLOAT casts require checking the sign of the source so allowing
+        // a memory operand would result in 2 loads instead of 1.
         if (!varTypeIsSmall(srcType) && ((srcType != TYP_LONG) || !cast->IsUnsigned()))
         {
             if (IsContainableMemoryOp(src))

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -173,12 +173,6 @@ GenTree* Compiler::fgMorphCast(GenTreeCast* cast)
         src->gtFlags |= (cast->gtFlags & (GTF_OVERFLOW | GTF_EXCEPT));
         cast->SetOp(0, src);
         srcType = TYP_INT;
-
-        // TODO-MIKE-CQ: This should not be needed. It's only meaningfull for overflow
-        // checking casts from LONG and in that case removing it makes the INT to small
-        // int cast check for negative values, something that the ULONG to INT cast
-        // already does.
-        cast->gtFlags &= ~GTF_UNSIGNED;
     }
 
     if (varTypeIsFloating(srcType) && varTypeIsIntegral(dstType))

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -253,30 +253,16 @@ GenTree* Compiler::fgMorphCast(GenTreeCast* cast)
         if (cast->IsUnsigned())
         {
             // X64 doesn't have any instruction to cast FP types to unsigned types
-            // but codegen handles the ULONG to DOUBLE case by adjusting the result
-            // of a LONG to DOUBLE cast. For all other cases we need to introduce
-            // additional casts:
-            //   - UINT  to DOUBLE => UINT  to LONG   to DOUBLE
-            //   - UINT  to FLOAT  => UINT  to LONG   to FLOAT
-            //   - ULONG to FLOAT  => ULONG to DOUBLE to FLOAT
-
-            var_types newSrcType = TYP_UNDEF;
+            // but codegen handles the ULONG to DOUBLE/FLOAT case by adjusting the
+            // result of a ULONG to DOUBLE/FLOAT cast. For UINT to DOUBLE/FLOAT we
+            // need to first cast the source to LONG.
 
             if (srcType == TYP_INT)
             {
-                newSrcType = TYP_LONG;
-            }
-            else if ((srcType == TYP_LONG) && (dstType == TYP_FLOAT))
-            {
-                newSrcType = TYP_DOUBLE;
-            }
-
-            if (newSrcType != TYP_UNDEF)
-            {
-                src = gtNewCastNode(newSrcType, src, true, newSrcType);
+                src = gtNewCastNode(TYP_LONG, src, true, TYP_LONG);
                 cast->SetOp(0, src);
                 cast->gtFlags &= ~GTF_UNSIGNED;
-                srcType = newSrcType;
+                srcType = TYP_LONG;
             }
         }
 #elif defined(TARGET_X86)


### PR DESCRIPTION
x64:
```
Total bytes of diff: -583 (-0.00% of base)
    diff is an improvement.
Top file improvements (bytes):
         -66 : System.Private.Uri.dasm (-0.08% of base)
         -65 : System.Security.Cryptography.Pkcs.dasm (-0.02% of base)
         -56 : System.Security.Cryptography.Algorithms.dasm (-0.02% of base)
         -56 : System.Security.Cryptography.Cng.dasm (-0.03% of base)
         -50 : System.Reflection.Metadata.dasm (-0.02% of base)
         -46 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00% of base)
         -35 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.00% of base)
         -29 : System.Security.Cryptography.X509Certificates.dasm (-0.02% of base)
         -24 : System.Text.RegularExpressions.dasm (-0.01% of base)
         -23 : System.Private.CoreLib.dasm (-0.00% of base)
         -19 : System.Data.Common.dasm (-0.00% of base)
         -18 : System.Drawing.Primitives.dasm (-0.05% of base)
         -16 : Microsoft.VisualBasic.Core.dasm (-0.00% of base)
         -12 : System.Linq.Expressions.dasm (-0.00% of base)
          -9 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
          -8 : System.Data.Odbc.dasm (-0.00% of base)
          -8 : System.Diagnostics.PerformanceCounter.dasm (-0.01% of base)
          -8 : System.Management.dasm (-0.00% of base)
          -8 : System.Security.AccessControl.dasm (-0.01% of base)
          -7 : System.Text.Json.dasm (-0.00% of base)
28 total files with Code Size differences (28 improved, 0 regressed), 236 unchanged.
Top method regressions (bytes):
           8 ( 0.54% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DocumentationCommentCrefBinder:BindInsideCrefAttributeValue(CrefReferenceSyntax,bool,DiagnosticBag,byref):ImmutableArray`1:this
           3 ( 0.12% of base) : System.Private.Uri.dasm - Uri:CheckAuthorityHelper(long,int,int,byref,byref,UriParser,byref):int:this
Top method improvements (bytes):
         -33 (-0.28% of base) : System.Reflection.Metadata.dasm - MetadataReader:InitializeTableReaders(MemoryBlock,ubyte,ref,ref):this
         -26 (-0.55% of base) : System.Private.Uri.dasm - Uri:ReCreateParts(int,ushort,int):String:this
         -18 (-0.92% of base) : System.Security.Cryptography.Algorithms.dasm - AsnValueReader:ProcessConstructedBitString(ReadOnlySpan`1,Span`1,BitStringCopyAction,bool,byref,byref):int:this
         -18 (-1.01% of base) : System.Security.Cryptography.Algorithms.dasm - AsnValueReader:CopyConstructedOctetString(ReadOnlySpan`1,Span`1,bool,bool,byref):int:this
         -18 (-0.92% of base) : System.Security.Cryptography.Cng.dasm - AsnValueReader:ProcessConstructedBitString(ReadOnlySpan`1,Span`1,BitStringCopyAction,bool,byref,byref):int:this
         -18 (-1.01% of base) : System.Security.Cryptography.Cng.dasm - AsnValueReader:CopyConstructedOctetString(ReadOnlySpan`1,Span`1,bool,bool,byref):int:this
         -18 (-0.93% of base) : System.Security.Cryptography.Pkcs.dasm - AsnValueReader:ProcessConstructedBitString(ReadOnlySpan`1,Span`1,BitStringCopyAction,bool,byref,byref):int:this
         -18 (-1.01% of base) : System.Security.Cryptography.Pkcs.dasm - AsnValueReader:CopyConstructedOctetString(ReadOnlySpan`1,Span`1,bool,bool,byref):int:this
         -16 (-0.85% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Parser:ParseDeclarationStatementInternal():StatementSyntax:this
         -16 (-1.28% of base) : Microsoft.VisualBasic.Core.dasm - Conversions:ToSingle(Object,NumberFormatInfo):float
         -16 (-1.49% of base) : System.Text.RegularExpressions.dasm - RegexCharClass:Canonicalize():this
         -15 (-3.60% of base) : System.Security.Cryptography.X509Certificates.dasm - Helpers:ValidateDer(ReadOnlyMemory`1)
         -12 (-1.13% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Lexer:ScanIdentifier_CrefSlowPath(byref):bool:this
         -12 (-0.89% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Lexer:ScanXmlEntity(byref):this
         -12 (-2.82% of base) : System.Drawing.Primitives.dasm - ColorConverterCommon:PossibleKnownColor(Color):Color
          -9 (-0.82% of base) : System.Private.Uri.dasm - Uri:GetLocalPath():String:this
          -8 (-0.20% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:DoUncheckedConversion(byte,ConstantValue):Object
          -8 (-0.36% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Parser:ParseStatementInMethodBodyCore():StatementSyntax:this
          -8 (-0.46% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - TdhEventParser:ParseFields(int,int):PayloadFetchClassInfo:this
          -8 (-0.66% of base) : System.Data.Common.dasm - SqlConvert:ConvertToSqlSingle(Object):SqlSingle
Top method regressions (percentages):
           8 ( 0.54% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DocumentationCommentCrefBinder:BindInsideCrefAttributeValue(CrefReferenceSyntax,bool,DiagnosticBag,byref):ImmutableArray`1:this
           3 ( 0.12% of base) : System.Private.Uri.dasm - Uri:CheckAuthorityHelper(long,int,int,byref,byref,UriParser,byref):int:this
Top method improvements (percentages):
          -4 (-26.67% of base) : System.Private.CoreLib.dasm - UInt32:System.IConvertible.ToSingle(IFormatProvider):float:this
          -4 (-17.39% of base) : System.Private.CoreLib.dasm - Convert:ToSingle(int):float (2 methods)
          -4 (-13.79% of base) : System.Private.CoreLib.dasm - UInt64:System.IConvertible.ToSingle(IFormatProvider):float:this
          -4 (-11.43% of base) : System.Private.CoreLib.dasm - Convert:ToSingle(long):float (2 methods)
          -8 (-8.08% of base) : System.Diagnostics.PerformanceCounter.dasm - CounterSampleCalculator:GetElapsedTime(CounterSample,CounterSample):float
          -3 (-4.62% of base) : System.Text.Json.dasm - BitStack:Pop():bool:this
          -1 (-3.85% of base) : System.Private.Uri.dasm - Uri:EnsureParseRemaining():this
         -15 (-3.60% of base) : System.Security.Cryptography.X509Certificates.dasm - Helpers:ValidateDer(ReadOnlyMemory`1)
          -3 (-2.86% of base) : System.Data.Common.dasm - SByteStorage:Compare(int,int):int:this
         -12 (-2.82% of base) : System.Drawing.Primitives.dasm - ColorConverterCommon:PossibleKnownColor(Color):Color
          -2 (-2.82% of base) : System.Private.Uri.dasm - Uri:EnsureHostString(bool):this
          -4 (-2.48% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Parser:IsContinuableQueryOperator(SyntaxToken):bool:this
          -4 (-2.05% of base) : System.Text.Json.dasm - Utf8JsonWriter:ValidateEnd(ubyte):this
          -3 (-1.97% of base) : System.Data.Common.dasm - SByteStorage:CompareValueTo(int,Object):int:this
          -4 (-1.82% of base) : System.Text.RegularExpressions.dasm - RegexCharClass:AddLowercase(CultureInfo):this
          -3 (-1.64% of base) : System.Security.Cryptography.Pkcs.dasm - AsnValueReader:ReadNull(Asn1Tag):this
          -3 (-1.49% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Lexer:AdvanceIfMatches(ushort):bool:this
         -16 (-1.49% of base) : System.Text.RegularExpressions.dasm - RegexCharClass:Canonicalize():this
          -2 (-1.32% of base) : System.Data.Odbc.dasm - OdbcDataReader:FirstResult():this
          -2 (-1.32% of base) : System.Data.Common.dasm - Int16Storage:CompareValueTo(int,Object):int:this
118 total methods with Code Size differences (116 improved, 2 regressed), 187586 unchanged.
```

x86:
```
Total bytes of diff: -4106 (-0.02% of base)
    diff is an improvement.
Top file regressions (bytes):
           3 : System.Threading.dasm (0.02% of base)
Top file improvements (bytes):
       -1383 : System.Private.CoreLib.dasm (-0.05% of base)
        -343 : System.Private.Xml.dasm (-0.01% of base)
        -218 : System.Private.Uri.dasm (-0.30% of base)
        -159 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.01% of base)
        -157 : System.Data.Common.dasm (-0.02% of base)
        -150 : System.Text.Json.dasm (-0.04% of base)
        -145 : System.Diagnostics.PerformanceCounter.dasm (-0.24% of base)
         -99 : System.Management.dasm (-0.04% of base)
         -97 : System.Drawing.Primitives.dasm (-0.31% of base)
         -67 : System.Security.Principal.Windows.dasm (-0.22% of base)
         -66 : Microsoft.CodeAnalysis.dasm (-0.01% of base)
         -63 : Microsoft.VisualBasic.Core.dasm (-0.02% of base)
         -60 : Newtonsoft.Json.dasm (-0.01% of base)
         -56 : System.Private.DataContractSerialization.dasm (-0.01% of base)
         -55 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.00% of base)
         -53 : System.Resources.Extensions.dasm (-0.20% of base)
         -52 : System.Reflection.Metadata.dasm (-0.02% of base)
         -51 : System.Linq.Expressions.dasm (-0.00% of base)
         -50 : Newtonsoft.Json.Bson.dasm (-0.08% of base)
         -48 : System.IO.MemoryMappedFiles.dasm (-0.47% of base)
73 total files with Code Size differences (72 improved, 1 regressed), 191 unchanged.
Top method regressions (bytes):
          43 ( 2.29% of base) : System.Private.CoreLib.dasm - DecCalc:DecAddSub(byref,byref,bool)
           9 ( 4.71% of base) : System.Reflection.Metadata.dasm - MetadataReader:ComputeCodedTokenSize(int,ref,long):int:this
           4 ( 0.37% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DocumentationCommentCrefBinder:BindInsideCrefAttributeValue(CrefReferenceSyntax,bool,DiagnosticBag,byref):ImmutableArray`1:this
           3 ( 0.48% of base) : System.Threading.dasm - Barrier:AddParticipants(int):long:this
           2 ( 0.16% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SourceAssemblySymbol:GetUnusedFieldWarnings(CancellationToken):ImmutableArray`1:this
           2 ( 0.58% of base) : Microsoft.CodeAnalysis.CSharp.dasm - PENamedTypeSymbol:Create(PEModuleSymbol,PENamedTypeSymbol,int):PENamedTypeSymbol
           2 ( 0.28% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ClsComplianceChecker:VisitAssembly(AssemblySymbol):this
           2 ( 0.03% of base) : System.Text.Json.dasm - ObjectWithParameterizedConstructorConverter`1:OnTryRead(byref,Type,JsonSerializerOptions,byref,byref):bool:this
           1 ( 0.24% of base) : System.IO.MemoryMappedFiles.dasm - MemoryMappedFile:CreateOrOpenCore(String,int,int,int,long):SafeMemoryMappedFileHandle
           1 ( 0.22% of base) : System.Net.Http.dasm - Http2Connection:ProcessAltSvcFrame(FrameHeader):this
Top method improvements (bytes):
        -133 (-4.15% of base) : System.Private.Uri.dasm - Uri:CheckAuthorityHelper(int,int,int,byref,byref,UriParser,byref):int:this
         -91 (-9.71% of base) : System.Private.Xml.dasm - BigNumber:Mul(byref):this
         -78 (-16.96% of base) : System.Private.CoreLib.dasm - BinaryWriter:Write(long):this (2 methods)
         -72 (-1.32% of base) : System.Text.Json.dasm - ObjectWithParameterizedConstructorConverter`1:ReadConstructorArguments(byref,byref,JsonSerializerOptions):this
         -50 (-21.55% of base) : Newtonsoft.Json.Bson.dasm - AsyncBinaryWriter:WriteAsync(long,CancellationToken):Task:this
         -47 (-2.62% of base) : System.Security.Principal.Windows.dasm - IdentityReferenceCollection:Translate(Type,bool):IdentityReferenceCollection:this
         -46 (-5.78% of base) : Newtonsoft.Json.dasm - JavaScriptUtils:TryGetDateFromConstructorJson(JsonReader,byref,byref):bool
         -44 (-2.18% of base) : System.Resources.Extensions.dasm - PreserializedResourceWriter:Generate():this
         -44 (-2.19% of base) : System.Resources.Writer.dasm - ResourceWriter:Generate():this
         -38 (-1.98% of base) : System.Data.Common.dasm - SqlDecimal:MpDiv(ReadOnlySpan`1,int,Span`1,int,Span`1,byref,Span`1,byref)
         -38 (-0.68% of base) : System.Text.Json.dasm - ObjectDefaultConverter`1:OnTryRead(byref,Type,JsonSerializerOptions,byref,byref):bool:this
         -37 (-4.19% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - CtfInteger:Read(ref,int):Object:this
         -33 (-15.49% of base) : System.Private.CoreLib.dasm - BinaryWriter:Write(double):this
         -33 (-7.71% of base) : System.Private.CoreLib.dasm - Sha1ForNonSecretPurposes:Finish(ref):this
         -29 (-2.66% of base) : System.Private.Uri.dasm - Uri:InternalIsWellFormedOriginalString():bool:this
         -28 (-4.89% of base) : System.Linq.Expressions.dasm - Checked:ConvertUInt64(long):Object:this
         -28 (-0.88% of base) : System.Private.CoreLib.dasm - DecCalc:VarDecDiv(byref,byref)
         -27 (-5.01% of base) : System.Private.Xml.dasm - XsdDuration:.ctor(TimeSpan,int):this
         -24 (-1.57% of base) : Microsoft.VisualBasic.Core.dasm - Conversions:ToShort(Object):short
         -24 (-1.28% of base) : System.Text.Json.dasm - ObjectWithParameterizedConstructorConverter`1:TryLookupConstructorParameter(byref,byref,JsonSerializerOptions,byref):bool:this
Top method regressions (percentages):
           9 ( 4.71% of base) : System.Reflection.Metadata.dasm - MetadataReader:ComputeCodedTokenSize(int,ref,long):int:this
          43 ( 2.29% of base) : System.Private.CoreLib.dasm - DecCalc:DecAddSub(byref,byref,bool)
           2 ( 0.58% of base) : Microsoft.CodeAnalysis.CSharp.dasm - PENamedTypeSymbol:Create(PEModuleSymbol,PENamedTypeSymbol,int):PENamedTypeSymbol
           3 ( 0.48% of base) : System.Threading.dasm - Barrier:AddParticipants(int):long:this
           4 ( 0.37% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DocumentationCommentCrefBinder:BindInsideCrefAttributeValue(CrefReferenceSyntax,bool,DiagnosticBag,byref):ImmutableArray`1:this
           2 ( 0.28% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ClsComplianceChecker:VisitAssembly(AssemblySymbol):this
           1 ( 0.24% of base) : System.IO.MemoryMappedFiles.dasm - MemoryMappedFile:CreateOrOpenCore(String,int,int,int,long):SafeMemoryMappedFileHandle
           1 ( 0.22% of base) : System.Net.Http.dasm - Http2Connection:ProcessAltSvcFrame(FrameHeader):this
           2 ( 0.16% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SourceAssemblySymbol:GetUnusedFieldWarnings(CancellationToken):ImmutableArray`1:this
           2 ( 0.03% of base) : System.Text.Json.dasm - ObjectWithParameterizedConstructorConverter`1:OnTryRead(byref,Type,JsonSerializerOptions,byref,byref):bool:this
Top method improvements (percentages):
          -4 (-40.00% of base) : System.Private.CoreLib.dasm - UInt64:GetHashCode():int:this
          -4 (-40.00% of base) : System.Private.CoreLib.dasm - EventRegistrationToken:GetHashCode():int:this
          -5 (-38.46% of base) : System.Private.CoreLib.dasm - Int64:GetHashCode():int:this
          -5 (-38.46% of base) : System.Private.CoreLib.dasm - TimeSpan:GetHashCode():int:this
          -9 (-33.33% of base) : System.IO.MemoryMappedFiles.dasm - Interop:SplitLong(long,byref,byref)
          -9 (-29.03% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:GetHashCode(long):int:this (2 methods)
          -6 (-28.57% of base) : System.Data.Common.dasm - SqlInt32:SameSignInt(int,int):bool
          -3 (-27.27% of base) : System.Private.CoreLib.dasm - Char8:op_Implicit(Char8):short
          -5 (-25.00% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - IMAGE_RESOURCE_DIRECTORY_ENTRY:get_IsLeaf():bool:this
         -10 (-25.00% of base) : System.Private.CoreLib.dasm - UInt32:System.IConvertible.ToSingle(IFormatProvider):float:this
          -2 (-25.00% of base) : System.Private.Xml.dasm - Location:get_Line():int:this
         -10 (-23.81% of base) : System.Private.CoreLib.dasm - UInt64:System.IConvertible.ToSingle(IFormatProvider):float:this
          -5 (-22.73% of base) : System.Private.CoreLib.dasm - DateTime:GetHashCode():int:this
          -2 (-22.22% of base) : System.Data.Common.dasm - SqlDecimal:HI(long):int
          -9 (-21.95% of base) : System.Private.CoreLib.dasm - Math:Sign(long):int
         -50 (-21.55% of base) : Newtonsoft.Json.Bson.dasm - AsyncBinaryWriter:WriteAsync(long,CancellationToken):Task:this
          -9 (-20.93% of base) : System.DirectoryServices.dasm - AdsValueHelper:set_LowInt64(long):this
         -10 (-20.83% of base) : System.Private.CoreLib.dasm - CancellationTokenRegistration:GetHashCode():int:this
          -5 (-20.00% of base) : System.Console.dasm - Win32Marshal:MakeHRFromErrorCode(int):int
          -6 (-20.00% of base) : System.Drawing.Primitives.dasm - Color:get_B():ubyte:this
621 total methods with Code Size differences (611 improved, 10 regressed), 186980 unchanged.
```
arm64:
```
Total bytes of diff: -42256 (-0.04% of base)
    diff is an improvement.
Top file improvements (bytes):
       -6976 : System.Private.CoreLib.dasm (-0.06% of base)
       -3128 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.02% of base)
       -2744 : System.Threading.Tasks.Dataflow.dasm (-0.43% of base)
       -1744 : Microsoft.CodeAnalysis.CSharp.dasm (-0.01% of base)
       -1568 : Microsoft.CodeAnalysis.dasm (-0.03% of base)
       -1520 : System.Data.OleDb.dasm (-0.16% of base)
       -1432 : System.Net.Http.dasm (-0.08% of base)
       -1000 : System.Diagnostics.TraceSource.dasm (-0.75% of base)
        -920 : System.Data.Odbc.dasm (-0.15% of base)
        -832 : System.Transactions.Local.dasm (-0.24% of base)
        -784 : xunit.runner.utility.netcoreapp10.dasm (-0.15% of base)
        -768 : Newtonsoft.Json.dasm (-0.04% of base)
        -736 : System.Linq.Parallel.dasm (-0.05% of base)
        -712 : System.Private.Xml.dasm (-0.01% of base)
        -688 : System.Collections.NonGeneric.dasm (-0.75% of base)
        -672 : System.ComponentModel.TypeConverter.dasm (-0.08% of base)
        -656 : System.DirectoryServices.AccountManagement.dasm (-0.07% of base)
        -632 : System.Private.DataContractSerialization.dasm (-0.03% of base)
        -608 : System.Diagnostics.PerformanceCounter.dasm (-0.24% of base)
        -584 : System.Diagnostics.EventLog.dasm (-0.20% of base)
115 total files with Code Size differences (115 improved, 0 regressed), 149 unchanged.
Top method improvements (bytes):
        -208 (-5.12% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Conversions:ClassifyReferenceConversion(TypeSymbol,TypeSymbol,int,byref):int (4 methods)
        -176 (-2.43% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Conversions:ClassifyConversionFromTypeParameter(TypeParameterSymbol,TypeSymbol,byref,int,byref):int (4 methods)
        -112 (-2.06% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Conversions:ClassifyConversionToTypeParameter(TypeSymbol,TypeParameterSymbol,int,byref):int (4 methods)
         -96 (-1.07% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Lexer:ScanXmlEntity(byref):this (4 methods)
         -96 (-1.35% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceMemberContainerTypeSymbol:CheckForOverloadOverridesShadowsClashesInSameType(MembersAndInitializers,DiagnosticBag):this (4 methods)
         -96 (-0.65% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceNamedTypeSymbol:EarlyDecodeWellKnownAttribute(byref):VisualBasicAttributeData:this (4 methods)
         -96 (-0.55% of base) : System.Linq.Parallel.dasm - TakeOrSkipWhileQueryOperatorEnumerator`1:MoveNext(byref,byref):bool:this (6 methods)
         -80 (-1.67% of base) : System.Configuration.ConfigurationManager.dasm - BaseConfigurationRecord:Evaluate(FactoryRecord,SectionRecord,Object,bool,bool,byref,byref):bool:this (2 methods)
         -80 (-1.81% of base) : System.Net.Primitives.dasm - CookieContainer:Add(Cookie,bool):this (2 methods)
         -80 (-1.06% of base) : System.Net.Primitives.dasm - CookieContainer:AgeCookies(String):bool:this (2 methods)
         -80 (-1.74% of base) : System.Runtime.Caching.dasm - ExpiresBucket:FlushExpiredItems(DateTime,bool):int:this (2 methods)
         -80 (-2.29% of base) : System.Threading.Tasks.Dataflow.dasm - JoinBlockTarget`1:ConsumeOnePostponedMessage():bool:this (4 methods)
         -72 (-2.78% of base) : System.Linq.Parallel.dasm - QuerySettings:Merge(QuerySettings):QuerySettings:this (2 methods)
         -72 (-1.45% of base) : System.Threading.Tasks.Dataflow.dasm - BatchBlockTargetCore:RetrievePostponedItemsNonGreedy(bool):this (2 methods)
         -72 (-0.93% of base) : xunit.execution.dotnet.dasm - XunitSerializationInfo:Serialize(Object):String (2 methods)
         -72 (-0.95% of base) : xunit.runner.utility.netcoreapp10.dasm - XunitSerializationInfo:Serialize(Object):String (2 methods)
         -64 (-0.39% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:MakeDecimalLiteral(CSharpSyntaxNode,ConstantValue):BoundExpression:this (4 methods)
         -64 (-1.30% of base) : Microsoft.CodeAnalysis.dasm - CommonReferenceManager`2:GetMetadata(PortableExecutableReference,CommonMessageProvider,Location,DiagnosticBag):Metadata:this (4 methods)
         -64 (-2.55% of base) : Microsoft.CodeAnalysis.dasm - CompilationData:GetOrCreateCachedSemanticModel(SyntaxTree,Compilation,CancellationToken):SemanticModel:this (4 methods)
         -64 (-0.71% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Parser:ParseLambda(bool):ExpressionSyntax:this (4 methods)
Top method improvements (percentages):
          -8 (-14.29% of base) : System.Private.CoreLib.dasm - UInt32:System.IConvertible.ToSingle(IFormatProvider):float:this (2 methods)
          -8 (-14.29% of base) : System.Private.CoreLib.dasm - UInt64:System.IConvertible.ToSingle(IFormatProvider):float:this (2 methods)
         -24 (-11.11% of base) : Newtonsoft.Json.dasm - JsonSerializerInternalWriter:ResolveIsReference(JsonContract,JsonProperty,JsonContainerContract,JsonProperty):Nullable`1:this (2 methods)
          -8 (-9.09% of base) : System.Net.HttpListener.dasm - HttpResponseStreamAsyncResult:get_dataChunkCount():ushort:this (2 methods)
          -8 (-9.09% of base) : System.Private.CoreLib.dasm - Convert:ToSingle(int):float (4 methods)
          -8 (-9.09% of base) : System.Private.CoreLib.dasm - Convert:ToSingle(long):float (4 methods)
         -16 (-7.69% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CSharpAttributeData:Microsoft.Cci.ICustomAttribute.get_NamedArgumentCount():ushort:this (4 methods)
         -16 (-7.69% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VisualBasicAttributeData:get_NamedArgumentCount():ushort:this (4 methods)
         -16 (-7.41% of base) : System.Diagnostics.PerformanceCounter.dasm - CounterSampleCalculator:GetElapsedTime(CounterSample,CounterSample):float (2 methods)
          -8 (-7.14% of base) : Newtonsoft.Json.dasm - <>c:<CreateProperties>b__75_0(JsonProperty):int:this (2 methods)
          -8 (-7.14% of base) : System.Private.DataContractSerialization.dasm - XmlBufferReader:GetInt8(int):int:this (2 methods)
          -8 (-7.14% of base) : xunit.runner.utility.netcoreapp10.dasm - TestAssemblyConfiguration:get_AppDomainOrDefault():int:this (2 methods)
          -8 (-7.14% of base) : xunit.runner.utility.netcoreapp10.dasm - TestAssemblyConfiguration:get_DiagnosticMessagesOrDefault():bool:this (2 methods)
          -8 (-7.14% of base) : xunit.runner.utility.netcoreapp10.dasm - TestAssemblyConfiguration:get_InternalDiagnosticMessagesOrDefault():bool:this (2 methods)
          -8 (-7.14% of base) : xunit.runner.utility.netcoreapp10.dasm - TestAssemblyConfiguration:get_LongRunningTestSecondsOrDefault():int:this (2 methods)
          -8 (-7.14% of base) : xunit.runner.utility.netcoreapp10.dasm - TestAssemblyConfiguration:get_MethodDisplayOrDefault():int:this (2 methods)
          -8 (-7.14% of base) : xunit.runner.utility.netcoreapp10.dasm - TestAssemblyConfiguration:get_MethodDisplayOptionsOrDefault():int:this (2 methods)
          -8 (-7.14% of base) : xunit.runner.utility.netcoreapp10.dasm - TestAssemblyConfiguration:get_ParallelizeAssemblyOrDefault():bool:this (2 methods)
          -8 (-7.14% of base) : xunit.runner.utility.netcoreapp10.dasm - TestAssemblyConfiguration:get_ParallelizeTestCollectionsOrDefault():bool:this (2 methods)
          -8 (-7.14% of base) : xunit.runner.utility.netcoreapp10.dasm - TestAssemblyConfiguration:get_PreEnumerateTheoriesOrDefault():bool:this (2 methods)
2235 total methods with Code Size differences (2235 improved, 0 regressed), 184952 unchanged.
```
arm32:
```
Total bytes of diff: -5296 (-0.01% of base)
    diff is an improvement.
Top file improvements (bytes):
       -1852 : System.Private.CoreLib.dasm (-0.02% of base)
        -492 : System.Text.Json.dasm (-0.05% of base)
        -440 : System.Private.Xml.dasm (-0.01% of base)
        -196 : System.Diagnostics.PerformanceCounter.dasm (-0.11% of base)
        -192 : Microsoft.CodeAnalysis.dasm (-0.01% of base)
        -156 : System.Data.Common.dasm (-0.01% of base)
        -140 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
        -128 : System.Private.Uri.dasm (-0.07% of base)
        -108 : System.Drawing.Primitives.dasm (-0.14% of base)
         -96 : System.IO.MemoryMappedFiles.dasm (-0.29% of base)
         -92 : System.Private.DataContractSerialization.dasm (-0.01% of base)
         -88 : Microsoft.VisualBasic.Core.dasm (-0.01% of base)
         -80 : System.Runtime.Numerics.dasm (-0.05% of base)
         -72 : Newtonsoft.Json.dasm (-0.00% of base)
         -64 : System.Security.Cryptography.Algorithms.dasm (-0.01% of base)
         -60 : System.Management.dasm (-0.01% of base)
         -56 : Newtonsoft.Json.Bson.dasm (-0.03% of base)
         -48 : System.Net.HttpListener.dasm (-0.01% of base)
         -44 : System.Linq.Expressions.dasm (-0.00% of base)
         -40 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.00% of base)
71 total files with Code Size differences (71 improved, 0 regressed), 193 unchanged.
Top method improvements (bytes):
        -164 (-18.55% of base) : System.Private.CoreLib.dasm - BinaryWriter:Write(long):this (4 methods)
        -112 (-0.54% of base) : System.Text.Json.dasm - ObjectDefaultConverter`1:OnTryRead(byref,Type,JsonSerializerOptions,byref,byref):bool:this (4 methods)
        -104 (-0.42% of base) : System.Text.Json.dasm - ObjectWithParameterizedConstructorConverter`1:OnTryRead(byref,Type,JsonSerializerOptions,byref,byref):bool:this (4 methods)
         -68 (-4.84% of base) : System.Private.Xml.dasm - BigNumber:Mul(byref):this (2 methods)
         -68 (-0.74% of base) : System.Text.Json.dasm - ObjectWithParameterizedConstructorConverter`1:ReadConstructorArguments(byref,byref,JsonSerializerOptions):this (2 methods)
         -60 (-0.58% of base) : System.Text.Json.dasm - ObjectWithParameterizedConstructorConverter`1:ReadConstructorArgumentsWithContinuation(byref,byref,JsonSerializerOptions):bool:this (2 methods)
         -56 (-11.76% of base) : Newtonsoft.Json.Bson.dasm - AsyncBinaryWriter:WriteAsync(long,CancellationToken):Task:this (2 methods)
         -56 (-6.11% of base) : System.Private.CoreLib.dasm - Sha1ForNonSecretPurposes:Finish(ref):this (2 methods)
         -52 (-11.02% of base) : System.Security.Cryptography.Algorithms.dasm - DES:QuadWordFromBigEndian(ref):long (2 methods)
         -44 (-2.39% of base) : Newtonsoft.Json.dasm - JavaScriptUtils:TryGetDateFromConstructorJson(JsonReader,byref,byref):bool (2 methods)
         -44 (-5.39% of base) : System.Private.Xml.dasm - BigInteger:DivRem(BigInteger):int:this (2 methods)
         -40 (-1.08% of base) : System.Data.Common.dasm - SqlDecimal:MpDiv(ReadOnlySpan`1,int,Span`1,int,Span`1,byref,Span`1,byref) (2 methods)
         -40 (-1.32% of base) : System.Private.CoreLib.dasm - DecCalc:DecAddSub(byref,byref,bool) (2 methods)
         -36 (-3.02% of base) : System.Private.Xml.dasm - XsdDuration:.ctor(TimeSpan,int):this (2 methods)
         -32 (-1.09% of base) : Microsoft.CodeAnalysis.dasm - PeWriter:WriteRuntimeStartupStub(Stream,int):this (4 methods)
         -32 (-8.33% of base) : Microsoft.CodeAnalysis.dasm - AssemblyIdentity:ToVersion(long):Version (4 methods)
         -32 (-0.85% of base) : Microsoft.VisualBasic.Core.dasm - Conversions:ToSByte(Object):byte (2 methods)
         -32 (-0.85% of base) : Microsoft.VisualBasic.Core.dasm - Conversions:ToShort(Object):short (2 methods)
         -32 (-2.51% of base) : System.Linq.Expressions.dasm - Checked:ConvertUInt64(long):Object:this (2 methods)
         -32 (-2.63% of base) : System.Private.CoreLib.dasm - Utf8Parser:TryParseGuidN(ReadOnlySpan`1,byref,byref):bool (2 methods)
Top method improvements (percentages):
          -4 (-20.00% of base) : System.Private.Xml.dasm - Location:get_Line():int:this (2 methods)
        -164 (-18.55% of base) : System.Private.CoreLib.dasm - BinaryWriter:Write(long):this (4 methods)
          -4 (-16.67% of base) : System.Private.CoreLib.dasm - Int64:GetHashCode():int:this (2 methods)
          -4 (-16.67% of base) : System.Private.CoreLib.dasm - TimeSpan:GetHashCode():int:this (2 methods)
          -4 (-16.67% of base) : System.Private.CoreLib.dasm - UInt64:GetHashCode():int:this (2 methods)
          -4 (-16.67% of base) : System.Private.CoreLib.dasm - EventRegistrationToken:GetHashCode():int:this (2 methods)
          -4 (-16.67% of base) : System.Private.Xml.dasm - SourceLineInfo:get_StartLine():int:this (2 methods)
          -8 (-14.29% of base) : System.IO.MemoryMappedFiles.dasm - Interop:SplitLong(long,byref,byref) (2 methods)
         -12 (-14.29% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:GetHashCode(long):int:this (4 methods)
          -4 (-12.50% of base) : System.Data.Common.dasm - SqlDecimal:HI(long):int (2 methods)
          -4 (-12.50% of base) : System.Text.Encodings.Web.dasm - DefaultJavaScriptEncoderBasicLatin:<FindFirstCharacterToEncode>g__CalculateIndex|3_0(int,int):int (2 methods)
         -56 (-11.76% of base) : Newtonsoft.Json.Bson.dasm - AsyncBinaryWriter:WriteAsync(long,CancellationToken):Task:this (2 methods)
         -16 (-11.76% of base) : System.IO.MemoryMappedFiles.dasm - Interop:CreateFileMapping(SafeFileHandle,byref,int,long,String):SafeMemoryMappedFileHandle (2 methods)
         -16 (-11.76% of base) : System.IO.MemoryMappedFiles.dasm - Interop:CreateFileMapping(int,byref,int,long,String):SafeMemoryMappedFileHandle (2 methods)
          -4 (-11.11% of base) : System.Net.HttpListener.dasm - HttpResponseStreamAsyncResult:get_dataChunkCount():ushort:this (2 methods)
          -4 (-11.11% of base) : System.Private.CoreLib.dasm - Char8:op_Implicit(Char8):short (2 methods)
          -8 (-11.11% of base) : System.Private.CoreLib.dasm - Math:Sign(long):int (2 methods)
         -28 (-11.11% of base) : System.Private.CoreLib.dasm - FileStream:LockInternal(long,long):this (2 methods)
         -28 (-11.11% of base) : System.Private.CoreLib.dasm - FileStream:UnlockInternal(long,long):this (2 methods)
         -52 (-11.02% of base) : System.Security.Cryptography.Algorithms.dasm - DES:QuadWordFromBigEndian(ref):long (2 methods)
561 total methods with Code Size differences (561 improved, 0 regressed), 186516 unchanged.
```
Most arm64 improvements coming from using `cbnz` in more places, due to "Fold CAST(IND(x)) and similar when possible" removing a cast that was inconvenient for `OptimizeConstCompare`.

x86 regression in `DecCalc:DecAddSub` and a few others caused by unfortunate changes in register allocation resulting in spilling. On ARM32 the same method shows improvements due to "Remove LONG to INT casts on 32 bit targets".

Other small regressions caused by interaction between cast removal in lowering and `OptimizeConstCompare`/`ContainCheckCompare`.