### PR TITLE
Don't introduce temp copies for struct stack args

### DIFF
--- a/src/coreclr/src/jit/codegen.h
+++ b/src/coreclr/src/jit/codegen.h
@@ -1251,7 +1251,6 @@ protected:
                                unsigned outArgLclOffs DEBUGARG(unsigned outArgLclSize));
 #endif // !TARGET_X86
 
-#ifdef FEATURE_PUT_STRUCT_ARG_STK
 #ifdef TARGET_X86
     void genPreAdjustStackForPutArgStk(unsigned argSize);
     void genPushReg(var_types type, regNumber srcReg);
@@ -1269,7 +1268,6 @@ protected:
 #endif
 #endif
                             );
-#endif // FEATURE_PUT_STRUCT_ARG_STK
 
     void genCodeForStoreBlk(GenTreeBlk* storeBlkNode);
 #ifndef TARGET_X86

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -7260,6 +7260,16 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* putArgStk)
         return;
     }
 
+    if (srcType == TYP_STRUCT)
+    {
+#if defined(TARGET_AMD64)
+        genPutStructArgStk(putArgStk, outArgLclNum, outArgLclOffs);
+#else
+        genPutStructArgStk(putArgStk);
+#endif
+        return;
+    }
+
     if (varTypeIsSIMD(srcType))
     {
         assert(roundUp(varTypeSize(srcType), REGSIZE_BYTES) <= putArgStk->GetSlotCount() * REGSIZE_BYTES);
@@ -7284,16 +7294,6 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* putArgStk)
             GetEmitter()->emitIns_AR_R(ins_Store(srcType), emitTypeSize(srcType), srcReg, REG_SPBASE, 0);
         }
 #endif
-#endif
-        return;
-    }
-
-    if (srcType == TYP_STRUCT)
-    {
-#if defined(TARGET_AMD64)
-        genPutStructArgStk(putArgStk, outArgLclNum, outArgLclOffs);
-#else
-        genPutStructArgStk(putArgStk);
 #endif
         return;
     }

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -7603,7 +7603,7 @@ void CodeGen::genPutStructArgStk(GenTreePutArgStk* putArgStk NOT_X86_ARG(unsigne
         // We assume that the size of a struct which contains GC pointers is a multiple of the slot size.
         assert(srcLayout->GetSize() % REGSIZE_BYTES == 0);
 
-        for (int i = putArgStk->gtNumSlots - 1; i >= 0; --i)
+        for (int i = putArgStk->GetSlotCount() - 1; i >= 0; --i)
         {
             emitAttr slotAttr      = emitTypeSize(srcLayout->GetGCPtrType(i));
             int      slotSrcOffset = srcOffset + i * REGSIZE_BYTES;
@@ -7706,7 +7706,7 @@ void CodeGen::genPutStructArgStk(GenTreePutArgStk* putArgStk NOT_X86_ARG(unsigne
     // We assume that the size of a struct which contains GC pointers is a multiple of the slot size.
     assert(srcLayout->GetSize() % REGSIZE_BYTES == 0);
 
-    unsigned numSlots = putArgStk->gtNumSlots;
+    unsigned numSlots = putArgStk->GetSlotCount();
 
     for (unsigned i = 0; i < numSlots; i++)
     {

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -3048,8 +3048,6 @@ void CodeGen::genCodeForCpBlkRepMovs(GenTreeBlk* cpBlkNode)
     instGen(INS_r_movsb);
 }
 
-#ifdef FEATURE_PUT_STRUCT_ARG_STK
-
 //------------------------------------------------------------------------
 // If any Vector3 args are on stack and they are not pass-by-ref, the upper 32bits
 // must be cleared to zeroes. The native compiler doesn't clear the upper bits
@@ -3100,7 +3098,6 @@ void CodeGen::genClearStackVec3ArgUpperBits()
     }
 }
 #endif // defined(UNIX_AMD64_ABI) && defined(FEATURE_SIMD)
-#endif // FEATURE_PUT_STRUCT_ARG_STK
 
 //
 // genCodeForCpObj - Generate code for CpObj nodes to copy structs that have interleaved
@@ -7248,7 +7245,7 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* putArgStk)
 
     if (src->OperIs(GT_FIELD_LIST))
     {
-#if defined(UNIX_AMD64_ABI)
+#if defined(TARGET_AMD64)
 #if FEATURE_FASTTAILCALL
         // TODO-MIKE-Cleanup: This seems to be sligtly different from ARMARCH's outArgLclSize.
         INDEBUG(unsigned outArgLclSize = putArgStk->putInIncomingArgArea() ? compiler->info.compArgStackSize
@@ -7257,27 +7254,23 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* putArgStk)
         INDEBUG(unsigned outArgLclSize = compiler->lvaLclSize(outArgLclNum);)
 #endif
         genPutArgStkFieldList(src->AsFieldList(), outArgLclNum, outArgLclOffs DEBUGARG(outArgLclSize));
-#elif defined(TARGET_X86)
-        genPutArgStkFieldList(putArgStk);
 #else
-        // WIN64 passes struct types as integers or by reference.
-        unreached();
+        genPutArgStkFieldList(putArgStk);
 #endif
         return;
     }
 
     if (varTypeIsSIMD(srcType))
     {
+        assert(roundUp(varTypeSize(srcType), REGSIZE_BYTES) <= putArgStk->GetSlotCount() * REGSIZE_BYTES);
+
+        regNumber srcReg = genConsumeReg(src);
+        assert(genIsValidFloatReg(srcReg));
+
 #if defined(FEATURE_SIMD)
-#if defined(UNIX_AMD64_ABI)
-        regNumber srcReg = genConsumeReg(src);
-        assert((srcReg != REG_NA) && (genIsValidFloatReg(srcReg)));
-
+#if defined(TARGET_AMD64)
         GetEmitter()->emitIns_S_R(ins_Store(srcType), emitTypeSize(srcType), srcReg, outArgLclNum, outArgLclOffs);
-#elif defined(TARGET_X86)
-        regNumber srcReg = genConsumeReg(src);
-        assert((srcReg != REG_NA) && (genIsValidFloatReg(srcReg)));
-
+#else
         inst_RV_IV(INS_sub, REG_SPBASE, putArgStk->getArgSize(), EA_4BYTE);
         AddStackLevel(putArgStk->getArgSize());
 
@@ -7290,9 +7283,6 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* putArgStk)
         {
             GetEmitter()->emitIns_AR_R(ins_Store(srcType), emitTypeSize(srcType), srcReg, REG_SPBASE, 0);
         }
-#else
-        // WIN64 passes SIMD types by reference (no vectorcall support).
-        unreached();
 #endif
 #endif
         return;
@@ -7300,13 +7290,10 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* putArgStk)
 
     if (srcType == TYP_STRUCT)
     {
-#if defined(UNIX_AMD64_ABI)
+#if defined(TARGET_AMD64)
         genPutStructArgStk(putArgStk, outArgLclNum, outArgLclOffs);
-#elif defined(TARGET_X86)
-        genPutStructArgStk(putArgStk);
 #else
-        // WIN64 passes register sized structs as integers and the rest by reference.
-        unreached();
+        genPutStructArgStk(putArgStk);
 #endif
         return;
     }
@@ -7403,8 +7390,6 @@ void CodeGen::genPushReg(var_types type, regNumber srcReg)
     AddStackLevel(size);
 }
 #endif // TARGET_X86
-
-#if defined(FEATURE_PUT_STRUCT_ARG_STK)
 
 //---------------------------------------------------------------------
 // genPutStructArgStk - Generate code for copying a struct arg on the stack by value.
@@ -7805,7 +7790,6 @@ void CodeGen::genPutStructArgStk(GenTreePutArgStk* putArgStk NOT_X86_ARG(unsigne
     }
 #endif // TARGET_AMD64
 }
-#endif // defined(FEATURE_PUT_STRUCT_ARG_STK)
 
 /*****************************************************************************
  *

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -9899,6 +9899,8 @@ public:
     GenTreeFieldList* abiMorphPromotedStructArgToFieldList(LclVarDsc* lcl, CallArgInfo* argInfo);
 #endif
 #endif
+    bool abiMorphStructStackArg(CallArgInfo* argInfo, GenTree* argNode);
+    void abiMorphPromotedStructStackArg(CallArgInfo* argInfo, GenTreeLclVar* argNode);
 
     bool killGCRefs(GenTree* tree);
 

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -1641,28 +1641,20 @@ public:
         return numRegs + numSlots == 1;
     }
 
-    // Returns the number of "slots" used, where for this purpose a
-    // register counts as a slot.
-    unsigned getSlotCount()
-    {
-        return numSlots + numRegs;
-    }
-
     unsigned GetRegCount()
     {
         return numRegs;
     }
 
-    unsigned GetStackSlotCount()
+    unsigned GetSlotCount()
     {
         return numSlots;
     }
 
-    // Returns the size as a multiple of pointer-size.
-    // For targets without HFAs, this is the same as getSlotCount().
+    // Returns the size as a multiple of slot-size.
     unsigned getSize()
     {
-        unsigned size = getSlotCount();
+        unsigned size = numSlots + numRegs;
 #ifdef FEATURE_HFA
         if (IsHfaArg() && isPassedInRegisters())
         {

--- a/src/coreclr/src/jit/compiler.hpp
+++ b/src/coreclr/src/jit/compiler.hpp
@@ -612,27 +612,7 @@ inline var_types genActualType(var_types type)
 
 inline var_types genUnsignedType(var_types type)
 {
-    /* Force signed types into corresponding unsigned type */
-
-    switch (type)
-    {
-        case TYP_BYTE:
-            type = TYP_UBYTE;
-            break;
-        case TYP_SHORT:
-            type = TYP_USHORT;
-            break;
-        case TYP_INT:
-            type = TYP_UINT;
-            break;
-        case TYP_LONG:
-            type = TYP_ULONG;
-            break;
-        default:
-            break;
-    }
-
-    return type;
+    return varTypeToUnsigned(type);
 }
 
 /*****************************************************************************/
@@ -1493,6 +1473,12 @@ inline void GenTree::ChangeOper(genTreeOps oper, ValueNumberUpdate vnUpdate)
     // Do "oper"-specific initializations...
     switch (oper)
     {
+        case GT_FIELD_LIST:
+            AsFieldList()->SetType(TYP_STRUCT);
+            AsFieldList()->ClearFields();
+            AsFieldList()->SetContained();
+            break;
+
         case GT_LCL_VAR:
         case GT_LCL_VAR_ADDR:
             INDEBUG(AsLclVar()->gtLclILoffs = BAD_IL_OFFSET;)

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -1176,13 +1176,6 @@ bool GenTreeCall::Equals(GenTreeCall* c1, GenTreeCall* c2)
     return true;
 }
 
-#if !defined(FEATURE_PUT_STRUCT_ARG_STK)
-unsigned GenTreePutArgStk::getArgSize()
-{
-    return genTypeSize(genActualType(gtOp1->gtType));
-}
-#endif // !defined(FEATURE_PUT_STRUCT_ARG_STK)
-
 /*****************************************************************************
  *
  *  Returns non-zero if the two trees are identical.
@@ -9953,7 +9946,6 @@ void Compiler::gtDispTree(GenTree*     tree,
                 }
             }
         }
-#if FEATURE_PUT_STRUCT_ARG_STK
         else if (tree->OperGet() == GT_PUTARG_STK)
         {
             printf(" (%d slots)", tree->AsPutArgStk()->gtNumSlots);
@@ -9975,7 +9967,6 @@ void Compiler::gtDispTree(GenTree*     tree,
                     kindName = "PushAllSlots";
                     break;
 #endif
-#ifdef UNIX_AMD64_ABI
                 case GenTreePutArgStk::Kind::RepInstrXMM:
                     kindName = "RepInstrXMM";
                     break;
@@ -9985,7 +9976,6 @@ void Compiler::gtDispTree(GenTree*     tree,
                 case GenTreePutArgStk::Kind::GCUnrollXMM:
                     kindName = "GCUnrollXMM";
                     break;
-#endif
                 default:
                     kindName = "???";
                     break;
@@ -9993,7 +9983,6 @@ void Compiler::gtDispTree(GenTree*     tree,
             printf(" (%s)", kindName);
 #endif
         }
-#endif // FEATURE_PUT_STRUCT_ARG_STK
 
         if (tree->gtOper == GT_INTRINSIC)
         {

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -9948,7 +9948,7 @@ void Compiler::gtDispTree(GenTree*     tree,
         }
         else if (tree->OperGet() == GT_PUTARG_STK)
         {
-            printf(" (%d slots)", tree->AsPutArgStk()->gtNumSlots);
+            printf(" (%d slots)", tree->AsPutArgStk()->GetSlotCount());
 #ifdef TARGET_XARCH
             const char* kindName;
             switch (tree->AsPutArgStk()->gtPutArgStkKind)

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -2530,6 +2530,11 @@ public:
     // Insert a new field use after the specified use without updating side effect flags.
     void InsertFieldLIR(Compiler* compiler, Use* insertAfter, GenTree* node, unsigned offset, var_types type);
 
+    void ClearFields()
+    {
+        m_uses = UseList();
+    }
+
     //--------------------------------------------------------------------------
     // Equals: Check if 2 FIELD_LIST nodes are equal.
     //

--- a/src/coreclr/src/jit/jit.h
+++ b/src/coreclr/src/jit/jit.h
@@ -246,11 +246,6 @@
 #define UNIX_AMD64_ABI_ONLY(x)
 #endif // defined(UNIX_AMD64_ABI)
 
-#if defined(UNIX_AMD64_ABI) || defined(TARGET_ARM) || defined(TARGET_ARM64) || defined(TARGET_X86)
-#define FEATURE_PUT_STRUCT_ARG_STK 1
-#define PUT_STRUCT_ARG_STK_ONLY_ARG(x) , x
-#define PUT_STRUCT_ARG_STK_ONLY(x) x
-
 // Arm64 Windows supports FEATURE_ARG_SPLIT, note this is different from
 // the official Arm64 ABI.
 // Case: splitting 16 byte struct between x7 and stack
@@ -259,11 +254,6 @@
 #else
 #define FEATURE_ARG_SPLIT 0
 #endif // (defined(TARGET_ARM) || (defined(TARGET_WINDOWS) && defined(TARGET_ARM64)))
-
-#else
-#define PUT_STRUCT_ARG_STK_ONLY_ARG(x)
-#define PUT_STRUCT_ARG_STK_ONLY(x)
-#endif
 
 #if defined(UNIX_AMD64_ABI)
 #define UNIX_AMD64_ABI_ONLY_ARG(x) , x

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -1136,10 +1136,8 @@ GenTree* Lowering::NewPutArg(GenTreeCall* call, CallArgInfo* info)
         return comp->gtNewPutArgReg(varActualType(arg->GetType()), arg, info->GetRegNum());
     }
 
-    return new (comp, GT_PUTARG_STK)
-        GenTreePutArgStk(GT_PUTARG_STK, TYP_VOID, arg,
-                         info->GetSlotNum() PUT_STRUCT_ARG_STK_ONLY_ARG(info->GetStackSlotCount()),
-                         call->IsFastTailCall(), call);
+    return new (comp, GT_PUTARG_STK) GenTreePutArgStk(GT_PUTARG_STK, TYP_VOID, arg, info->GetSlotNum(),
+                                                      info->GetStackSlotCount(), call->IsFastTailCall(), call);
 }
 
 void Lowering::LowerCallArgs(GenTreeCall* call)

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -1050,7 +1050,7 @@ GenTree* Lowering::NewPutArg(GenTreeCall* call, CallArgInfo* info)
         }
 
         GenTreePutArgSplit* argSplit =
-            new (comp, GT_PUTARG_SPLIT) GenTreePutArgSplit(arg, info->GetSlotNum(), info->GetStackSlotCount(),
+            new (comp, GT_PUTARG_SPLIT) GenTreePutArgSplit(arg, info->GetSlotNum(), info->GetSlotCount(),
                                                            info->GetRegCount(), call->IsFastTailCall(), call);
 
         for (unsigned regIndex = 0; regIndex < info->GetRegCount(); regIndex++)
@@ -1137,7 +1137,7 @@ GenTree* Lowering::NewPutArg(GenTreeCall* call, CallArgInfo* info)
     }
 
     return new (comp, GT_PUTARG_STK) GenTreePutArgStk(GT_PUTARG_STK, TYP_VOID, arg, info->GetSlotNum(),
-                                                      info->GetStackSlotCount(), call->IsFastTailCall(), call);
+                                                      info->GetSlotCount(), call->IsFastTailCall(), call);
 }
 
 void Lowering::LowerCallArgs(GenTreeCall* call)
@@ -1201,7 +1201,7 @@ void Lowering::LowerCallArg(GenTreeCall* call, CallArgInfo* argInfo)
             // For longs, we will replace the GT_LONG with a GT_FIELD_LIST, and put that under a PUTARG_STK.
             // Although the hi argument needs to be pushed first, that will be handled by the general case,
             // in which the fields will be reversed.
-            assert(argInfo->GetStackSlotCount() == 2);
+            assert(argInfo->GetSlotCount() == 2);
             newArg->SetRegNum(REG_STK);
             BlockRange().InsertBefore(arg, fieldList, newArg);
             argInfo->SetNode(newArg);

--- a/src/coreclr/src/jit/lowerxarch.cpp
+++ b/src/coreclr/src/jit/lowerxarch.cpp
@@ -501,7 +501,6 @@ void Lowering::LowerPutArgStk(GenTreePutArgStk* putArgStk)
         return;
     }
 
-#ifdef FEATURE_PUT_STRUCT_ARG_STK
     if (src->TypeIs(TYP_STRUCT))
     {
         ClassLayout* layout;
@@ -629,7 +628,6 @@ void Lowering::LowerPutArgStk(GenTreePutArgStk* putArgStk)
 
         return;
     }
-#endif // FEATURE_PUT_STRUCT_ARG_STK
 
     // If the child of GT_PUTARG_STK is a constant, we don't need a register to
     // move it to memory (stack location).

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -3688,11 +3688,11 @@ bool Compiler::abiCanMorphPromotedStructArgToFieldList(LclVarDsc* lcl, CallArgIn
 
     unsigned fieldCount      = lcl->GetPromotedFieldCount();
     unsigned field           = 0;
-    unsigned regAndSlotCount = argInfo->GetRegCount() + argInfo->GetStackSlotCount();
+    unsigned regAndSlotCount = argInfo->GetRegCount() + argInfo->GetSlotCount();
     unsigned reg             = 0;
 
 #ifdef FEATURE_HFA
-    if (argInfo->IsHfaArg() && (argInfo->GetStackSlotCount() == 0))
+    if (argInfo->IsHfaArg() && (argInfo->GetSlotCount() == 0))
     {
         if (regAndSlotCount > fieldCount)
         {
@@ -3842,11 +3842,11 @@ GenTreeFieldList* Compiler::abiMorphPromotedStructArgToFieldList(LclVarDsc* lcl,
 
     unsigned fieldCount      = lcl->GetPromotedFieldCount();
     unsigned field           = 0;
-    unsigned regAndSlotCount = argInfo->GetRegCount() + argInfo->GetStackSlotCount();
+    unsigned regAndSlotCount = argInfo->GetRegCount() + argInfo->GetSlotCount();
     unsigned reg             = 0;
 
 #ifdef FEATURE_HFA
-    if (argInfo->IsHfaArg() && (argInfo->GetStackSlotCount() == 0))
+    if (argInfo->IsHfaArg() && (argInfo->GetSlotCount() == 0))
     {
         assert(regAndSlotCount <= fieldCount);
 

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -4267,9 +4267,6 @@ GenTree* Compiler::fgMorphMultiregStructArg(GenTree* arg, fgArgTabEntry* fgEntry
     // dependent promotion. ARM64 doesn't copy so it always triggers dependent promotion of any
     // struct type that cannot be passed in registers (e.g. a struct with 2-4 INT fields).
     if ((lcl != nullptr) && (lvaGetPromotionType(lcl->GetLclNum()) == PROMOTION_TYPE_INDEPENDENT)
-#if defined(UNIX_AMD64_ABI)
-        && fgEntryPtr->isPassedInRegisters()
-#endif
 #if defined(TARGET_ARM64) || defined(UNIX_AMD64_ABI)
         && abiCanMorphPromotedStructArgToFieldList(lvaGetDesc(lcl), fgEntryPtr)
 #endif

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -1103,7 +1103,7 @@ void fgArgInfo::ArgsComplete(Compiler* compiler)
                 // TODO-Arm: This optimization is not implemented for ARM32
                 // so we skip this for ARM32 until it is ported to use RyuJIT backend
                 //
-                else if (argx->OperGet() == GT_OBJ)
+                else if (argx->OperIs(GT_OBJ) && (curArgTabEntry->GetRegCount() != 0))
                 {
                     GenTreeObj* argObj     = argx->AsObj();
                     unsigned    structSize = argObj->GetLayout()->GetSize();
@@ -1660,10 +1660,6 @@ void fgArgInfo::EvalArgsToTemps(Compiler* compiler, GenTreeCall* call)
                 }
 #endif
 
-#if defined(TARGET_AMD64) && !defined(UNIX_AMD64_ABI)
-                noway_assert(argx->gtType != TYP_STRUCT);
-#endif
-
                 unsigned tmpVarNum = compiler->lvaGrabTemp(true DEBUGARG("argument with side effect"));
 
                 if (setupArg != nullptr)
@@ -1754,21 +1750,11 @@ void fgArgInfo::EvalArgsToTemps(Compiler* compiler, GenTreeCall* call)
             // For a struct type we also need to record the class handle of the arg.
             CORINFO_CLASS_HANDLE clsHnd = NO_CLASS_HANDLE;
 
-#if defined(TARGET_AMD64) && !defined(UNIX_AMD64_ABI)
-
-            // All structs are either passed (and retyped) as integral types, OR they
-            // are passed by reference.
-            noway_assert(argx->gtType != TYP_STRUCT);
-
-#else // !defined(TARGET_AMD64) || defined(UNIX_AMD64_ABI)
-
             if (defArg->TypeGet() == TYP_STRUCT)
             {
                 clsHnd = compiler->gtGetStructHandleIfPresent(defArg);
                 noway_assert(clsHnd != NO_CLASS_HANDLE);
             }
-
-#endif // !(defined(TARGET_AMD64) && !defined(UNIX_AMD64_ABI))
 
             setupArg = compiler->gtNewArgPlaceHolderNode(defArg->gtType, clsHnd);
 
@@ -3070,6 +3056,7 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
     // that occupy more than a single slot that are passed by value (not necessarily in regs).
     bool hasMultiregStructArgs = false;
 #endif
+    bool hasMultiFieldPromotedArgs = false;
 
     for (GenTreeCall::Use *args = call->gtCallArgs; args != nullptr; args = args->GetNext(), argIndex++)
     {
@@ -3137,7 +3124,11 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
                 assert(!"Structs are not passed by reference on x64/ux");
 #endif // UNIX_AMD64_ABI
             }
-            else // This is passed by value.
+            else if (argEntry->GetRegCount() == 0)
+            {
+                hasMultiFieldPromotedArgs |= abiMorphStructStackArg(argEntry, argObj);
+            }
+            else
             {
                 unsigned  roundupSize    = roundUp(originalSize, TARGET_POINTER_SIZE);
                 unsigned  structSize     = originalSize;
@@ -3434,7 +3425,7 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
             if (((argEntry->numRegs + argEntry->numSlots) > 1) ||
                 (argEntry->IsHfaArg() && argx->TypeGet() == TYP_STRUCT))
             {
-                hasMultiregStructArgs = true;
+                hasMultiregStructArgs |= argEntry->GetRegCount() != 0;
             }
         }
 #ifdef TARGET_ARM
@@ -3541,6 +3532,30 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
     }
 #endif
 
+    if (hasMultiFieldPromotedArgs)
+    {
+        // TODO-MIKE-Cleanup: Consolidate with fgMorphMultiregStructArgs.
+
+        for (unsigned i = 0; i < call->GetInfo()->GetArgCount(); i++)
+        {
+            CallArgInfo* argInfo = call->GetInfo()->GetArgInfo(i);
+
+            if (argInfo->GetRegCount() != 0)
+            {
+                continue;
+            }
+
+            GenTree* argNode = argInfo->GetNode()->gtEffectiveVal(true);
+
+            if (!argNode->OperIs(GT_LCL_VAR))
+            {
+                continue;
+            }
+
+            abiMorphPromotedStructStackArg(argInfo, argNode->AsLclVar());
+        }
+    }
+
 #ifdef DEBUG
     if (verbose)
     {
@@ -3554,6 +3569,192 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
 #ifdef _PREFAST_
 #pragma warning(pop)
 #endif
+
+bool Compiler::abiMorphStructStackArg(CallArgInfo* argInfo, GenTree* argNode)
+{
+    assert(argInfo->GetRegCount() == 0);
+    assert(varTypeIsStruct(argNode->GetType()));
+
+    if (argNode->OperIs(GT_OBJ))
+    {
+        // TODO-MIKE-Cleanup: This OBJ(ADDR(LCL_VAR)) simplification should be confined to LocalAddressVisitor.
+        //
+        // However, we may still need to something like this to convert certain LCL_FLDs to LCL_VARs because
+        // LocalAddressVisitor has a restriction which call arg morphing does not have - LocalAddressVisitor
+        // has to maintain the struct layout on call arg nodes for fgInitArgInfo to determine how the arg is
+        // passed. Once this was done, the layout is no longer needed and we can allow reinterpretation,
+        // mostly to prevent dependent struct promotion of call args.
+        //
+        // It would be easier if struct reinterpretation was some rare, ignorable scenario but unfortunately
+        // it is not:
+        //   - FX sometimes makes use of it (Memory/ReadOnlyMemory)
+        //   - The JIT/VM sometimes mix up C<T> and C<Cannon>, these have the same layout but they get different
+        //     class handles and this different ClassLayout instances.
+        //   - Pseudo-recursive struct promotion also leavs us with primitive type locals being passed as structs.
+
+        GenTreeLclVarCommon* lclNode  = nullptr;
+        unsigned             lclOffs  = 0;
+        FieldSeqNode*        fieldSeq = nullptr;
+
+        if (argNode->AsObj()->GetAddr()->IsLocalAddrExpr(this, &lclNode, &lclOffs, &fieldSeq))
+        {
+            if (lclOffs == 0)
+            {
+                unsigned argSize = argInfo->GetSlotCount() * REGSIZE_BYTES;
+
+                LclVarDsc* lcl     = lvaGetDesc(lclNode);
+                var_types  lclType = lcl->GetType();
+                unsigned   lclSize = (lclType == TYP_STRUCT) ? lcl->GetLayout()->GetSize() : varTypeSize(lclType);
+
+                // With some care in codegen and a few other places we could probably allow any local size
+                // here. We have alreadyd determined how many slots the arg uses so it's just matter of not
+                // storing more slots if the struct is larger and not pushing less (on X86) if the struct is
+                // smaller. It's not clear if there's any good reason to do this.
+                //
+                // As a simple compromise, allow size mismatches if the slot count is the same. This is
+                // sufficient for the special case of SIMD12, which can be treated as SIMD16 on 64 bit.
+
+                if ((lclSize != 0) && (roundUp(lclSize, REGSIZE_BYTES) == argSize))
+                {
+                    argNode->ChangeOper(GT_LCL_VAR);
+                    argNode->SetType(lclType);
+                    argNode->AsLclVar()->SetLclNum(lclNode->GetLclNum());
+                    argNode->gtFlags = 0;
+                }
+            }
+
+            if (argNode->OperIs(GT_OBJ))
+            {
+                argNode->ChangeOper(GT_LCL_FLD);
+                argNode->AsLclFld()->SetLclNum(lclNode->GetLclNum());
+                argNode->AsLclFld()->SetFieldSeq(fieldSeq == nullptr ? FieldSeqStore::NotAField() : fieldSeq);
+                argNode->AsLclFld()->SetLayout(argNode->AsObj()->GetLayout(), this);
+                argNode->gtFlags = 0;
+
+                lvaSetVarDoNotEnregister(lclNode->GetLclNum() DEBUGARG(DNER_LocalField));
+            }
+        }
+    }
+
+    if (argNode->OperIs(GT_LCL_VAR) && varTypeIsStruct(argNode->GetType()) &&
+        (lvaGetPromotionType(argNode->AsLclVar()->GetLclNum()) == PROMOTION_TYPE_INDEPENDENT))
+    {
+        LclVarDsc* lcl = lvaGetDesc(argNode->AsLclVar());
+
+        if (lcl->GetPromotedFieldCount() > 1)
+        {
+            // If we need more than one field we need to generate a FIELD_LIST.
+            // If this argument ends up needing a temp then EvalArgsToTemps will
+            // need the struct layout to create the temp and FIELD_LIST doesn't
+            // have layout. So we have to do this transform after EvalArgsToTemps.
+
+            return true;
+        }
+
+        LclVarDsc* fieldLcl  = lvaGetDesc(lcl->GetPromotedFieldLclNum(0));
+        var_types  fieldType = fieldLcl->GetType();
+
+        assert(roundUp(varTypeSize(fieldType), REGSIZE_BYTES) <= argInfo->GetSlotCount() * REGSIZE_BYTES);
+
+        argNode->AsLclVar()->SetLclNum(lcl->GetPromotedFieldLclNum(0));
+        argNode->SetType(fieldType);
+        argNode->gtFlags = 0;
+
+        argInfo->isStruct = false;
+        argInfo->argType  = fieldType;
+
+        return false;
+    }
+
+    if (argNode->TypeIs(TYP_STRUCT) && (argInfo->argType != TYP_STRUCT))
+    {
+        // While not required for corectness, we can change the type of a struct arg to
+        // be a primitive type of suitable size (e.g. a 2 byte struct can be treated as
+        // USHORT. Currently CSE does not handle STRUCT OBJs but it can CSE an IND, even
+        // if this is a form a reinterpretation that has other limitations in VN/CSE.
+        //
+        // TODO-MIKE-CQ: Investigate reinterpretation effect on VN. For example, would
+        // VN be able to convert from a "zero map" to any primitive type in order to
+        // const propagate default struct initialization?
+
+        assert(argInfo->GetSlotCount() == 1);
+
+        var_types argType   = argInfo->argType;
+        bool      canRetype = false;
+
+        if (argNode->OperIs(GT_OBJ))
+        {
+            canRetype = varTypeSize(argType) <= argNode->AsObj()->GetLayout()->GetSize();
+
+            if (canRetype)
+            {
+                argNode->ChangeOper(GT_IND);
+            }
+        }
+        else if (argNode->OperIs(GT_LCL_FLD))
+        {
+            canRetype =
+                argNode->AsLclFld()->GetLclOffs() + varTypeSize(argType) <= lvaGetDesc(argNode->AsLclFld())->lvSize();
+
+            if (canRetype)
+            {
+                argNode->AsLclFld()->SetFieldSeq(FieldSeqStore::NotAField());
+            }
+        }
+        else
+        {
+            canRetype = true;
+            lvaSetVarDoNotEnregister(argNode->AsLclVar()->GetLclNum() DEBUGARG(DNER_LocalField));
+            argNode->ChangeOper(GT_LCL_FLD);
+        }
+
+        if (canRetype)
+        {
+            if (varTypeIsSmall(argType))
+            {
+                // argType is a signed type but this is a struct so sign extension isn't necessary.
+                // On XARCH it causes MOVSX to be generated, which has larger encoding than MOVZX.
+                argType = varTypeToUnsigned(argType);
+            }
+
+            argNode->SetType(argType);
+            argInfo->isStruct = false;
+        }
+    }
+
+    return false;
+}
+
+void Compiler::abiMorphPromotedStructStackArg(CallArgInfo* argInfo, GenTreeLclVar* argNode)
+{
+    assert(argInfo->GetRegCount() == 0);
+
+    LclVarDsc* lcl = lvaGetDesc(argNode);
+
+    if (lvaGetPromotionType(argNode->GetLclNum()) != PROMOTION_TYPE_INDEPENDENT)
+    {
+        return;
+    }
+
+    assert(lcl->GetPromotedFieldCount() > 1);
+
+    argNode->ChangeOper(GT_FIELD_LIST);
+
+    GenTreeFieldList* fieldList = argNode->AsFieldList();
+
+    for (unsigned i = 0; i < lcl->GetPromotedFieldCount(); i++)
+    {
+        unsigned       fieldLclNum = lcl->GetPromotedFieldLclNum(i);
+        LclVarDsc*     fieldLcl    = lvaGetDesc(fieldLclNum);
+        var_types      fieldType   = fieldLcl->GetType();
+        unsigned       fieldOffset = fieldLcl->GetPromotedFieldOffset();
+        GenTreeLclVar* fieldLclVar = gtNewLclvNode(fieldLclNum, fieldType);
+
+        assert(fieldOffset + varTypeSize(fieldType) <= argInfo->GetSlotCount() * REGSIZE_BYTES);
+
+        fieldList->AddField(this, fieldLclVar, fieldOffset, fieldType);
+    }
+}
 
 #if FEATURE_MULTIREG_ARGS
 //-----------------------------------------------------------------------------
@@ -3608,7 +3809,7 @@ void Compiler::fgMorphMultiregStructArgs(GenTreeCall* call)
             assert((lateUse != nullptr) && (lateNode != nullptr));
         }
 
-        if (!fgEntryPtr->isStruct)
+        if (!fgEntryPtr->isStruct || (fgEntryPtr->GetRegCount() == 0))
         {
             continue;
         }

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -3190,31 +3190,28 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
                     // - We have a known struct type (e.g. SIMD) that requires multiple registers.
                     // TODO-Amd64-Unix-Throughput: We don't need to keep the structDesc in the argEntry if it's not
                     // actually passed in registers.
-                    if (argEntry->isPassedInRegisters())
+                    if (argObj->OperIs(GT_OBJ))
                     {
-                        if (argObj->OperIs(GT_OBJ))
+                        if (passingSize != structSize)
                         {
-                            if (passingSize != structSize)
-                            {
-                                copyBlkClass = objClass;
-                            }
+                            copyBlkClass = objClass;
                         }
-                        else if (argObj->TypeIs(TYP_STRUCT))
-                        {
-                            assert(argObj->OperIs(GT_LCL_VAR, GT_LCL_FLD));
+                    }
+                    else if (argObj->TypeIs(TYP_STRUCT))
+                    {
+                        assert(argObj->OperIs(GT_LCL_VAR, GT_LCL_FLD));
 
-                            if (passingSize != structSize)
-                            {
-                                copyBlkClass = objClass;
-                            }
-                        }
-                        else
+                        if (passingSize != structSize)
                         {
-                            // This should only be the case of a value directly producing a known struct type.
-                            if (argEntry->numRegs > 1)
-                            {
-                                copyBlkClass = objClass;
-                            }
+                            copyBlkClass = objClass;
+                        }
+                    }
+                    else
+                    {
+                        // This should only be the case of a value directly producing a known struct type.
+                        if (argEntry->numRegs > 1)
+                        {
+                            copyBlkClass = objClass;
                         }
                     }
 #endif // UNIX_AMD64_ABI

--- a/src/coreclr/src/jit/stacklevelsetter.cpp
+++ b/src/coreclr/src/jit/stacklevelsetter.cpp
@@ -259,7 +259,7 @@ unsigned StackLevelSetter::PopArgumentsFromCall(GenTreeCall* call)
                 GenTreePutArgStk* putArg = node->AsPutArgStk();
 
 #if !FEATURE_FIXED_OUT_ARGS
-                assert(argTab->numSlots == putArg->gtNumSlots);
+                assert(argTab->GetStackSlotCount() == putArg->GetSlotCount());
 #endif // !FEATURE_FIXED_OUT_ARGS
 
                 putArgNumSlots.Set(putArg, argTab->numSlots);

--- a/src/coreclr/src/jit/stacklevelsetter.h
+++ b/src/coreclr/src/jit/stacklevelsetter.h
@@ -23,8 +23,8 @@ private:
 #endif // !FEATURE_FIXED_OUT_ARGS
 
     unsigned PopArgumentsFromCall(GenTreeCall* call);
-    void AddStackLevel(unsigned value);
-    void SubStackLevel(unsigned value);
+    void PushArg(GenTreePutArgStk* putArgStk);
+    void PopArg(GenTreePutArgStk* putArgStk);
 
     void CheckArgCnt();
     void CheckAdditionalArgs();
@@ -32,11 +32,6 @@ private:
 private:
     unsigned currentStackLevel; // current number of stack slots used by arguments.
     unsigned maxStackLevel;     // max number of stack slots for arguments.
-
-    CompAllocator memAllocator;
-
-    typedef JitHashTable<GenTreePutArgStk*, JitPtrKeyFuncs<GenTreePutArgStk>, unsigned> PutArgNumSlotsMap;
-    PutArgNumSlotsMap putArgNumSlots; // The hash table keeps stack slot sizes for active GT_PUTARG_STK nodes.
 
 #if !FEATURE_FIXED_OUT_ARGS
     bool framePointerRequired;  // Is frame pointer required based on the analysis made by this phase.

--- a/src/coreclr/src/jit/vartype.h
+++ b/src/coreclr/src/jit/vartype.h
@@ -349,6 +349,29 @@ inline var_types varActualType(var_types type)
     return static_cast<var_types>(genActualTypes[type]);
 }
 
+inline var_types varTypeToUnsigned(var_types type)
+{
+    switch (type)
+    {
+        case TYP_BYTE:
+            type = TYP_UBYTE;
+            break;
+        case TYP_SHORT:
+            type = TYP_USHORT;
+            break;
+        case TYP_INT:
+            type = TYP_UINT;
+            break;
+        case TYP_LONG:
+            type = TYP_ULONG;
+            break;
+        default:
+            break;
+    }
+
+    return type;
+}
+
 /*****************************************************************************/
 #endif // _VARTYPE_H_
 /*****************************************************************************/


### PR DESCRIPTION
win-x64 diff:
```
Total bytes of diff: -3437 (-0.01% of base)
    diff is an improvement.
Top file regressions (bytes):
          58 : Microsoft.CodeAnalysis.CSharp.dasm (0.00% of base)
Top file improvements (bytes):
       -2726 : System.Net.Http.dasm (-0.47% of base)
        -236 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.01% of base)
         -99 : System.Net.WebSockets.WebSocketProtocol.dasm (-0.29% of base)
         -94 : xunit.performance.execution.dasm (-0.64% of base)
         -92 : System.Net.WebSockets.dasm (-0.21% of base)
         -78 : xunit.console.dasm (-0.11% of base)
         -66 : Microsoft.Extensions.DependencyModel.dasm (-0.16% of base)
         -28 : System.Drawing.Common.dasm (-0.01% of base)
         -25 : System.Net.HttpListener.dasm (-0.01% of base)
         -18 : System.Text.Json.dasm (-0.00% of base)
         -16 : Microsoft.CodeAnalysis.dasm (-0.00% of base)
          -7 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
          -5 : System.DirectoryServices.AccountManagement.dasm (-0.00% of base)
          -3 : xunit.runner.utility.netcoreapp10.dasm (-0.00% of base)
          -1 : System.Configuration.ConfigurationManager.dasm (-0.00% of base)
          -1 : System.Private.CoreLib.dasm (-0.00% of base)
17 total files with Code Size differences (16 improved, 1 regressed), 247 unchanged.
Top method regressions (bytes):
          86 ( 3.62% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SourceMethodSymbol:DecodeDllImportAttribute(byref):this
           2 ( 0.66% of base) : xunit.console.dasm - <>c__DisplayClass12_1:<RunProject>b__5():XElement:this
Top method improvements (bytes):
       -2726 (-16.49% of base) : System.Net.Http.dasm - KnownHeaders:.cctor()
         -98 (-1.16% of base) : System.Net.WebSockets.WebSocketProtocol.dasm - <ReceiveAsyncPrivate>d__62`2:MoveNext():this (2 methods)
         -82 (-0.67% of base) : System.Net.WebSockets.dasm - <ReceiveAsyncPrivate>d__66`2:MoveNext():this (3 methods)
         -59 (-24.28% of base) : Microsoft.Extensions.DependencyModel.dasm - CompilationOptions:.cctor()
         -59 (-24.28% of base) : xunit.console.dasm - CompilationOptions:.cctor()
         -45 (-1.96% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DocumentationCommentWalker:DefaultVisit(SyntaxNode):this
         -32 (-6.88% of base) : xunit.performance.execution.dasm - BenchmarkEventSource:BenchmarkIterationStart(String,String,int):this
         -32 (-5.99% of base) : xunit.performance.execution.dasm - BenchmarkEventSource:BenchmarkIterationStop(String,String,int,long):this
         -29 (-0.56% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceMethodSymbol:DecodeWellKnownAttributeAppliedToMethod(byref):this
         -28 (-17.61% of base) : System.Drawing.Common.dasm - Graphics:CopyFromScreen(Point,Point,Size):this
         -25 (-2.74% of base) : System.Net.HttpListener.dasm - ReceiveOperation:ProcessAction_IndicateReceiveComplete(Nullable`1,int,int,ref,int,long):this
         -24 (-1.45% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindFilterQueryOperator(BoundQueryClauseBase,QueryClauseSyntax,String,TextSpan,ExpressionSyntax,DiagnosticBag):BoundQueryClause:this
         -23 (-0.50% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindCollectionRangeVariables(QueryClauseSyntax,BoundQueryClauseBase,SeparatedSyntaxList`1,byref,DiagnosticBag):BoundQueryClauseBase:this
         -23 (-0.99% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindLetClause(BoundQueryClauseBase,LetClauseSyntax,Enumerator,DiagnosticBag,bool):BoundQueryClause:this
         -21 (-2.00% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindSelectClause(BoundQueryClauseBase,SelectClauseSyntax,Enumerator,DiagnosticBag):BoundQueryClause:this
         -18 (-0.84% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - MethodCompiler:GenerateMethodBody(PEModuleBuilder,MethodSymbol,int,BoundStatement,ImmutableArray`1,ImmutableArray`1,StateMachineTypeSymbol,VariableSlotAllocator,DebugDocumentProvider,DiagnosticBag,bool):MethodBody
         -17 (-3.74% of base) : xunit.performance.execution.dasm - BenchmarkEventSource:BenchmarkStop(String,String,String):this
         -16 (-1.63% of base) : Microsoft.CodeAnalysis.dasm - DefinitionMap`1:TryCreateVariableSlotAllocator(EmitBaseline,IMethodSymbol,IMethodSymbol):VariableSlotAllocator:this
         -15 (-4.89% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:VisitForStatement(BoundForStatement):BoundNode:this
         -13 (-1.68% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - CodeGenerator:DefineLocal(LocalSymbol,VisualBasicSyntaxNode):LocalDefinition:this
Top method regressions (percentages):
          86 ( 3.62% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SourceMethodSymbol:DecodeDllImportAttribute(byref):this
           2 ( 0.66% of base) : xunit.console.dasm - <>c__DisplayClass12_1:<RunProject>b__5():XElement:this
Top method improvements (percentages):
         -59 (-24.28% of base) : Microsoft.Extensions.DependencyModel.dasm - CompilationOptions:.cctor()
         -59 (-24.28% of base) : xunit.console.dasm - CompilationOptions:.cctor()
         -28 (-17.61% of base) : System.Drawing.Common.dasm - Graphics:CopyFromScreen(Point,Point,Size):this
       -2726 (-16.49% of base) : System.Net.Http.dasm - KnownHeaders:.cctor()
          -8 (-16.33% of base) : System.Net.WebSockets.dasm - WebSocketReceiveResult:.ctor(int,int,bool):this
          -8 (-15.38% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VBSemanticModel:ComputeDeclarationsInNode(SyntaxNode,bool,List`1,CancellationToken,Nullable`1):this
          -8 (-8.25% of base) : System.Text.Json.dasm - JsonClassInfo:CreatePropertyInfoForClassInfo(Type,Type,JsonConverter,JsonSerializerOptions):JsonPropertyInfo
         -32 (-6.88% of base) : xunit.performance.execution.dasm - BenchmarkEventSource:BenchmarkIterationStart(String,String,int):this
         -32 (-5.99% of base) : xunit.performance.execution.dasm - BenchmarkEventSource:BenchmarkIterationStop(String,String,int,long):this
         -15 (-4.89% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:VisitForStatement(BoundForStatement):BoundNode:this
         -10 (-4.44% of base) : System.Text.Json.dasm - JsonClassInfo:AddProperty(PropertyInfo,Type,JsonSerializerOptions):JsonPropertyInfo
         -17 (-3.74% of base) : xunit.performance.execution.dasm - BenchmarkEventSource:BenchmarkStop(String,String,String):this
         -13 (-3.46% of base) : xunit.performance.execution.dasm - BenchmarkEventSource:BenchmarkStart(String,String):this
         -25 (-2.74% of base) : System.Net.HttpListener.dasm - ReceiveOperation:ProcessAction_IndicateReceiveComplete(Nullable`1,int,int,ref,int,long):this
         -12 (-2.71% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindDistinctClause(BoundQueryClauseBase,DistinctClauseSyntax,DiagnosticBag):BoundQueryClause:this
         -21 (-2.00% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindSelectClause(BoundQueryClauseBase,SelectClauseSyntax,Enumerator,DiagnosticBag):BoundQueryClause:this
         -45 (-1.96% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DocumentationCommentWalker:DefaultVisit(SyntaxNode):this
         -10 (-1.82% of base) : xunit.console.dasm - AssemblyHelper:.ctor(String,IMessageSink):this
         -11 (-1.75% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindPartitionClause(BoundQueryClauseBase,PartitionClauseSyntax,String,DiagnosticBag):BoundQueryClause:this
         -13 (-1.68% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - CodeGenerator:DefineLocal(LocalSymbol,VisualBasicSyntaxNode):LocalDefinition:this
50 total methods with Code Size differences (48 improved, 2 regressed), 187654 unchanged.
```
linux-x64 diff:
```
Total bytes of diff: -2268 (-0.01 % of base)
    diff is an improvement.
Top file improvements (bytes):
       -1908 : System.Net.Http.dasm (-0.33 % of base)
        -164 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.01 % of base)
         -62 : xunit.console.dasm (-0.09 % of base)
         -45 : Microsoft.Extensions.DependencyModel.dasm (-0.11 % of base)
         -31 : Microsoft.Extensions.Logging.Abstractions.dasm (-0.13 % of base)
         -17 : System.Text.Json.dasm (-0.00 % of base)
         -16 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00 % of base)
         -16 : System.Private.CoreLib.dasm (-0.00 % of base)
          -7 : System.Net.WebSockets.dasm (-0.01 % of base)
          -2 : System.Net.WebSockets.WebSocketProtocol.dasm (-0.01 % of base)
10 total files with Code Size differences (10 improved, 0 regressed), 254 unchanged.
Top method regressions (bytes):
           1 (0.15 % of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VisualBasicCompilation:Create(String,VisualBasicCompilationOptions,IEnumerable`1,IEnumerable`1,VisualBasicCompilation,Type,Type,bool):VisualBasicCompilation
Top method improvements (bytes):
       -1908 (-11.91 % of base) : System.Net.Http.dasm - KnownHeaders:.cctor()
         -40 (-18.26 % of base) : Microsoft.Extensions.DependencyModel.dasm - CompilationOptions:.cctor()
         -40 (-18.26 % of base) : xunit.console.dasm - CompilationOptions:.cctor()
         -38 (-5.35 % of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindPartitionClause(BoundQueryClauseBase,PartitionClauseSyntax,String,DiagnosticBag):BoundQueryClause:this
         -31 (-1.86 % of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindFilterQueryOperator(BoundQueryClauseBase,QueryClauseSyntax,String,TextSpan,ExpressionSyntax,DiagnosticBag):BoundQueryClause:this
         -31 (-13.84 % of base) : Microsoft.Extensions.Logging.Abstractions.dasm - LoggerExtensions:Log(ILogger,int,EventId,Exception,String,ref)
         -26 (-2.15 % of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindSelectClause(BoundQueryClauseBase,SelectClauseSyntax,Enumerator,DiagnosticBag):BoundQueryClause:this
         -25 (-0.53 % of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindCollectionRangeVariables(QueryClauseSyntax,BoundQueryClauseBase,SeparatedSyntaxList`1,byref,DiagnosticBag):BoundQueryClauseBase:this
         -25 (-1.05 % of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindLetClause(BoundQueryClauseBase,LetClauseSyntax,Enumerator,DiagnosticBag,bool):BoundQueryClause:this
         -16 (-3.45 % of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindDistinctClause(BoundQueryClauseBase,DistinctClauseSyntax,DiagnosticBag):BoundQueryClause:this
         -14 (-4.68 % of base) : xunit.console.dasm - <>c__DisplayClass12_1:<RunProject>b__5():XElement:this
         -13 (-4.26 % of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:VisitForStatement(BoundForStatement):BoundNode:this
         -10 (-10.10 % of base) : System.Text.Json.dasm - JsonClassInfo:CreatePropertyInfoForClassInfo(Type,Type,JsonConverter,JsonSerializerOptions):JsonPropertyInfo
          -7 (-3.02 % of base) : System.Text.Json.dasm - JsonClassInfo:AddProperty(PropertyInfo,Type,JsonSerializerOptions):JsonPropertyInfo
          -5 (-0.47 % of base) : Microsoft.Extensions.DependencyModel.dasm - DependencyContextJsonReader:ReadCompilationOptions(byref):CompilationOptions
          -5 (-1.63 % of base) : System.Net.WebSockets.dasm - ManagedWebSocket:ValidateAndReceiveAsync(Task,ref,CancellationToken):Task:this
          -5 (-0.71 % of base) : xunit.console.dasm - DependencyContextJsonReader:ReadCompilationOptions(JsonObject):CompilationOptions:this
          -3 (-0.14 % of base) : xunit.console.dasm - ConsoleRunner:RunProject(XunitProject,bool,Nullable`1,Nullable`1,Nullable`1,bool,bool,Nullable`1,bool,bool,bool):int:this
          -1 (-0.40 % of base) : Microsoft.CodeAnalysis.CSharp.dasm - CSharpCompilationOptions:.ctor(int,String,String,String,IEnumerable`1,int,bool,bool,String,String,ImmutableArray`1,Nullable`1,int,int,int,IEnumerable`1,bool,bool,XmlReferenceResolver,SourceReferenceResolver,MetadataReferenceResolver,AssemblyIdentityComparer,StrongNameProvider):this
          -1 (-0.41 % of base) : Microsoft.CodeAnalysis.CSharp.dasm - CSharpCompilationOptions:.ctor(int,bool,String,String,String,IEnumerable`1,int,bool,bool,String,String,ImmutableArray`1,Nullable`1,int,int,int,IEnumerable`1,bool,bool,XmlReferenceResolver,SourceReferenceResolver,MetadataReferenceResolver,AssemblyIdentityComparer,StrongNameProvider):this
Top method regressions (percentages):
           1 (0.15 % of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VisualBasicCompilation:Create(String,VisualBasicCompilationOptions,IEnumerable`1,IEnumerable`1,VisualBasicCompilation,Type,Type,bool):VisualBasicCompilation
Top method improvements (percentages):
         -40 (-18.26 % of base) : Microsoft.Extensions.DependencyModel.dasm - CompilationOptions:.cctor()
         -40 (-18.26 % of base) : xunit.console.dasm - CompilationOptions:.cctor()
         -31 (-13.84 % of base) : Microsoft.Extensions.Logging.Abstractions.dasm - LoggerExtensions:Log(ILogger,int,EventId,Exception,String,ref)
       -1908 (-11.91 % of base) : System.Net.Http.dasm - KnownHeaders:.cctor()
         -10 (-10.10 % of base) : System.Text.Json.dasm - JsonClassInfo:CreatePropertyInfoForClassInfo(Type,Type,JsonConverter,JsonSerializerOptions):JsonPropertyInfo
         -38 (-5.35 % of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindPartitionClause(BoundQueryClauseBase,PartitionClauseSyntax,String,DiagnosticBag):BoundQueryClause:this
         -14 (-4.68 % of base) : xunit.console.dasm - <>c__DisplayClass12_1:<RunProject>b__5():XElement:this
         -13 (-4.26 % of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:VisitForStatement(BoundForStatement):BoundNode:this
         -16 (-3.45 % of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindDistinctClause(BoundQueryClauseBase,DistinctClauseSyntax,DiagnosticBag):BoundQueryClause:this
          -7 (-3.02 % of base) : System.Text.Json.dasm - JsonClassInfo:AddProperty(PropertyInfo,Type,JsonSerializerOptions):JsonPropertyInfo
         -26 (-2.15 % of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindSelectClause(BoundQueryClauseBase,SelectClauseSyntax,Enumerator,DiagnosticBag):BoundQueryClause:this
         -31 (-1.86 % of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindFilterQueryOperator(BoundQueryClauseBase,QueryClauseSyntax,String,TextSpan,ExpressionSyntax,DiagnosticBag):BoundQueryClause:this
          -5 (-1.63 % of base) : System.Net.WebSockets.dasm - ManagedWebSocket:ValidateAndReceiveAsync(Task,ref,CancellationToken):Task:this
          -1 (-1.47 % of base) : System.Private.CoreLib.dasm - Task`1:DangerousSetResult(VoidTaskResult):this
          -1 (-1.08 % of base) : System.Private.CoreLib.dasm - AsyncIteratorMethodBuilder:Complete():this
         -25 (-1.05 % of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindLetClause(BoundQueryClauseBase,LetClauseSyntax,Enumerator,DiagnosticBag,bool):BoundQueryClause:this
          -1 (-1.04 % of base) : System.Private.CoreLib.dasm - AsyncTaskMethodBuilder:SetResult():this
          -1 (-0.88 % of base) : System.Private.CoreLib.dasm - AsyncVoidMethodBuilder:SetResult():this
          -5 (-0.71 % of base) : xunit.console.dasm - DependencyContextJsonReader:ReadCompilationOptions(JsonObject):CompilationOptions:this
          -1 (-0.68 % of base) : System.Private.CoreLib.dasm - AsyncValueTaskMethodBuilder:SetResult():this
46 total methods with Code Size differences (45 improved, 1 regressed), 180858 unchanged.
```
alt-arm64 diff:
```
Total bytes of diff: -128 (-0.00% of base)
    diff is an improvement.
Top file improvements (bytes):
         -64 : Microsoft.Extensions.DependencyModel.dasm (-0.04% of base)
         -32 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.00% of base)
         -32 : xunit.console.dasm (-0.01% of base)
3 total files with Code Size differences (3 improved, 0 regressed), 261 unchanged.
Top method regressions (bytes):
          16 ( 0.27% of base) : xunit.console.dasm - ConsoleRunner:RunProject(XunitProject,bool,Nullable`1,Nullable`1,Nullable`1,bool,bool,Nullable`1,bool,bool,bool):int:this (2 methods)
          16 ( 2.70% of base) : xunit.console.dasm - <>c__DisplayClass12_1:<RunProject>b__5():XElement:this (2 methods)
Top method improvements (bytes):
         -64 (-10.26% of base) : Microsoft.Extensions.DependencyModel.dasm - CompilationOptions:.cctor() (2 methods)
         -64 (-10.26% of base) : xunit.console.dasm - CompilationOptions:.cctor() (2 methods)
         -32 (-0.86% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VisualBasicCompilation:Create(String,VisualBasicCompilationOptions,IEnumerable`1,IEnumerable`1,VisualBasicCompilation,Type,Type,bool):VisualBasicCompilation (4 methods)
Top method regressions (percentages):
          16 ( 2.70% of base) : xunit.console.dasm - <>c__DisplayClass12_1:<RunProject>b__5():XElement:this (2 methods)
          16 ( 0.27% of base) : xunit.console.dasm - ConsoleRunner:RunProject(XunitProject,bool,Nullable`1,Nullable`1,Nullable`1,bool,bool,Nullable`1,bool,bool,bool):int:this (2 methods)
Top method improvements (percentages):
         -64 (-10.26% of base) : Microsoft.Extensions.DependencyModel.dasm - CompilationOptions:.cctor() (2 methods)
         -64 (-10.26% of base) : xunit.console.dasm - CompilationOptions:.cctor() (2 methods)
         -32 (-0.86% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VisualBasicCompilation:Create(String,VisualBasicCompilationOptions,IEnumerable`1,IEnumerable`1,VisualBasicCompilation,Type,Type,bool):VisualBasicCompilation (4 methods)
5 total methods with Code Size differences (3 improved, 2 regressed), 187182 unchanged.
```
alt-arm32 diff:
```
Total bytes of diff: -1548 (-0.00% of base)
    diff is an improvement.
Top file regressions (bytes):
         304 : Microsoft.CodeAnalysis.CSharp.dasm (0.00% of base)
         128 : Microsoft.CodeAnalysis.VisualBasic.dasm (0.00% of base)
          16 : System.Transactions.Local.dasm (0.01% of base)
Top file improvements (bytes):
       -1504 : System.Text.Json.dasm (-0.14% of base)
        -228 : xunit.performance.execution.dasm (-0.59% of base)
         -84 : Microsoft.Extensions.DependencyModel.dasm (-0.08% of base)
         -64 : xunit.console.dasm (-0.04% of base)
         -48 : System.Net.Http.dasm (-0.00% of base)
         -36 : Microsoft.Extensions.Logging.Abstractions.dasm (-0.05% of base)
         -12 : System.Configuration.ConfigurationManager.dasm (-0.00% of base)
         -12 : xunit.runner.utility.netcoreapp10.dasm (-0.00% of base)
          -8 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
12 total files with Code Size differences (9 improved, 3 regressed), 252 unchanged.
Top method regressions (bytes):
         304 ( 2.56% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SourceMethodSymbol:DecodeDllImportAttribute(byref):this (4 methods)
         232 ( 0.89% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceMethodSymbol:DecodeWellKnownAttributeAppliedToMethod(byref):this (4 methods)
          16 ( 0.34% of base) : System.Transactions.Local.dasm - TransactionScope:.ctor(int,TransactionOptions,int):this (4 methods)
          12 ( 2.70% of base) : xunit.console.dasm - <>c__DisplayClass12_1:<RunProject>b__5():XElement:this (2 methods)
           8 ( 0.17% of base) : xunit.console.dasm - ConsoleRunner:RunProject(XunitProject,bool,Nullable`1,Nullable`1,Nullable`1,bool,bool,Nullable`1,bool,bool,bool):int:this (2 methods)
Top method improvements (bytes):
        -168 (-4.81% of base) : System.Text.Json.dasm - Utf8JsonWriter:WriteStringIndented(ReadOnlySpan`1,Guid):this (4 methods)
        -164 (-7.48% of base) : System.Text.Json.dasm - Utf8JsonWriter:WriteNumberMinimized(ReadOnlySpan`1,Decimal):this (4 methods)
        -164 (-6.79% of base) : System.Text.Json.dasm - Utf8JsonWriter:WriteStringMinimized(ReadOnlySpan`1,Guid):this (4 methods)
        -160 (-4.95% of base) : System.Text.Json.dasm - Utf8JsonWriter:WriteNumberIndented(ReadOnlySpan`1,Decimal):this (4 methods)
        -144 (-3.49% of base) : System.Text.Json.dasm - Utf8JsonWriter:WriteNumberMinimized(ReadOnlySpan`1,long):this (8 methods)
        -128 (-2.06% of base) : System.Text.Json.dasm - Utf8JsonWriter:WriteNumberIndented(ReadOnlySpan`1,long):this (8 methods)
        -112 (-8.92% of base) : System.Text.Json.dasm - Utf8JsonWriter:WriteNumberValueMinimized(long):this (4 methods)
        -104 (-14.94% of base) : System.Text.Json.dasm - Utf8JsonWriter:WriteNumberValueMinimized(Decimal):this (2 methods)
        -104 (-12.87% of base) : System.Text.Json.dasm - Utf8JsonWriter:WriteStringValueMinimized(Guid):this (2 methods)
         -88 (-7.72% of base) : System.Text.Json.dasm - Utf8JsonWriter:WriteNumberValueIndented(Decimal):this (2 methods)
         -84 (-17.50% of base) : Microsoft.Extensions.DependencyModel.dasm - CompilationOptions:.cctor() (2 methods)
         -84 (-6.48% of base) : System.Text.Json.dasm - Utf8JsonWriter:WriteStringValueIndented(Guid):this (2 methods)
         -84 (-17.50% of base) : xunit.console.dasm - CompilationOptions:.cctor() (2 methods)
         -72 (-3.37% of base) : System.Text.Json.dasm - Utf8JsonWriter:WriteNumberValueIndented(long):this (4 methods)
         -68 (-4.04% of base) : xunit.performance.execution.dasm - BenchmarkEventSource:BenchmarkIterationStop(String,String,int,long):this (2 methods)
         -64 (-4.79% of base) : xunit.performance.execution.dasm - BenchmarkEventSource:BenchmarkIterationStart(String,String,int):this (2 methods)
         -52 (-4.21% of base) : xunit.performance.execution.dasm - BenchmarkEventSource:BenchmarkStop(String,String,String):this (2 methods)
         -44 (-4.80% of base) : xunit.performance.execution.dasm - BenchmarkEventSource:BenchmarkStart(String,String):this (2 methods)
         -36 (-8.26% of base) : Microsoft.Extensions.Logging.Abstractions.dasm - LoggerExtensions:Log(ILogger,int,EventId,Exception,String,ref) (2 methods)
         -32 (-3.48% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindTakeWhileClause(BoundQueryClauseBase,PartitionWhileClauseSyntax,DiagnosticBag):BoundQueryClause:this (4 methods)
Top method regressions (percentages):
          12 ( 2.70% of base) : xunit.console.dasm - <>c__DisplayClass12_1:<RunProject>b__5():XElement:this (2 methods)
         304 ( 2.56% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SourceMethodSymbol:DecodeDllImportAttribute(byref):this (4 methods)
         232 ( 0.89% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceMethodSymbol:DecodeWellKnownAttributeAppliedToMethod(byref):this (4 methods)
          16 ( 0.34% of base) : System.Transactions.Local.dasm - TransactionScope:.ctor(int,TransactionOptions,int):this (4 methods)
           8 ( 0.17% of base) : xunit.console.dasm - ConsoleRunner:RunProject(XunitProject,bool,Nullable`1,Nullable`1,Nullable`1,bool,bool,Nullable`1,bool,bool,bool):int:this (2 methods)
Top method improvements (percentages):
         -84 (-17.50% of base) : Microsoft.Extensions.DependencyModel.dasm - CompilationOptions:.cctor() (2 methods)
         -84 (-17.50% of base) : xunit.console.dasm - CompilationOptions:.cctor() (2 methods)
        -104 (-14.94% of base) : System.Text.Json.dasm - Utf8JsonWriter:WriteNumberValueMinimized(Decimal):this (2 methods)
        -104 (-12.87% of base) : System.Text.Json.dasm - Utf8JsonWriter:WriteStringValueMinimized(Guid):this (2 methods)
        -112 (-8.92% of base) : System.Text.Json.dasm - Utf8JsonWriter:WriteNumberValueMinimized(long):this (4 methods)
         -36 (-8.26% of base) : Microsoft.Extensions.Logging.Abstractions.dasm - LoggerExtensions:Log(ILogger,int,EventId,Exception,String,ref) (2 methods)
         -88 (-7.72% of base) : System.Text.Json.dasm - Utf8JsonWriter:WriteNumberValueIndented(Decimal):this (2 methods)
        -164 (-7.48% of base) : System.Text.Json.dasm - Utf8JsonWriter:WriteNumberMinimized(ReadOnlySpan`1,Decimal):this (4 methods)
        -164 (-6.79% of base) : System.Text.Json.dasm - Utf8JsonWriter:WriteStringMinimized(ReadOnlySpan`1,Guid):this (4 methods)
         -32 (-6.78% of base) : System.Net.Http.dasm - HttpConnection:WriteDecimalInt32Async(int):Task:this (2 methods)
         -84 (-6.48% of base) : System.Text.Json.dasm - Utf8JsonWriter:WriteStringValueIndented(Guid):this (2 methods)
        -160 (-4.95% of base) : System.Text.Json.dasm - Utf8JsonWriter:WriteNumberIndented(ReadOnlySpan`1,Decimal):this (4 methods)
        -168 (-4.81% of base) : System.Text.Json.dasm - Utf8JsonWriter:WriteStringIndented(ReadOnlySpan`1,Guid):this (4 methods)
         -44 (-4.80% of base) : xunit.performance.execution.dasm - BenchmarkEventSource:BenchmarkStart(String,String):this (2 methods)
         -64 (-4.79% of base) : xunit.performance.execution.dasm - BenchmarkEventSource:BenchmarkIterationStart(String,String,int):this (2 methods)
         -52 (-4.21% of base) : xunit.performance.execution.dasm - BenchmarkEventSource:BenchmarkStop(String,String,String):this (2 methods)
         -68 (-4.04% of base) : xunit.performance.execution.dasm - BenchmarkEventSource:BenchmarkIterationStop(String,String,int,long):this (2 methods)
        -144 (-3.49% of base) : System.Text.Json.dasm - Utf8JsonWriter:WriteNumberMinimized(ReadOnlySpan`1,long):this (8 methods)
         -32 (-3.48% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindTakeWhileClause(BoundQueryClauseBase,PartitionWhileClauseSyntax,DiagnosticBag):BoundQueryClause:this (4 methods)
         -32 (-3.48% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindSkipWhileClause(BoundQueryClauseBase,PartitionWhileClauseSyntax,DiagnosticBag):BoundQueryClause:this (4 methods)
38 total methods with Code Size differences (33 improved, 5 regressed), 187039 unchanged.
```
Regression in `SourceMethodSymbol:DecodeDllImportAttribute` is caused by changes in register allocation. Removing one struct stack arg temp can result in other arg temps no longer being created because call arg morphing code (probably wrongly) believes that the stack arg temp has side effects. 