### PR TITLE
Do not introduce temp copies for SIMD reg args

### DIFF
--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -4749,7 +4749,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
                 genConsumeReg(putArgRegNode);
 
                 // Validate the putArgRegNode has the right type.
-                assert(varTypeIsFloating(putArgRegNode->TypeGet()) == genIsValidFloatReg(argReg));
+                assert(varTypeUsesFloatReg(putArgRegNode->GetType()) == genIsValidFloatReg(argReg));
                 if (putArgRegNode->GetRegNum() != argReg)
                 {
                     inst_RV_RV(ins_Move_Extend(putArgRegNode->TypeGet(), false), argReg, putArgRegNode->GetRegNum());

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -1553,9 +1553,9 @@ public:
         regType = type;
     }
 
-    var_types GetRegType() const
+    var_types GetRegType(unsigned i = 0) const
     {
-        assert(numRegs > 0);
+        assert(i < numRegs);
         return regType;
     }
 #elif defined(UNIX_AMD64_ABI)

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -4503,12 +4503,13 @@ GenTree* Compiler::fgMorphMultiregStructArg(GenTree* arg, fgArgTabEntry* fgEntry
 #ifdef FEATURE_HFA
     if (fgEntryPtr->IsHfaArg())
     {
-        unsigned elemSize = genTypeSize(fgEntryPtr->GetRegType());
-        elemCount         = structSize / elemSize;
-        assert(elemSize * elemCount == structSize);
-        for (unsigned inx = 0; inx < elemCount; inx++)
+        // If it's HFA then it should never be split.
+        assert(fgEntryPtr->GetSlotCount() == 0);
+
+        elemCount = fgEntryPtr->GetRegCount();
+        for (unsigned i = 0; i < elemCount; i++)
         {
-            type[inx] = fgEntryPtr->GetRegType();
+            type[i] = fgEntryPtr->GetRegType(i);
         }
     }
     else

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -4535,17 +4535,8 @@ GenTree* Compiler::fgMorphMultiregStructArg(GenTree* arg, fgArgTabEntry* fgEntry
         }
 
 #ifndef UNIX_AMD64_ABI
-        if (arg->OperIs(GT_LCL_VAR, GT_LCL_FLD))
+        if (arg->OperIs(GT_OBJ))
         {
-            // We can safely widen this to aligned bytes since we are loading from
-            // a GT_LCL_VAR or a GT_LCL_FLD which is properly padded and
-            // lives in the stack frame or will be a promoted field.
-            structSize = elemCount * TARGET_POINTER_SIZE;
-        }
-        else
-        {
-            assert(arg->OperIs(GT_OBJ));
-
             // We need to load the struct from an arbitrary address
             // and we can't read past the end of the structSize
             // We adjust the last load type here


### PR DESCRIPTION
linux-x64:
```
Total bytes of diff: -205 (-0.00 % of base)
    diff is an improvement.
Top file improvements (bytes):
        -205 : System.Private.CoreLib.dasm (-0.01 % of base)
1 total files with Code Size differences (1 improved, 0 regressed), 263 unchanged.
Top method regressions (bytes):
          42 (2.22 % of base) : System.Private.CoreLib.dasm - Matrix4x4:Decompose(Matrix4x4,byref,byref,byref):bool
           2 (0.42 % of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateReflection(Plane):Matrix4x4
           2 (1.06 % of base) : System.Private.CoreLib.dasm - Plane:Normalize(Plane):Plane
Top method improvements (bytes):
         -64 (-3.90 % of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateConstrainedBillboard(Vector3,Vector3,Vector3,Vector3,Vector3):Matrix4x4
         -36 (-3.80 % of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateLookAt(Vector3,Vector3,Vector3):Matrix4x4
         -21 (-2.43 % of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateBillboard(Vector3,Vector3,Vector3,Vector3):Matrix4x4
         -16 (-2.21 % of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateWorld(Vector3,Vector3,Vector3):Matrix4x4
         -14 (-16.09 % of base) : System.Private.CoreLib.dasm - Plane:DotCoordinate(Plane,Vector3):float
         -14 (-17.07 % of base) : System.Private.CoreLib.dasm - Plane:DotNormal(Plane,Vector3):float
         -13 (-15.48 % of base) : System.Private.CoreLib.dasm - Vector3:Distance(Vector3,Vector3):float
         -13 (-16.05 % of base) : System.Private.CoreLib.dasm - Vector3:DistanceSquared(Vector3,Vector3):float
         -13 (-20.31 % of base) : System.Private.CoreLib.dasm - Vector4:Distance(Vector4,Vector4):float
         -13 (-21.31 % of base) : System.Private.CoreLib.dasm - Vector4:DistanceSquared(Vector4,Vector4):float
         -10 (-2.53 % of base) : System.Private.CoreLib.dasm - Plane:CreateFromVertices(Vector3,Vector3,Vector3):Plane
         -10 (-9.90 % of base) : System.Private.CoreLib.dasm - Vector128:AsVector128(Vector3):Vector128`1
          -6 (-4.29 % of base) : System.Private.CoreLib.dasm - Vector3:Reflect(Vector3,Vector3):Vector3
          -4 (-0.71 % of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateShadow(Vector3,Plane):Matrix4x4
          -4 (-5.71 % of base) : System.Private.CoreLib.dasm - Vector128:AsVector128(Vector2):Vector128`1
Top method regressions (percentages):
          42 (2.22 % of base) : System.Private.CoreLib.dasm - Matrix4x4:Decompose(Matrix4x4,byref,byref,byref):bool
           2 (1.06 % of base) : System.Private.CoreLib.dasm - Plane:Normalize(Plane):Plane
           2 (0.42 % of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateReflection(Plane):Matrix4x4
Top method improvements (percentages):
         -13 (-21.31 % of base) : System.Private.CoreLib.dasm - Vector4:DistanceSquared(Vector4,Vector4):float
         -13 (-20.31 % of base) : System.Private.CoreLib.dasm - Vector4:Distance(Vector4,Vector4):float
         -14 (-17.07 % of base) : System.Private.CoreLib.dasm - Plane:DotNormal(Plane,Vector3):float
         -14 (-16.09 % of base) : System.Private.CoreLib.dasm - Plane:DotCoordinate(Plane,Vector3):float
         -13 (-16.05 % of base) : System.Private.CoreLib.dasm - Vector3:DistanceSquared(Vector3,Vector3):float
         -13 (-15.48 % of base) : System.Private.CoreLib.dasm - Vector3:Distance(Vector3,Vector3):float
         -10 (-9.90 % of base) : System.Private.CoreLib.dasm - Vector128:AsVector128(Vector3):Vector128`1
          -4 (-5.71 % of base) : System.Private.CoreLib.dasm - Vector128:AsVector128(Vector2):Vector128`1
          -6 (-4.29 % of base) : System.Private.CoreLib.dasm - Vector3:Reflect(Vector3,Vector3):Vector3
         -64 (-3.90 % of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateConstrainedBillboard(Vector3,Vector3,Vector3,Vector3,Vector3):Matrix4x4
         -36 (-3.80 % of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateLookAt(Vector3,Vector3,Vector3):Matrix4x4
         -10 (-2.53 % of base) : System.Private.CoreLib.dasm - Plane:CreateFromVertices(Vector3,Vector3,Vector3):Plane
         -21 (-2.43 % of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateBillboard(Vector3,Vector3,Vector3,Vector3):Matrix4x4
         -16 (-2.21 % of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateWorld(Vector3,Vector3,Vector3):Matrix4x4
          -4 (-0.71 % of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateShadow(Vector3,Plane):Matrix4x4
18 total methods with Code Size differences (15 improved, 3 regressed), 180886 unchanged.
```
alt-arm64:
```
Total bytes of diff: -1720 (-0.00% of base)
    diff is an improvement.
Top file improvements (bytes):
       -1720 : System.Private.CoreLib.dasm (-0.02% of base)
1 total files with Code Size differences (1 improved, 0 regressed), 263 unchanged.
Top method improvements (bytes):
        -360 (-11.78% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateConstrainedBillboard(Vector3,Vector3,Vector3,Vector3,Vector3):Matrix4x4 (2 methods)
        -216 (-12.44% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateLookAt(Vector3,Vector3,Vector3):Matrix4x4 (2 methods)
        -104 (-7.51% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateBillboard(Vector3,Vector3,Vector3,Vector3):Matrix4x4 (2 methods)
         -96 (-8.00% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateWorld(Vector3,Vector3,Vector3):Matrix4x4 (2 methods)
         -72 (-23.08% of base) : System.Private.CoreLib.dasm - Vector4:Distance(Vector4,Vector4):float (2 methods)
         -72 (-23.68% of base) : System.Private.CoreLib.dasm - Vector4:DistanceSquared(Vector4,Vector4):float (2 methods)
         -64 (-21.05% of base) : System.Private.CoreLib.dasm - Vector4:Normalize(Vector4):Vector4 (2 methods)
         -56 (-21.21% of base) : System.Private.CoreLib.dasm - Vector3:Distance(Vector3,Vector3):float (2 methods)
         -56 (-21.88% of base) : System.Private.CoreLib.dasm - Vector3:DistanceSquared(Vector3,Vector3):float (2 methods)
         -56 (-19.44% of base) : System.Private.CoreLib.dasm - Vector128:AsVector128(Vector3):Vector128`1 (2 methods)
         -48 (-5.08% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateShadow(Vector3,Plane):Matrix4x4 (2 methods)
         -48 (-5.77% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateReflection(Plane):Matrix4x4 (2 methods)
         -48 (-11.32% of base) : System.Private.CoreLib.dasm - Plane:Normalize(Plane):Plane (2 methods)
         -48 (-19.35% of base) : System.Private.CoreLib.dasm - Plane:DotCoordinate(Plane,Vector3):float (2 methods)
         -48 (-20.69% of base) : System.Private.CoreLib.dasm - Plane:DotNormal(Plane,Vector3):float (2 methods)
         -48 (-18.75% of base) : System.Private.CoreLib.dasm - Vector3:Normalize(Vector3):Vector3 (2 methods)
         -48 (-15.38% of base) : System.Private.CoreLib.dasm - Vector3:Reflect(Vector3,Vector3):Vector3 (2 methods)
         -48 (-17.65% of base) : System.Private.CoreLib.dasm - Vector128:AsVector128(Vector2):Vector128`1 (2 methods)
         -40 (-5.05% of base) : System.Private.CoreLib.dasm - Plane:CreateFromVertices(Vector3,Vector3,Vector3):Plane (2 methods)
         -40 (-18.52% of base) : System.Private.CoreLib.dasm - Vector2:Distance(Vector2,Vector2):float (2 methods)
Top method improvements (percentages):
         -72 (-23.68% of base) : System.Private.CoreLib.dasm - Vector4:DistanceSquared(Vector4,Vector4):float (2 methods)
         -72 (-23.08% of base) : System.Private.CoreLib.dasm - Vector4:Distance(Vector4,Vector4):float (2 methods)
         -56 (-21.88% of base) : System.Private.CoreLib.dasm - Vector3:DistanceSquared(Vector3,Vector3):float (2 methods)
         -56 (-21.21% of base) : System.Private.CoreLib.dasm - Vector3:Distance(Vector3,Vector3):float (2 methods)
         -64 (-21.05% of base) : System.Private.CoreLib.dasm - Vector4:Normalize(Vector4):Vector4 (2 methods)
         -48 (-20.69% of base) : System.Private.CoreLib.dasm - Plane:DotNormal(Plane,Vector3):float (2 methods)
         -56 (-19.44% of base) : System.Private.CoreLib.dasm - Vector128:AsVector128(Vector3):Vector128`1 (2 methods)
         -48 (-19.35% of base) : System.Private.CoreLib.dasm - Plane:DotCoordinate(Plane,Vector3):float (2 methods)
         -40 (-19.23% of base) : System.Private.CoreLib.dasm - Vector2:DistanceSquared(Vector2,Vector2):float (2 methods)
         -48 (-18.75% of base) : System.Private.CoreLib.dasm - Vector3:Normalize(Vector3):Vector3 (2 methods)
         -40 (-18.52% of base) : System.Private.CoreLib.dasm - Vector2:Distance(Vector2,Vector2):float (2 methods)
         -48 (-17.65% of base) : System.Private.CoreLib.dasm - Vector128:AsVector128(Vector2):Vector128`1 (2 methods)
         -32 (-15.38% of base) : System.Private.CoreLib.dasm - Vector2:Normalize(Vector2):Vector2 (2 methods)
         -48 (-15.38% of base) : System.Private.CoreLib.dasm - Vector3:Reflect(Vector3,Vector3):Vector3 (2 methods)
        -216 (-12.44% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateLookAt(Vector3,Vector3,Vector3):Matrix4x4 (2 methods)
         -32 (-12.12% of base) : System.Private.CoreLib.dasm - Vector2:Reflect(Vector2,Vector2):Vector2 (2 methods)
        -360 (-11.78% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateConstrainedBillboard(Vector3,Vector3,Vector3,Vector3,Vector3):Matrix4x4 (2 methods)
         -48 (-11.32% of base) : System.Private.CoreLib.dasm - Plane:Normalize(Plane):Plane (2 methods)
         -96 (-8.00% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateWorld(Vector3,Vector3,Vector3):Matrix4x4 (2 methods)
        -104 (-7.51% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateBillboard(Vector3,Vector3,Vector3,Vector3):Matrix4x4 (2 methods)
23 total methods with Code Size differences (23 improved, 0 regressed), 187164 unchanged.
```
In Matrix4x4:Decompose this wasn't enough to prevent a promoted SIMD local to become DNER. fgMorphCopyBlock also can't handle copies between promoted and unpromoted SIMD locals without DNERing the promoted side. And in this case this happens only after fgMorphArgs thought it's dealing with a P-INDEP local...