### PR TITLE
Use extended/shifted ARM64 instruction forms

### DIFF
--- a/src/coreclr/src/jit/CMakeLists.txt
+++ b/src/coreclr/src/jit/CMakeLists.txt
@@ -268,6 +268,7 @@ set( JIT_ARM64_SOURCES
   lowerarmarch.cpp
   lsraarmarch.cpp
   lsraarm64.cpp
+  lowerarm64.cpp
   simd.cpp
   simdashwintrinsic.cpp
   targetarm64.cpp

--- a/src/coreclr/src/jit/codegen.h
+++ b/src/coreclr/src/jit/codegen.h
@@ -215,8 +215,6 @@ protected:
 #ifdef DEBUG
     // Last instr we have displayed for dspInstrs
     unsigned genCurDispOffset;
-
-    static const char* genInsName(instruction ins);
 #endif // DEBUG
 
     //-------------------------------------------------------------------------
@@ -1207,6 +1205,7 @@ protected:
     void genCodeForPhysReg(GenTreePhysReg* tree);
     void genCodeForNullCheck(GenTreeIndir* tree);
     void genCodeForCmpXchg(GenTreeCmpXchg* tree);
+    void genCodeForInstr(GenTreeInstr* instr);
 
     void genAlignStackBeforeCall(GenTreePutArgStk* putArgStk);
     void genAlignStackBeforeCall(GenTreeCall* call);

--- a/src/coreclr/src/jit/codegenarm.cpp
+++ b/src/coreclr/src/jit/codegenarm.cpp
@@ -1846,4 +1846,9 @@ void CodeGen::genAllocLclFrame(unsigned  frameSize,
 #endif // USING_SCOPE_INFO
 }
 
+void CodeGen::genCodeForInstr(GenTreeInstr* instr)
+{
+    unreached();
+}
+
 #endif // TARGET_ARM

--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -9718,8 +9718,11 @@ void CodeGen::genCodeForInstr(GenTreeInstr* instr)
         switch (ins)
         {
             case INS_and:
+            case INS_bic:
             case INS_orr:
+            case INS_orn:
             case INS_eor:
+            case INS_eon:
                 if (opt != INS_OPTS_NONE)
                 {
                     GetEmitter()->emitIns_R_R_R_I(ins, attr, dstReg, srcReg1, srcReg2, imm, opt);

--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -9645,6 +9645,13 @@ void CodeGen::genAllocLclFrame(unsigned  frameSize,
     }
 }
 
+ssize_t DecodeBitmaskImm(unsigned encoded, emitAttr size)
+{
+    emitter::bitMaskImm imm;
+    imm.immNRS = encoded;
+    return emitter::emitDecodeBitMaskImm(imm, size);
+}
+
 void CodeGen::genCodeForInstr(GenTreeInstr* instr)
 {
     if (instr->GetNumOps() == 1)
@@ -9653,6 +9660,13 @@ void CodeGen::genCodeForInstr(GenTreeInstr* instr)
 
         switch (instr->GetIns())
         {
+            case INS_and:
+            case INS_orr:
+            case INS_eor:
+                GetEmitter()->emitIns_R_R_I(instr->GetIns(), instr->GetAttr(), instr->GetRegNum(), srcReg1,
+                                            DecodeBitmaskImm(instr->GetImmediate(), instr->GetAttr()));
+                break;
+
             case INS_asr:
             case INS_lsr:
             case INS_lsl:

--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -3541,14 +3541,13 @@ void CodeGen::genCodeForJumpCompare(GenTreeOp* tree)
 
     if (tree->gtFlags & GTF_JCMP_TST)
     {
-        ssize_t compareImm = op2->AsIntCon()->IconValue();
+        size_t imm = static_cast<size_t>(op2->AsIntCon()->GetValue());
 
-        assert(isPow2(compareImm));
+        assert(imm < EA_SIZE(attr) * 8);
 
         instruction ins = (tree->gtFlags & GTF_JCMP_EQ) ? INS_tbz : INS_tbnz;
-        int         imm = genLog2((size_t)compareImm);
 
-        GetEmitter()->emitIns_J_R_I(ins, attr, compiler->compCurBB->bbJumpDest, reg, imm);
+        GetEmitter()->emitIns_J_R_I(ins, attr, compiler->compCurBB->bbJumpDest, reg, static_cast<int>(imm));
     }
     else
     {

--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -9701,6 +9701,13 @@ void CodeGen::genCodeForInstr(GenTreeInstr* instr)
                 }
                 break;
 
+            case INS_sbfiz:
+            case INS_ubfiz:
+            case INS_sbfx:
+            case INS_ubfx:
+                GetEmitter()->emitIns_R_R_I_I(ins, attr, dstReg, srcReg1, imm >> 6, imm & 63);
+                break;
+
             default:
                 GetEmitter()->emitIns_R_R(ins, attr, dstReg, srcReg1);
                 break;

--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -9660,6 +9660,12 @@ void CodeGen::genCodeForInstr(GenTreeInstr* instr)
 
         switch (instr->GetIns())
         {
+            case INS_add:
+            case INS_sub:
+                GetEmitter()->emitIns_R_R_I(instr->GetIns(), instr->GetAttr(), instr->GetRegNum(), srcReg1,
+                                            instr->GetImmediate());
+                break;
+
             case INS_and:
             case INS_orr:
             case INS_eor:

--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -9664,6 +9664,11 @@ void CodeGen::genCodeForInstr(GenTreeInstr* instr)
 
         switch (ins)
         {
+            case INS_mul:
+                // Special case - INS_mul with a single operand is treated as ADD ..., x1, x1, LSL #imm
+                GetEmitter()->emitIns_R_R_R_I(INS_add, attr, dstReg, srcReg1, srcReg1, imm, INS_OPTS_LSL);
+                break;
+
             case INS_add:
             case INS_sub:
             case INS_asr:

--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -9690,6 +9690,7 @@ void CodeGen::genCodeForInstr(GenTreeInstr* instr)
                 break;
 
             case INS_mvn:
+            case INS_neg:
                 if (opt != INS_OPTS_NONE)
                 {
                     GetEmitter()->emitIns_R_R_I(ins, attr, dstReg, srcReg1, imm, opt);

--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -9647,7 +9647,11 @@ void CodeGen::genAllocLclFrame(unsigned  frameSize,
 
 void CodeGen::genCodeForInstr(GenTreeInstr* instr)
 {
-    unreached();
+    regNumber srcReg1 = genConsumeReg(instr->GetOp(0));
+
+    GetEmitter()->emitIns_R_R(instr->GetIns(), instr->GetAttr(), instr->GetRegNum(), srcReg1);
+
+    genProduceReg(instr);
 }
 
 #endif // TARGET_ARM64

--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -9717,6 +9717,8 @@ void CodeGen::genCodeForInstr(GenTreeInstr* instr)
 
         switch (ins)
         {
+            case INS_add:
+            case INS_sub:
             case INS_and:
             case INS_bic:
             case INS_orr:

--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -9645,4 +9645,9 @@ void CodeGen::genAllocLclFrame(unsigned  frameSize,
     }
 }
 
+void CodeGen::genCodeForInstr(GenTreeInstr* instr)
+{
+    unreached();
+}
+
 #endif // TARGET_ARM64

--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -9681,6 +9681,16 @@ void CodeGen::genCodeForInstr(GenTreeInstr* instr)
                                             instr->GetImmediate());
                 break;
 
+            case INS_cmp:
+            case INS_cmn:
+                GetEmitter()->emitIns_R_I(instr->GetIns(), instr->GetAttr(), srcReg1, instr->GetImmediate());
+                break;
+
+            case INS_tst:
+                GetEmitter()->emitIns_R_I(instr->GetIns(), instr->GetAttr(), srcReg1,
+                                          DecodeBitmaskImm(instr->GetImmediate(), instr->GetAttr()));
+                break;
+
             default:
                 GetEmitter()->emitIns_R_R(instr->GetIns(), instr->GetAttr(), instr->GetRegNum(), srcReg1);
                 break;
@@ -9691,10 +9701,24 @@ void CodeGen::genCodeForInstr(GenTreeInstr* instr)
         regNumber srcReg1 = genConsumeReg(instr->GetOp(0));
         regNumber srcReg2 = genConsumeReg(instr->GetOp(1));
 
-        GetEmitter()->emitIns_R_R_R(instr->GetIns(), instr->GetAttr(), instr->GetRegNum(), srcReg1, srcReg2);
+        switch (instr->GetIns())
+        {
+            case INS_cmp:
+            case INS_cmn:
+            case INS_tst:
+                GetEmitter()->emitIns_R_R(instr->GetIns(), instr->GetAttr(), srcReg1, srcReg2);
+                break;
+
+            default:
+                GetEmitter()->emitIns_R_R_R(instr->GetIns(), instr->GetAttr(), instr->GetRegNum(), srcReg1, srcReg2);
+                break;
+        }
     }
 
-    genProduceReg(instr);
+    if (!instr->TypeIs(TYP_VOID))
+    {
+        genProduceReg(instr);
+    }
 }
 
 #endif // TARGET_ARM64

--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -9753,6 +9753,19 @@ void CodeGen::genCodeForInstr(GenTreeInstr* instr)
                 break;
         }
     }
+    else
+    {
+        assert(instr->GetNumOps() == 3);
+
+        instruction ins     = instr->GetIns();
+        emitAttr    attr    = instr->GetAttr();
+        regNumber   dstReg  = instr->TypeIs(TYP_VOID) ? REG_NA : instr->GetRegNum();
+        regNumber   srcReg1 = genConsumeReg(instr->GetOp(0));
+        regNumber   srcReg2 = genConsumeReg(instr->GetOp(1));
+        regNumber   srcReg3 = genConsumeReg(instr->GetOp(2));
+
+        GetEmitter()->emitIns_R_R_R_R(ins, attr, dstReg, srcReg1, srcReg2, srcReg3);
+    }
 
     if (!instr->TypeIs(TYP_VOID))
     {

--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -9647,9 +9647,32 @@ void CodeGen::genAllocLclFrame(unsigned  frameSize,
 
 void CodeGen::genCodeForInstr(GenTreeInstr* instr)
 {
-    regNumber srcReg1 = genConsumeReg(instr->GetOp(0));
+    if (instr->GetNumOps() == 1)
+    {
+        regNumber srcReg1 = genConsumeReg(instr->GetOp(0));
 
-    GetEmitter()->emitIns_R_R(instr->GetIns(), instr->GetAttr(), instr->GetRegNum(), srcReg1);
+        switch (instr->GetIns())
+        {
+            case INS_asr:
+            case INS_lsr:
+            case INS_lsl:
+            case INS_ror:
+                GetEmitter()->emitIns_R_R_I(instr->GetIns(), instr->GetAttr(), instr->GetRegNum(), srcReg1,
+                                            instr->GetImmediate());
+                break;
+
+            default:
+                GetEmitter()->emitIns_R_R(instr->GetIns(), instr->GetAttr(), instr->GetRegNum(), srcReg1);
+                break;
+        }
+    }
+    else if (instr->GetNumOps() == 2)
+    {
+        regNumber srcReg1 = genConsumeReg(instr->GetOp(0));
+        regNumber srcReg2 = genConsumeReg(instr->GetOp(1));
+
+        GetEmitter()->emitIns_R_R_R(instr->GetIns(), instr->GetAttr(), instr->GetRegNum(), srcReg1, srcReg2);
+    }
 
     genProduceReg(instr);
 }

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -525,6 +525,10 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
             // Do nothing; these nodes are simply markers for debug info.
             break;
 
+        case GT_INSTR:
+            genCodeForInstr(treeNode->AsInstr());
+            break;
+
         default:
         {
 #ifdef DEBUG

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -2865,7 +2865,7 @@ void CodeGen::genIntCastOverflowCheck(GenTreeCast* cast, const GenIntCastDesc& d
             genJumpToThrowHlpBlk(EJ_lt, SCK_OVERFLOW);
             break;
 
-#ifdef TARGET_64BIT
+#ifdef TARGET_ARM64
         case GenIntCastDesc::CHECK_UINT_RANGE:
             // We need to check if the value is not greater than 0xFFFFFFFF but this value
             // cannot be encoded in the immediate operand of CMP. Use TST instead to check
@@ -2883,17 +2883,9 @@ void CodeGen::genIntCastOverflowCheck(GenTreeCast* cast, const GenIntCastDesc& d
             break;
 
         case GenIntCastDesc::CHECK_INT_RANGE:
-        {
-            const regNumber tempReg = cast->GetSingleTempReg();
-            assert(tempReg != reg);
-            instGen_Set_Reg_To_Imm(EA_8BYTE, tempReg, INT32_MAX);
-            GetEmitter()->emitIns_R_R(INS_cmp, EA_8BYTE, reg, tempReg);
-            genJumpToThrowHlpBlk(EJ_gt, SCK_OVERFLOW);
-            instGen_Set_Reg_To_Imm(EA_8BYTE, tempReg, INT32_MIN);
-            GetEmitter()->emitIns_R_R(INS_cmp, EA_8BYTE, reg, tempReg);
-            genJumpToThrowHlpBlk(EJ_lt, SCK_OVERFLOW);
-        }
-        break;
+            GetEmitter()->emitIns_R_R_I(INS_cmp, EA_8BYTE, reg, reg, 0, INS_OPTS_SXTW);
+            genJumpToThrowHlpBlk(EJ_ne, SCK_OVERFLOW);
+            break;
 #endif
 
         default:
@@ -2902,6 +2894,19 @@ void CodeGen::genIntCastOverflowCheck(GenTreeCast* cast, const GenIntCastDesc& d
             const int castMaxValue = desc.CheckSmallIntMax();
             const int castMinValue = desc.CheckSmallIntMin();
 
+#ifdef TARGET_ARM64
+            if (castMinValue != 0)
+            {
+                assert(((castMinValue == -128) && (castMaxValue == 127)) ||
+                       ((castMinValue == -32768) && (castMaxValue == 32767)));
+
+                GetEmitter()->emitIns_R_R_I(INS_cmp, EA_ATTR(desc.CheckSrcSize()), reg, reg, 0,
+                                            castMinValue == -128 ? INS_OPTS_SXTB : INS_OPTS_SXTH);
+                genJumpToThrowHlpBlk(EJ_ne, SCK_OVERFLOW);
+                break;
+            }
+#endif
+
             // Values greater than 255 cannot be encoded in the immediate operand of CMP.
             // Replace (x > max) with (x >= max + 1) where max + 1 (a power of 2) can be
             // encoded. We could do this for all max values but on ARM32 "cmp r0, 255"
@@ -2909,18 +2914,18 @@ void CodeGen::genIntCastOverflowCheck(GenTreeCast* cast, const GenIntCastDesc& d
             if (castMaxValue > 255)
             {
                 assert((castMaxValue == 32767) || (castMaxValue == 65535));
-                GetEmitter()->emitIns_R_I(INS_cmp, EA_SIZE(desc.CheckSrcSize()), reg, castMaxValue + 1);
+                GetEmitter()->emitIns_R_I(INS_cmp, EA_ATTR(desc.CheckSrcSize()), reg, castMaxValue + 1);
                 genJumpToThrowHlpBlk((castMinValue == 0) ? EJ_hs : EJ_ge, SCK_OVERFLOW);
             }
             else
             {
-                GetEmitter()->emitIns_R_I(INS_cmp, EA_SIZE(desc.CheckSrcSize()), reg, castMaxValue);
+                GetEmitter()->emitIns_R_I(INS_cmp, EA_ATTR(desc.CheckSrcSize()), reg, castMaxValue);
                 genJumpToThrowHlpBlk((castMinValue == 0) ? EJ_hi : EJ_gt, SCK_OVERFLOW);
             }
 
             if (castMinValue != 0)
             {
-                GetEmitter()->emitIns_R_I(INS_cmp, EA_SIZE(desc.CheckSrcSize()), reg, castMinValue);
+                GetEmitter()->emitIns_R_I(INS_cmp, EA_ATTR(desc.CheckSrcSize()), reg, castMinValue);
                 genJumpToThrowHlpBlk(EJ_lt, SCK_OVERFLOW);
             }
         }

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -1836,6 +1836,10 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
             // Do nothing; these nodes are simply markers for debug info.
             break;
 
+        case GT_INSTR:
+            genCodeForInstr(treeNode->AsInstr());
+            break;
+
         default:
         {
 #ifdef DEBUG
@@ -8687,5 +8691,10 @@ void CodeGen::genProfilingLeaveCallback(unsigned helper)
 #endif // TARGET_AMD64
 
 #endif // PROFILING_SUPPORTED
+
+void CodeGen::genCodeForInstr(GenTreeInstr* instr)
+{
+    unreached();
+}
 
 #endif // TARGET_XARCH

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -10978,7 +10978,7 @@ public:
         assert(ins < INS_count);
 
         m_ins  = ins;
-        m_attr = emitTypeSize(GetType());
+        m_attr = emitActualTypeSize(GetType());
 #ifdef TARGET_ARMARCH
         m_opt = INS_OPTS_NONE;
 #endif

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -2808,6 +2808,7 @@ public:
 
 #ifdef DEBUG
     void gtDispNode(GenTree* tree, IndentStack* indentStack, __in_z const char* msg, bool isLIR);
+    int gtDispNodeHeader(GenTree* tree, IndentStack* indentStack, int msgLength);
 
     void gtDispConst(GenTree* tree);
     void gtDispLeaf(GenTree* tree, IndentStack* indentStack);
@@ -10233,6 +10234,17 @@ public:
                 break;
 #endif
 
+            case GT_INSTR:
+                for (GenTreeInstr::Use& use : node->AsInstr()->Uses())
+                {
+                    result = WalkTree(&use.NodeRef(), node);
+                    if (result == fgWalkResult::WALK_ABORT)
+                    {
+                        return result;
+                    }
+                }
+                break;
+
             case GT_CMPXCHG:
             {
                 GenTreeCmpXchg* const cmpXchg = node->AsCmpXchg();
@@ -10857,6 +10869,271 @@ void dumpConvertedVarSet(Compiler* comp, VARSET_VALARG_TP vars);
 #endif // DEBUG
 
 #include "compiler.hpp" // All the shared inline functions
+
+struct GenTreeInstr : public GenTree
+{
+    using Use = GenTreeUse;
+
+private:
+#if defined(TARGET_ARM64)
+    static constexpr unsigned NUM_OPS_BITS = 2;
+    static constexpr unsigned INS_BITS     = 9;
+    static constexpr unsigned ATTR_BITS    = 9;
+    static constexpr unsigned OPT_BITS     = 4;
+#elif defined(TARGET_ARM)
+    static constexpr unsigned NUM_OPS_BITS = 2;
+    static constexpr unsigned INS_BITS     = 9;
+    static constexpr unsigned ATTR_BITS    = 9;
+    static constexpr unsigned OPT_BITS     = 3;
+#elif defined(TARGET_XARCH)
+    static constexpr unsigned NUM_OPS_BITS = 2;
+    static constexpr unsigned INS_BITS     = 10;
+    static constexpr unsigned ATTR_BITS    = 9;
+#endif
+
+    static_assert_no_msg(INS_count <= (1 << INS_BITS));
+    static_assert_no_msg(EA_BYREF < (1 << ATTR_BITS));
+#if defined(TARGET_ARM64)
+    static_assert_no_msg(INS_OPTS_SXTX < (1 << OPT_BITS));
+#elif defined(TARGET_ARM)
+    static_assert_no_msg(INS_OPTS_ROR < (1 << OPT_BITS));
+#endif
+
+    unsigned    m_numOps : NUM_OPS_BITS;
+    instruction m_ins : INS_BITS;
+    emitAttr    m_attr : ATTR_BITS;
+#ifdef TARGET_ARMARCH
+    insOpts m_opt : OPT_BITS;
+#endif
+    unsigned m_imm;
+
+    union {
+        Use  m_inlineUses[3];
+        Use* m_uses;
+    };
+
+public:
+    GenTreeInstr(var_types type, instruction ins, GenTree* op1)
+        : GenTree(GT_INSTR, type)
+        , m_numOps(1)
+        , m_ins(ins)
+        , m_attr(emitActualTypeSize(type))
+#ifdef TARGET_ARMARCH
+        , m_opt(INS_OPTS_NONE)
+#endif
+        , m_imm(0)
+        , m_inlineUses{op1}
+    {
+    }
+
+    GenTreeInstr(var_types type, instruction ins, GenTree* op1, GenTree* op2)
+        : GenTree(GT_INSTR, type)
+        , m_numOps(2)
+        , m_ins(ins)
+        , m_attr(emitActualTypeSize(type))
+#ifdef TARGET_ARMARCH
+        , m_opt(INS_OPTS_NONE)
+#endif
+        , m_imm(0)
+        , m_inlineUses{op1, op2}
+    {
+    }
+
+    GenTreeInstr(GenTreeInstr* from, Compiler* compiler)
+        : GenTree(from->GetOper(), from->GetType())
+        , m_ins(from->m_ins)
+        , m_attr(from->m_attr)
+#ifdef TARGET_ARMARCH
+        , m_opt(from->m_opt)
+#endif
+        , m_imm(from->m_imm)
+    {
+        SetNumOps(from->m_numOps, compiler->getAllocator(CMK_ASTNode));
+
+        for (unsigned i = 0; i < from->m_numOps; i++)
+        {
+            SetOp(i, compiler->gtCloneExpr(from->GetOp(i)));
+        }
+    }
+
+    instruction GetIns() const
+    {
+        return m_ins;
+    }
+
+    emitAttr GetAttr() const
+    {
+        return m_attr;
+    }
+
+#ifdef TARGET_ARMARCH
+    insOpts GetOption() const
+    {
+        return m_opt;
+    }
+#endif
+
+    void SetIns(instruction ins)
+    {
+        assert(ins < INS_count);
+
+        m_ins  = ins;
+        m_attr = emitTypeSize(GetType());
+#ifdef TARGET_ARMARCH
+        m_opt = INS_OPTS_NONE;
+#endif
+    }
+
+    void SetIns(instruction ins,
+                emitAttr    attr
+#ifdef TARGET_ARMARCH
+                ,
+                insOpts opt = INS_OPTS_NONE
+#endif
+                )
+    {
+        assert(ins < INS_count);
+        assert(attr <= EA_BYREF);
+#if defined(TARGET_ARM64)
+        assert(opt <= INS_OPTS_SXTX);
+#elif defined(TARGET_ARM)
+        assert(opt <= INS_OPTS_ROR);
+#endif
+
+        m_ins  = ins;
+        m_attr = attr;
+#ifdef TARGET_ARMARCH
+        m_opt = opt;
+#endif
+    }
+
+    unsigned GetImmediate() const
+    {
+        return m_imm;
+    }
+
+    void SetImmediate(unsigned imm)
+    {
+        m_imm = imm;
+    }
+
+    unsigned GetNumOps() const
+    {
+        return m_numOps;
+    }
+
+    void SetNumOps(unsigned numOps)
+    {
+        assert(m_numOps == 0);
+
+        m_numOps = static_cast<uint16_t>(numOps);
+        assert(HasInlineUses());
+
+        new (m_inlineUses) Use[numOps]();
+    }
+
+    void SetNumOps(unsigned numOps, CompAllocator alloc)
+    {
+        assert(numOps < UINT16_MAX);
+        assert(m_numOps == 0);
+
+        m_numOps = static_cast<uint16_t>(numOps);
+
+        if (HasInlineUses())
+        {
+            new (m_inlineUses) Use[numOps]();
+        }
+        else
+        {
+            m_uses = new (alloc) Use[numOps]();
+        }
+    }
+
+    GenTree* GetOp(unsigned index) const
+    {
+        return GetUse(index).GetNode();
+    }
+
+    void SetOp(unsigned index, GenTree* node)
+    {
+        assert(node != nullptr);
+        GetUse(index).SetNode(node);
+    }
+
+    const Use& GetUse(unsigned index) const
+    {
+        assert(index < m_numOps);
+        return GetUses()[index];
+    }
+
+    Use& GetUse(unsigned index)
+    {
+        assert(index < m_numOps);
+        return GetUses()[index];
+    }
+
+    IteratorPair<Use*> Uses()
+    {
+        Use* uses = GetUses();
+        return MakeIteratorPair(uses, uses + GetNumOps());
+    }
+
+    static bool Equals(GenTreeInstr* instr1, GenTreeInstr* instr2)
+    {
+        if ((instr1->GetType() != instr2->GetType()) || (instr1->m_ins != instr2->m_ins) ||
+            (instr1->m_attr != instr2->m_attr) ||
+#ifdef TARGET_ARMARCH
+            (instr1->m_opt != instr2->m_opt) ||
+#endif
+            (instr1->m_numOps != instr2->m_numOps))
+        {
+            return false;
+        }
+
+        for (unsigned i = 0; i < instr1->m_numOps; i++)
+        {
+            if (!Compare(instr1->GetOp(i), instr2->GetOp(i)))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    // Delete some functions inherited from GenTree to avoid accidental use, at least
+    // when the node object is accessed via GenTreeInstr* rather than GenTree*.
+    GenTree*           gtGetOp1() const          = delete;
+    GenTree*           gtGetOp2() const          = delete;
+    GenTree*           gtGetOp2IfPresent() const = delete;
+    GenTreeUnOp*       AsUnOp()                  = delete;
+    const GenTreeUnOp* AsUnOp() const            = delete;
+    GenTreeOp*         AsOp()                    = delete;
+    const GenTreeOp*   AsOp() const              = delete;
+
+private:
+    bool HasInlineUses() const
+    {
+        return m_numOps <= _countof(m_inlineUses);
+    }
+
+    Use* GetUses()
+    {
+        return HasInlineUses() ? m_inlineUses : m_uses;
+    }
+
+    const Use* GetUses() const
+    {
+        return HasInlineUses() ? m_inlineUses : m_uses;
+    }
+
+#if DEBUGGABLE_GENTREE
+public:
+    GenTreeInstr() : GenTree()
+    {
+    }
+#endif
+};
 
 /*****************************************************************************/
 #endif //_COMPILER_H_

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -9932,6 +9932,301 @@ public:
 
 }; // end of class Compiler
 
+#ifdef TARGET_ARM64
+// TODO-MIKE-Cleanup: It's not clear if storing immediates directly inside GenTreeInstr
+// is a good idea. It does avoid the need for "containment" but there's not enough space
+// in GenTreeInstr to store a 64 bit bitmask immediate so it has to be stored in its
+// encoded form so anyone who cares about the value has to decode it first. But then
+// there's not a lot going on post lowering that involves looking at immediates so it's
+// not such a big issue.
+// And at least in theory, storing the encoded immediate is good for throughput, since
+// the rather expensive encoding is done only once, in lowering. Except that currently
+// the emitter interface requires decoded immediates, only for the emitter to encode it
+// again...
+ssize_t DecodeBitmaskImm(unsigned encoded, emitAttr size);
+#endif
+
+struct GenTreeInstr : public GenTree
+{
+    using Use = GenTreeUse;
+
+private:
+#if defined(TARGET_ARM64)
+    static constexpr unsigned NUM_OPS_BITS = 2;
+    static constexpr unsigned INS_BITS     = 9;
+    static constexpr unsigned SIZE_BITS    = 9;
+    static constexpr unsigned OPT_BITS     = 4;
+#elif defined(TARGET_ARM)
+    static constexpr unsigned NUM_OPS_BITS = 2;
+    static constexpr unsigned INS_BITS     = 9;
+    static constexpr unsigned SIZE_BITS    = 9;
+    static constexpr unsigned OPT_BITS     = 3;
+#elif defined(TARGET_XARCH)
+    // TODO-MIKE-Cleanup: Wishful thinking... it may be nice to use GenTreeInstr on x86/64
+    // but compared to ARM there aren't many interesting use cases and x86/64 instructions
+    // are problematic due the possibility of having a 32 bit immediate and a 32 bit address
+    // mode displacement.
+    // There's just not enough room for both imm32 and disp32, no matter how things are packed.
+    // Except if we steal some bits from GenTree, value numbers aren't normally needed in and
+    // post lowering (except for the dumb gcIsWriteBarrierCandidate that checks for nulls !?!).
+    static constexpr unsigned NUM_OPS_BITS = 2;
+    static constexpr unsigned INS_BITS     = 10;
+    static constexpr unsigned SIZE_BITS    = 9;
+#endif
+
+    static_assert_no_msg(INS_count <= (1 << INS_BITS));
+    static_assert_no_msg(EA_BYREF < (1 << SIZE_BITS));
+#if defined(TARGET_ARM64)
+    static_assert_no_msg(INS_OPTS_SXTX < (1 << OPT_BITS));
+#elif defined(TARGET_ARM)
+    static_assert_no_msg(INS_OPTS_ROR < (1 << OPT_BITS));
+#endif
+
+    unsigned    m_numOps : NUM_OPS_BITS;
+    instruction m_ins : INS_BITS;
+    // TODO-MIKE-Cleanup: Using emitAttr for size is overkill, all we need is to be able to control
+    // the instruction size (32/64 bit) independently from type so we can potentially take advantage
+    // of the implicit zero extension that 32 bit instructions perform. But there's no need to do
+    // this for GC types so the GC info conveyed by emitAttr isn't necessary.
+    emitAttr m_size : SIZE_BITS;
+#ifdef TARGET_ARMARCH
+    insOpts m_opt : OPT_BITS;
+#endif
+    unsigned m_imm;
+
+    union {
+        Use  m_inlineUses[3];
+        Use* m_uses;
+    };
+
+public:
+    GenTreeInstr(var_types type, instruction ins, GenTree* op1)
+        : GenTree(GT_INSTR, type)
+        , m_numOps(1)
+        , m_ins(ins)
+        , m_size(emitActualTypeSize(type))
+#ifdef TARGET_ARMARCH
+        , m_opt(INS_OPTS_NONE)
+#endif
+        , m_imm(0)
+        , m_inlineUses{op1}
+    {
+    }
+
+    GenTreeInstr(var_types type, instruction ins, GenTree* op1, GenTree* op2)
+        : GenTree(GT_INSTR, type)
+        , m_numOps(2)
+        , m_ins(ins)
+        , m_size(emitActualTypeSize(type))
+#ifdef TARGET_ARMARCH
+        , m_opt(INS_OPTS_NONE)
+#endif
+        , m_imm(0)
+        , m_inlineUses{op1, op2}
+    {
+    }
+
+    GenTreeInstr(GenTreeInstr* from, Compiler* compiler)
+        : GenTree(from->GetOper(), from->GetType())
+        , m_ins(from->m_ins)
+        , m_size(from->m_size)
+#ifdef TARGET_ARMARCH
+        , m_opt(from->m_opt)
+#endif
+        , m_imm(from->m_imm)
+    {
+        SetNumOps(from->m_numOps, compiler->getAllocator(CMK_ASTNode));
+
+        for (unsigned i = 0; i < from->m_numOps; i++)
+        {
+            SetOp(i, compiler->gtCloneExpr(from->GetOp(i)));
+        }
+    }
+
+    instruction GetIns() const
+    {
+        return m_ins;
+    }
+
+    emitAttr GetSize() const
+    {
+        return m_size;
+    }
+
+#ifdef TARGET_ARMARCH
+    insOpts GetOption() const
+    {
+        return m_opt;
+    }
+
+    void SetOption(insOpts opt)
+    {
+        m_opt = opt;
+    }
+#endif
+
+    void SetIns(instruction ins)
+    {
+        assert(ins < INS_count);
+
+        m_ins  = ins;
+        m_size = emitActualTypeSize(GetType());
+#ifdef TARGET_ARMARCH
+        m_opt = INS_OPTS_NONE;
+#endif
+    }
+
+    void SetIns(instruction ins,
+                emitAttr    size
+#ifdef TARGET_ARMARCH
+                ,
+                insOpts opt = INS_OPTS_NONE
+#endif
+                )
+    {
+        assert(ins < INS_count);
+        assert(size <= EA_BYREF);
+#if defined(TARGET_ARM64)
+        assert(opt <= INS_OPTS_SXTX);
+#elif defined(TARGET_ARM)
+        assert(opt <= INS_OPTS_ROR);
+#endif
+
+        m_ins  = ins;
+        m_size = size;
+#ifdef TARGET_ARMARCH
+        m_opt = opt;
+#endif
+    }
+
+    unsigned GetImmediate() const
+    {
+        return m_imm;
+    }
+
+    void SetImmediate(unsigned imm)
+    {
+        m_imm = imm;
+    }
+
+    unsigned GetNumOps() const
+    {
+        return m_numOps;
+    }
+
+    void SetNumOps(unsigned numOps)
+    {
+        assert(m_numOps == 0);
+
+        m_numOps = static_cast<uint16_t>(numOps);
+        assert(HasInlineUses());
+
+        new (m_inlineUses) Use[numOps]();
+    }
+
+    void SetNumOps(unsigned numOps, CompAllocator alloc)
+    {
+        assert(numOps < UINT16_MAX);
+        assert(m_numOps == 0);
+
+        m_numOps = static_cast<uint16_t>(numOps);
+
+        if (HasInlineUses())
+        {
+            new (m_inlineUses) Use[numOps]();
+        }
+        else
+        {
+            m_uses = new (alloc) Use[numOps]();
+        }
+    }
+
+    GenTree* GetOp(unsigned index) const
+    {
+        return GetUse(index).GetNode();
+    }
+
+    void SetOp(unsigned index, GenTree* node)
+    {
+        assert(node != nullptr);
+        GetUse(index).SetNode(node);
+    }
+
+    const Use& GetUse(unsigned index) const
+    {
+        assert(index < m_numOps);
+        return GetUses()[index];
+    }
+
+    Use& GetUse(unsigned index)
+    {
+        assert(index < m_numOps);
+        return GetUses()[index];
+    }
+
+    IteratorPair<Use*> Uses()
+    {
+        Use* uses = GetUses();
+        return MakeIteratorPair(uses, uses + GetNumOps());
+    }
+
+    static bool Equals(GenTreeInstr* instr1, GenTreeInstr* instr2)
+    {
+        if ((instr1->GetType() != instr2->GetType()) || (instr1->m_ins != instr2->m_ins) ||
+            (instr1->m_size != instr2->m_size) ||
+#ifdef TARGET_ARMARCH
+            (instr1->m_opt != instr2->m_opt) ||
+#endif
+            (instr1->m_numOps != instr2->m_numOps))
+        {
+            return false;
+        }
+
+        for (unsigned i = 0; i < instr1->m_numOps; i++)
+        {
+            if (!Compare(instr1->GetOp(i), instr2->GetOp(i)))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    // Delete some functions inherited from GenTree to avoid accidental use, at least
+    // when the node object is accessed via GenTreeInstr* rather than GenTree*.
+    GenTree*           gtGetOp1() const          = delete;
+    GenTree*           gtGetOp2() const          = delete;
+    GenTree*           gtGetOp2IfPresent() const = delete;
+    GenTreeUnOp*       AsUnOp()                  = delete;
+    const GenTreeUnOp* AsUnOp() const            = delete;
+    GenTreeOp*         AsOp()                    = delete;
+    const GenTreeOp*   AsOp() const              = delete;
+
+private:
+    bool HasInlineUses() const
+    {
+        return m_numOps <= _countof(m_inlineUses);
+    }
+
+    Use* GetUses()
+    {
+        return HasInlineUses() ? m_inlineUses : m_uses;
+    }
+
+    const Use* GetUses() const
+    {
+        return HasInlineUses() ? m_inlineUses : m_uses;
+    }
+
+#if DEBUGGABLE_GENTREE
+public:
+    GenTreeInstr() : GenTree()
+    {
+    }
+#endif
+};
+
 //---------------------------------------------------------------------------------------------------------------------
 // GenTreeVisitor: a flexible tree walker implemented using the curiously-recurring-template pattern.
 //
@@ -10869,276 +11164,6 @@ void dumpConvertedVarSet(Compiler* comp, VARSET_VALARG_TP vars);
 #endif // DEBUG
 
 #include "compiler.hpp" // All the shared inline functions
-
-struct GenTreeInstr : public GenTree
-{
-    using Use = GenTreeUse;
-
-private:
-#if defined(TARGET_ARM64)
-    static constexpr unsigned NUM_OPS_BITS = 2;
-    static constexpr unsigned INS_BITS     = 9;
-    static constexpr unsigned ATTR_BITS    = 9;
-    static constexpr unsigned OPT_BITS     = 4;
-#elif defined(TARGET_ARM)
-    static constexpr unsigned NUM_OPS_BITS = 2;
-    static constexpr unsigned INS_BITS     = 9;
-    static constexpr unsigned ATTR_BITS    = 9;
-    static constexpr unsigned OPT_BITS     = 3;
-#elif defined(TARGET_XARCH)
-    static constexpr unsigned NUM_OPS_BITS = 2;
-    static constexpr unsigned INS_BITS     = 10;
-    static constexpr unsigned ATTR_BITS    = 9;
-#endif
-
-    static_assert_no_msg(INS_count <= (1 << INS_BITS));
-    static_assert_no_msg(EA_BYREF < (1 << ATTR_BITS));
-#if defined(TARGET_ARM64)
-    static_assert_no_msg(INS_OPTS_SXTX < (1 << OPT_BITS));
-#elif defined(TARGET_ARM)
-    static_assert_no_msg(INS_OPTS_ROR < (1 << OPT_BITS));
-#endif
-
-    unsigned    m_numOps : NUM_OPS_BITS;
-    instruction m_ins : INS_BITS;
-    emitAttr    m_attr : ATTR_BITS;
-#ifdef TARGET_ARMARCH
-    insOpts m_opt : OPT_BITS;
-#endif
-    unsigned m_imm;
-
-    union {
-        Use  m_inlineUses[3];
-        Use* m_uses;
-    };
-
-public:
-    GenTreeInstr(var_types type, instruction ins, GenTree* op1)
-        : GenTree(GT_INSTR, type)
-        , m_numOps(1)
-        , m_ins(ins)
-        , m_attr(emitActualTypeSize(type))
-#ifdef TARGET_ARMARCH
-        , m_opt(INS_OPTS_NONE)
-#endif
-        , m_imm(0)
-        , m_inlineUses{op1}
-    {
-    }
-
-    GenTreeInstr(var_types type, instruction ins, GenTree* op1, GenTree* op2)
-        : GenTree(GT_INSTR, type)
-        , m_numOps(2)
-        , m_ins(ins)
-        , m_attr(emitActualTypeSize(type))
-#ifdef TARGET_ARMARCH
-        , m_opt(INS_OPTS_NONE)
-#endif
-        , m_imm(0)
-        , m_inlineUses{op1, op2}
-    {
-    }
-
-    GenTreeInstr(GenTreeInstr* from, Compiler* compiler)
-        : GenTree(from->GetOper(), from->GetType())
-        , m_ins(from->m_ins)
-        , m_attr(from->m_attr)
-#ifdef TARGET_ARMARCH
-        , m_opt(from->m_opt)
-#endif
-        , m_imm(from->m_imm)
-    {
-        SetNumOps(from->m_numOps, compiler->getAllocator(CMK_ASTNode));
-
-        for (unsigned i = 0; i < from->m_numOps; i++)
-        {
-            SetOp(i, compiler->gtCloneExpr(from->GetOp(i)));
-        }
-    }
-
-    instruction GetIns() const
-    {
-        return m_ins;
-    }
-
-    emitAttr GetAttr() const
-    {
-        return m_attr;
-    }
-
-#ifdef TARGET_ARMARCH
-    insOpts GetOption() const
-    {
-        return m_opt;
-    }
-
-    void SetOption(insOpts opt)
-    {
-        m_opt = opt;
-    }
-#endif
-
-    void SetIns(instruction ins)
-    {
-        assert(ins < INS_count);
-
-        m_ins  = ins;
-        m_attr = emitActualTypeSize(GetType());
-#ifdef TARGET_ARMARCH
-        m_opt = INS_OPTS_NONE;
-#endif
-    }
-
-    void SetIns(instruction ins,
-                emitAttr    attr
-#ifdef TARGET_ARMARCH
-                ,
-                insOpts opt = INS_OPTS_NONE
-#endif
-                )
-    {
-        assert(ins < INS_count);
-        assert(attr <= EA_BYREF);
-#if defined(TARGET_ARM64)
-        assert(opt <= INS_OPTS_SXTX);
-#elif defined(TARGET_ARM)
-        assert(opt <= INS_OPTS_ROR);
-#endif
-
-        m_ins  = ins;
-        m_attr = attr;
-#ifdef TARGET_ARMARCH
-        m_opt = opt;
-#endif
-    }
-
-    unsigned GetImmediate() const
-    {
-        return m_imm;
-    }
-
-    void SetImmediate(unsigned imm)
-    {
-        m_imm = imm;
-    }
-
-    unsigned GetNumOps() const
-    {
-        return m_numOps;
-    }
-
-    void SetNumOps(unsigned numOps)
-    {
-        assert(m_numOps == 0);
-
-        m_numOps = static_cast<uint16_t>(numOps);
-        assert(HasInlineUses());
-
-        new (m_inlineUses) Use[numOps]();
-    }
-
-    void SetNumOps(unsigned numOps, CompAllocator alloc)
-    {
-        assert(numOps < UINT16_MAX);
-        assert(m_numOps == 0);
-
-        m_numOps = static_cast<uint16_t>(numOps);
-
-        if (HasInlineUses())
-        {
-            new (m_inlineUses) Use[numOps]();
-        }
-        else
-        {
-            m_uses = new (alloc) Use[numOps]();
-        }
-    }
-
-    GenTree* GetOp(unsigned index) const
-    {
-        return GetUse(index).GetNode();
-    }
-
-    void SetOp(unsigned index, GenTree* node)
-    {
-        assert(node != nullptr);
-        GetUse(index).SetNode(node);
-    }
-
-    const Use& GetUse(unsigned index) const
-    {
-        assert(index < m_numOps);
-        return GetUses()[index];
-    }
-
-    Use& GetUse(unsigned index)
-    {
-        assert(index < m_numOps);
-        return GetUses()[index];
-    }
-
-    IteratorPair<Use*> Uses()
-    {
-        Use* uses = GetUses();
-        return MakeIteratorPair(uses, uses + GetNumOps());
-    }
-
-    static bool Equals(GenTreeInstr* instr1, GenTreeInstr* instr2)
-    {
-        if ((instr1->GetType() != instr2->GetType()) || (instr1->m_ins != instr2->m_ins) ||
-            (instr1->m_attr != instr2->m_attr) ||
-#ifdef TARGET_ARMARCH
-            (instr1->m_opt != instr2->m_opt) ||
-#endif
-            (instr1->m_numOps != instr2->m_numOps))
-        {
-            return false;
-        }
-
-        for (unsigned i = 0; i < instr1->m_numOps; i++)
-        {
-            if (!Compare(instr1->GetOp(i), instr2->GetOp(i)))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    // Delete some functions inherited from GenTree to avoid accidental use, at least
-    // when the node object is accessed via GenTreeInstr* rather than GenTree*.
-    GenTree*           gtGetOp1() const          = delete;
-    GenTree*           gtGetOp2() const          = delete;
-    GenTree*           gtGetOp2IfPresent() const = delete;
-    GenTreeUnOp*       AsUnOp()                  = delete;
-    const GenTreeUnOp* AsUnOp() const            = delete;
-    GenTreeOp*         AsOp()                    = delete;
-    const GenTreeOp*   AsOp() const              = delete;
-
-private:
-    bool HasInlineUses() const
-    {
-        return m_numOps <= _countof(m_inlineUses);
-    }
-
-    Use* GetUses()
-    {
-        return HasInlineUses() ? m_inlineUses : m_uses;
-    }
-
-    const Use* GetUses() const
-    {
-        return HasInlineUses() ? m_inlineUses : m_uses;
-    }
-
-#if DEBUGGABLE_GENTREE
-public:
-    GenTreeInstr() : GenTree()
-    {
-    }
-#endif
-};
 
 /*****************************************************************************/
 #endif //_COMPILER_H_

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -10971,6 +10971,11 @@ public:
     {
         return m_opt;
     }
+
+    void SetOption(insOpts opt)
+    {
+        m_opt = opt;
+    }
 #endif
 
     void SetIns(instruction ins)

--- a/src/coreclr/src/jit/compiler.hpp
+++ b/src/coreclr/src/jit/compiler.hpp
@@ -4398,6 +4398,16 @@ void GenTree::VisitOperands(TVisitor visitor)
             return;
 #endif // FEATURE_HW_INTRINSICS
 
+        case GT_INSTR:
+            for (GenTreeInstr::Use& use : AsInstr()->Uses())
+            {
+                if (visitor(use.NodeRef()) == VisitResult::Abort)
+                {
+                    break;
+                }
+            }
+            return;
+
         case GT_CMPXCHG:
         {
             GenTreeCmpXchg* const cmpXchg = this->AsCmpXchg();

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -1139,8 +1139,7 @@ float emitter::insEvaluateExecutionCost(instrDesc* id)
 void emitter::perfScoreUnhandledInstruction(instrDesc* id, insExecutionCharacteristics* pResult)
 {
 #ifdef DEBUG
-    printf("PerfScore: unhandled instruction: %s, format %s", codeGen->genInsName(id->idIns()),
-           emitIfName(id->idInsFmt()));
+    printf("PerfScore: unhandled instruction: %s, format %s", insName(id->idIns()), emitIfName(id->idInsFmt()));
     assert(!"PerfScore: unhandled instruction");
 #endif
     pResult->insThroughput = PERFSCORE_THROUGHPUT_1C;

--- a/src/coreclr/src/jit/emitarm.cpp
+++ b/src/coreclr/src/jit/emitarm.cpp
@@ -2313,7 +2313,7 @@ void emitter::emitIns_R_R(
             break;
         default:
 #ifdef DEBUG
-            printf("did not expect instruction %s\n", codeGen->genInsName(ins));
+            printf("did not expect instruction %s\n", insName(ins));
 #endif
             unreached();
     }
@@ -6600,7 +6600,7 @@ static bool insAlwaysSetFlags(instruction ins)
  */
 void emitter::emitDispInst(instruction ins, insFlags flags)
 {
-    const char* insstr = codeGen->genInsName(ins);
+    const char* insstr = insName(ins);
     size_t      len    = strlen(insstr);
 
     /* Display the instruction name */
@@ -6740,23 +6740,30 @@ void emitter::emitDispRegmask(int imm, bool encodedPC_LR)
     printf("}");
 }
 
-/*****************************************************************************
- *
- *  Returns the encoding for the Shift Type bits to be used in a Thumb-2 encoding
- */
+const char* insOptsName(insOpts opt)
+{
+    switch (opt)
+    {
+        case INS_OPTS_NONE:
+            return "";
+        case INS_OPTS_RRX:
+            return "RRX";
+        case INS_OPTS_LSL:
+            return "LSL";
+        case INS_OPTS_LSR:
+            return "LSR";
+        case INS_OPTS_ASR:
+            return "ASR";
+        case INS_OPTS_ROR:
+            return "ROR";
+        default:
+            return "???";
+    }
+}
 
 void emitter::emitDispShiftOpts(insOpts opt)
 {
-    if (opt == INS_OPTS_LSL)
-        printf(" LSL ");
-    else if (opt == INS_OPTS_LSR)
-        printf(" LSR ");
-    else if (opt == INS_OPTS_ASR)
-        printf(" ASR ");
-    else if (opt == INS_OPTS_ROR)
-        printf(" ROR ");
-    else if (opt == INS_OPTS_RRX)
-        printf(" RRX ");
+    printf(" %s ", insOptsName(opt));
 }
 
 /*****************************************************************************

--- a/src/coreclr/src/jit/emitarm64.cpp
+++ b/src/coreclr/src/jit/emitarm64.cpp
@@ -11477,7 +11477,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
  */
 void emitter::emitDispInst(instruction ins)
 {
-    const char* insstr = codeGen->genInsName(ins);
+    const char* insstr = insName(ins);
     size_t      len    = strlen(insstr);
 
     /* Display the instruction name */
@@ -11629,73 +11629,56 @@ void emitter::emitDispBarrier(insBarrier barrier)
     printf(armBarriers[imm]);
 }
 
-/*****************************************************************************
- *
- *  Prints the encoding for the Shift Type encoding
- */
+const char* insOptsName(insOpts opt)
+{
+    switch (opt)
+    {
+        case INS_OPTS_NONE:
+            return "";
+        case INS_OPTS_LSL:
+            return "LSL";
+        case INS_OPTS_LSR:
+            return "LSR";
+        case INS_OPTS_ASR:
+            return "ASR";
+        case INS_OPTS_ROR:
+            return "ROR";
+        case INS_OPTS_MSL:
+            return "MSL";
+        case INS_OPTS_UXTB:
+            return "UXTB";
+        case INS_OPTS_UXTH:
+            return "UXTH";
+        case INS_OPTS_UXTW:
+            return "UXTW";
+        case INS_OPTS_UXTX:
+            return "UXTX";
+        case INS_OPTS_SXTB:
+            return "SXTB";
+        case INS_OPTS_SXTH:
+            return "SXTH";
+        case INS_OPTS_SXTW:
+            return "SXTW";
+        case INS_OPTS_SXTX:
+            return "SXTX";
+        default:
+            return "???";
+    }
+}
 
 void emitter::emitDispShiftOpts(insOpts opt)
 {
-    if (opt == INS_OPTS_LSL)
-        printf(" LSL ");
-    else if (opt == INS_OPTS_LSR)
-        printf(" LSR ");
-    else if (opt == INS_OPTS_ASR)
-        printf(" ASR ");
-    else if (opt == INS_OPTS_ROR)
-        printf(" ROR ");
-    else if (opt == INS_OPTS_MSL)
-        printf(" MSL ");
-    else
-        assert(!"Bad value");
+    printf(" %s ", insOptsName(opt));
 }
-
-/*****************************************************************************
- *
- *  Prints the encoding for the Extend Type encoding
- */
 
 void emitter::emitDispExtendOpts(insOpts opt)
 {
-    if (opt == INS_OPTS_UXTB)
-        printf("UXTB");
-    else if (opt == INS_OPTS_UXTH)
-        printf("UXTH");
-    else if (opt == INS_OPTS_UXTW)
-        printf("UXTW");
-    else if (opt == INS_OPTS_UXTX)
-        printf("UXTX");
-    else if (opt == INS_OPTS_SXTB)
-        printf("SXTB");
-    else if (opt == INS_OPTS_SXTH)
-        printf("SXTH");
-    else if (opt == INS_OPTS_SXTW)
-        printf("SXTW");
-    else if (opt == INS_OPTS_SXTX)
-        printf("SXTX");
-    else
-        assert(!"Bad value");
+    printf("%s", insOptsName(opt));
 }
-
-/*****************************************************************************
- *
- *  Prints the encoding for the Extend Type encoding in loads/stores
- */
 
 void emitter::emitDispLSExtendOpts(insOpts opt)
 {
-    if (opt == INS_OPTS_LSL)
-        printf("LSL");
-    else if (opt == INS_OPTS_UXTW)
-        printf("UXTW");
-    else if (opt == INS_OPTS_UXTX)
-        printf("UXTX");
-    else if (opt == INS_OPTS_SXTW)
-        printf("SXTW");
-    else if (opt == INS_OPTS_SXTX)
-        printf("SXTX");
-    else
-        assert(!"Bad value");
+    printf("%s", insOptsName(opt));
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/src/jit/emitarm64.h
+++ b/src/coreclr/src/jit/emitarm64.h
@@ -125,6 +125,7 @@ bool IsRedundantMov(instruction ins, emitAttr size, regNumber dst, regNumber src
 * that is listed as imm(N,r,s) and referred to as 'bitmask immediate'
 */
 
+public:
 union bitMaskImm {
     struct
     {
@@ -145,6 +146,7 @@ static emitter::bitMaskImm emitEncodeBitMaskImm(INT64 imm, emitAttr size);
 
 static INT64 emitDecodeBitMaskImm(const emitter::bitMaskImm bmImm, emitAttr size);
 
+private:
 /************************************************************************
 *
 * This union is used to to encode/decode the special ARM64 immediate values

--- a/src/coreclr/src/jit/emitxarch.cpp
+++ b/src/coreclr/src/jit/emitxarch.cpp
@@ -8176,7 +8176,7 @@ void emitter::emitDispIns(
 
     /* Display the instruction name */
 
-    sstr = codeGen->genInsName(ins);
+    sstr = insName(ins);
 
     if (IsAVXInstruction(ins) && !IsBMIInstruction(ins))
     {

--- a/src/coreclr/src/jit/flowgraph.cpp
+++ b/src/coreclr/src/jit/flowgraph.cpp
@@ -21429,11 +21429,7 @@ void Compiler::fgDebugCheckFlags(GenTree* tree)
                 break;
 
             default:
-
-#ifdef DEBUG
-                gtDispTree(tree);
-#endif
-
+                INDEBUG(gtDispTree(tree);)
                 assert(!"Unknown operator for fgDebugCheckFlags");
                 break;
         }

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -2237,7 +2237,7 @@ AGAIN:
 
         case GT_INSTR:
             hash = genTreeHashAdd(hash, tree->AsInstr()->GetIns());
-            hash = genTreeHashAdd(hash, tree->AsInstr()->GetAttr());
+            hash = genTreeHashAdd(hash, tree->AsInstr()->GetSize());
 #ifdef TARGET_ARMARCH
             hash = genTreeHashAdd(hash, tree->AsInstr()->GetOption());
 #endif
@@ -10874,13 +10874,25 @@ void Compiler::gtDispLIRNode(GenTree* node, const char* prefixMsg /* = nullptr *
 #ifdef TARGET_ARMARCH
         if (instr->GetOption() != INS_OPTS_NONE)
         {
-            printf(", %s #%u", insOptsName(instr->GetOption()), instr->GetImmediate());
+            printf(", %s %u", insOptsName(instr->GetOption()), instr->GetImmediate());
         }
         else
 #endif
             if (instr->GetImmediate() != 0)
         {
-            printf(", #%u", instr->GetImmediate());
+            switch (instr->GetIns())
+            {
+#ifdef TARGET_ARM64
+                case INS_and:
+                case INS_orr:
+                case INS_eor:
+                    printf(", 0x%x", DecodeBitmaskImm(instr->GetImmediate(), instr->GetSize()));
+                    break;
+#endif
+                default:
+                    printf(", %u", instr->GetImmediate());
+                    break;
+            }
         }
 
         printf("\n");

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -2655,6 +2655,7 @@ class GenTreeUseEdgeIterator final
     void AdvanceHWIntrinsic();
     void AdvanceHWIntrinsicReverseOp();
 #endif
+    void AdvanceInstr();
 
     template <bool ReverseOperands>
     void           AdvanceBinOp();
@@ -4852,6 +4853,7 @@ class GenTreeUse
 {
     friend struct GenTreeSIMD;
     friend struct GenTreeHWIntrinsic;
+    friend struct GenTreeInstr;
 
     GenTree* m_node;
 

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -1034,7 +1034,7 @@ public:
         if (gtType == TYP_VOID)
         {
             // These are the only operators which can produce either VOID or non-VOID results.
-            assert(OperIs(GT_NOP, GT_CALL, GT_COMMA) || OperIsCompare() || OperIsLong() || OperIsSIMD() ||
+            assert(OperIs(GT_NOP, GT_CALL, GT_COMMA, GT_INSTR) || OperIsCompare() || OperIsLong() || OperIsSIMD() ||
                    OperIsHWIntrinsic());
             return false;
         }

--- a/src/coreclr/src/jit/gtlist.h
+++ b/src/coreclr/src/jit/gtlist.h
@@ -296,7 +296,9 @@ GTNODE(PUTARG_SPLIT     , GenTreePutArgSplit ,0,GTK_UNOP)                       
 #endif // FEATURE_ARG_SPLIT
 GTNODE(RETURNTRAP       , GenTreeOp          ,0,GTK_UNOP|GTK_NOVALUE)            // a conditional call to wait on gc
 GTNODE(SWAP             , GenTreeOp          ,0,GTK_BINOP|GTK_NOVALUE)           // op1 and op2 swap (registers)
-GTNODE(IL_OFFSET        , Statement        ,0,GTK_LEAF|GTK_NOVALUE)            // marks an IL offset for debugging purposes
+GTNODE(IL_OFFSET        , Statement          ,0,GTK_LEAF|GTK_NOVALUE)            // marks an IL offset for debugging purposes
+
+GTNODE(INSTR            , GenTreeInstr       ,0,GTK_SPECIAL)
 
 /*****************************************************************************/
 #undef  GTNODE

--- a/src/coreclr/src/jit/gtstructs.h
+++ b/src/coreclr/src/jit/gtstructs.h
@@ -122,6 +122,7 @@ GTSTRUCT_1(MultiRegOp  , GT_MUL_LONG)
 #elif defined (TARGET_ARM)
 GTSTRUCT_3(MultiRegOp  , GT_MUL_LONG, GT_PUTARG_REG, GT_BITCAST)
 #endif
+GTSTRUCT_1(Instr       , GT_INSTR)
 /*****************************************************************************/
 #undef  GTSTRUCT_0
 #undef  GTSTRUCT_1

--- a/src/coreclr/src/jit/instr.cpp
+++ b/src/coreclr/src/jit/instr.cpp
@@ -29,7 +29,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
  *  Returns the string representation of the given CPU instruction.
  */
 
-const char* CodeGen::genInsName(instruction ins)
+const char* insName(instruction ins)
 {
     // clang-format off
     static
@@ -92,7 +92,7 @@ void __cdecl CodeGen::instDisp(instruction ins, bool noNL, const char* fmt, ...)
         /* Display the instruction mnemonic */
         printf("        ");
 
-        printf("            %-8s", genInsName(ins));
+        printf("            %-8s", insName(ins));
 
         if (fmt)
         {

--- a/src/coreclr/src/jit/instr.h
+++ b/src/coreclr/src/jit/instr.h
@@ -55,6 +55,8 @@ enum instruction : unsigned
     INS_count = INS_none
 };
 
+INDEBUG(const char* insName(instruction ins);)
+
 /*****************************************************************************/
 
 enum insUpdateModes
@@ -123,6 +125,9 @@ enum insOpts: unsigned
     INS_OPTS_ASR,
     INS_OPTS_ROR
 };
+
+INDEBUG(const char* insOptsName(insOpts opt);)
+
 #elif defined(TARGET_ARM64)
 enum insOpts : unsigned
 {
@@ -179,6 +184,8 @@ enum insOpts : unsigned
     INS_OPTS_S_TO_H,      // Single to Half
     INS_OPTS_D_TO_H,      // Double to Half
 };
+
+INDEBUG(const char* insOptsName(insOpts opt);)
 
 enum insCond : unsigned
 {

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -134,12 +134,16 @@ GenTree* Lowering::LowerNode(GenTree* node)
             LowerNeg(node->AsUnOp());
             break;
 
+        case GT_ADD:
+        case GT_SUB:
+            LowerArithmetic(node->AsOp());
+            break;
+
         case GT_MUL:
         case GT_MULHI:
             LowerMultiply(node->AsOp());
             break;
-#endif
-
+#else // TARGET_ARM64
         case GT_ADD:
         {
             GenTree* next = LowerAdd(node->AsOp());
@@ -157,15 +161,12 @@ GenTree* Lowering::LowerNode(GenTree* node)
         case GT_SUB_HI:
 #endif
         case GT_SUB:
-#ifndef TARGET_ARM64
         case GT_AND:
         case GT_OR:
         case GT_XOR:
-#endif
             ContainCheckBinary(node->AsOp());
             break;
 
-#ifdef TARGET_XARCH
         case GT_MUL:
         case GT_MULHI:
 #if defined(TARGET_X86)
@@ -173,7 +174,7 @@ GenTree* Lowering::LowerNode(GenTree* node)
 #endif
             ContainCheckMul(node->AsOp());
             break;
-#endif
+#endif // !TARGET_ARM64
 
         case GT_UDIV:
         case GT_UMOD:

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -119,6 +119,12 @@ GenTree* Lowering::LowerNode(GenTree* node)
             LowerStoreIndirCommon(node->AsIndir());
             break;
 
+#ifdef TARGET_ARM64
+        case GT_NOT:
+            LowerNot(node->AsUnOp());
+            break;
+#endif
+
         case GT_ADD:
         {
             GenTree* next = LowerAdd(node->AsOp());

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -124,6 +124,12 @@ GenTree* Lowering::LowerNode(GenTree* node)
             LowerNot(node->AsUnOp());
             break;
 
+        case GT_AND:
+        case GT_OR:
+        case GT_XOR:
+            LowerLogical(node->AsOp());
+            break;
+
         case GT_MUL:
         case GT_MULHI:
             LowerMultiply(node->AsOp());
@@ -147,9 +153,11 @@ GenTree* Lowering::LowerNode(GenTree* node)
         case GT_SUB_HI:
 #endif
         case GT_SUB:
+#ifndef TARGET_ARM64
         case GT_AND:
         case GT_OR:
         case GT_XOR:
+#endif
             ContainCheckBinary(node->AsOp());
             break;
 

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -123,6 +123,11 @@ GenTree* Lowering::LowerNode(GenTree* node)
         case GT_NOT:
             LowerNot(node->AsUnOp());
             break;
+
+        case GT_MUL:
+        case GT_MULHI:
+            LowerMultiply(node->AsOp());
+            break;
 #endif
 
         case GT_ADD:
@@ -148,6 +153,7 @@ GenTree* Lowering::LowerNode(GenTree* node)
             ContainCheckBinary(node->AsOp());
             break;
 
+#ifdef TARGET_XARCH
         case GT_MUL:
         case GT_MULHI:
 #if defined(TARGET_X86)
@@ -155,6 +161,7 @@ GenTree* Lowering::LowerNode(GenTree* node)
 #endif
             ContainCheckMul(node->AsOp());
             break;
+#endif
 
         case GT_UDIV:
         case GT_UMOD:

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -5383,6 +5383,7 @@ GenTree* Lowering::LowerSignedDivOrMod(GenTree* node)
     return next;
 }
 
+#ifndef TARGET_ARM64
 //------------------------------------------------------------------------
 // LowerShift: Lower shift nodes
 //
@@ -5532,6 +5533,8 @@ void Lowering::LowerShift(GenTreeOp* shift)
 
     ContainCheckShiftRotate(shift);
 }
+
+#endif // !TARGET_ARM64
 
 void Lowering::WidenSIMD12IfNecessary(GenTreeLclVarCommon* node)
 {

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -130,6 +130,10 @@ GenTree* Lowering::LowerNode(GenTree* node)
             LowerLogical(node->AsOp());
             break;
 
+        case GT_NEG:
+            LowerNeg(node->AsUnOp());
+            break;
+
         case GT_MUL:
         case GT_MULHI:
             LowerMultiply(node->AsOp());

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -131,7 +131,7 @@ GenTree* Lowering::LowerNode(GenTree* node)
             break;
 
         case GT_NEG:
-            LowerNeg(node->AsUnOp());
+            LowerNegate(node->AsUnOp());
             break;
 
         case GT_ADD:
@@ -5225,6 +5225,9 @@ GenTree* Lowering::LowerConstIntDivOrMod(GenTree* node)
 #endif
     }
 
+    // TODO-MIKE-ARM64-CQ: Signed division by 2 generate a LSR that can be combined with
+    // the subsequent ADD.
+
     // We're committed to the conversion now. Go find the use if any.
     LIR::Use use;
     if (!BlockRange().TryGetUse(node, &use))
@@ -5439,7 +5442,7 @@ void Lowering::LowerShift(GenTreeOp* shift)
 #elif defined(TARGET_X86)
         size_t mask = 0x1f;
 #elif defined(TARGET_ARM)
-        size_t   mask         = 0xff;
+        size_t mask = 0xff;
 #elif
 #error Unknown target
 #endif

--- a/src/coreclr/src/jit/lower.h
+++ b/src/coreclr/src/jit/lower.h
@@ -294,6 +294,7 @@ private:
 
 #ifdef TARGET_ARM64
     void LowerNot(GenTreeUnOp* not);
+    void LowerLogical(GenTreeOp* logical);
     void LowerMultiply(GenTreeOp* mul);
 #endif
 

--- a/src/coreclr/src/jit/lower.h
+++ b/src/coreclr/src/jit/lower.h
@@ -292,6 +292,10 @@ private:
     void ContainBlockStoreAddress(GenTree* store, unsigned size, GenTree* addr);
     void LowerPutArgStk(GenTreePutArgStk* tree);
 
+#ifdef TARGET_ARM64
+    void LowerNot(GenTreeUnOp* not);
+#endif
+
     bool TryCreateAddrMode(GenTree* addr, bool isContainable);
 
     bool TryTransformStoreObjAsStoreInd(GenTreeBlk* blkNode);

--- a/src/coreclr/src/jit/lower.h
+++ b/src/coreclr/src/jit/lower.h
@@ -295,15 +295,24 @@ private:
     void LowerPutArgStk(GenTreePutArgStk* tree);
 
 #ifdef TARGET_ARM64
-    void LowerNot(GenTreeUnOp* not);
+    void LowerNot(GenTreeUnOp* node);
+    void CombineNot(GenTreeInstr* instr);
     void LowerLogical(GenTreeOp* logical);
-    void LowerNeg(GenTreeUnOp* neg);
+    void LowerNegate(GenTreeUnOp* neg);
     void LowerArithmetic(GenTreeOp* arith);
     void LowerMultiply(GenTreeOp* mul);
     void LowerShiftImmediate(GenTreeOp* shift);
+    void CombineShiftImmediate(GenTreeInstr* shift);
     void LowerShiftVariable(GenTreeOp* shift);
     GenTree* LowerRelop(GenTreeOp* relop);
     GenTree* OptimizeRelopImm(GenTreeOp* relop);
+    GenTreeInstr* MakeInstr(GenTree* node, instruction ins, emitAttr size);
+    GenTreeInstr* MakeInstr(GenTree* node, instruction ins, emitAttr size, GenTree* op1);
+    GenTreeInstr* MakeInstr(GenTree* node, instruction ins, emitAttr size, GenTree* op1, GenTree* op2);
+    GenTreeInstr* NewInstrBefore(GenTree* before, var_types type, instruction ins, GenTree* op1);
+    GenTreeInstr* NewInstrAfter(GenTree* after, var_types type, instruction ins, GenTree* op1);
+    GenTreeInstr* NewInstrBefore(GenTree* before, var_types type, instruction ins, GenTree* op1, GenTree* op2);
+    INDEBUG(bool IsLegalToMoveUseForward(GenTree* oldUser, GenTree* newUser, GenTree* def);)
 #endif
 
     bool TryCreateAddrMode(GenTree* addr, bool isContainable);

--- a/src/coreclr/src/jit/lower.h
+++ b/src/coreclr/src/jit/lower.h
@@ -295,6 +295,7 @@ private:
 #ifdef TARGET_ARM64
     void LowerNot(GenTreeUnOp* not);
     void LowerLogical(GenTreeOp* logical);
+    void LowerNeg(GenTreeUnOp* neg);
     void LowerMultiply(GenTreeOp* mul);
 #endif
 

--- a/src/coreclr/src/jit/lower.h
+++ b/src/coreclr/src/jit/lower.h
@@ -83,7 +83,7 @@ private:
     void ContainCheckArrOffset(GenTreeArrOffs* node);
     void ContainCheckLclHeap(GenTreeOp* node);
     void ContainCheckRet(GenTreeUnOp* ret);
-    void ContainCheckJTrue(GenTreeOp* node);
+    void ContainCheckJTrue(GenTreeUnOp* node);
 
     void ContainCheckCallOperands(GenTreeCall* call);
     void ContainCheckIndir(GenTreeIndir* indirNode);
@@ -124,9 +124,11 @@ private:
 #ifndef TARGET_64BIT
     GenTree* DecomposeLongCompare(GenTree* cmp);
 #endif
+#ifndef TARGET_ARM64
     GenTree* OptimizeConstCompare(GenTree* cmp);
     GenTree* LowerCompare(GenTree* cmp);
-    GenTree* LowerJTrue(GenTreeOp* jtrue);
+#endif
+    GenTree* LowerJTrue(GenTreeUnOp* jtrue);
     GenTreeCC* LowerNodeCC(GenTree* node, GenCondition condition);
     void LowerJmpMethod(GenTree* jmp);
     void LowerRet(GenTreeUnOp* ret);
@@ -300,6 +302,8 @@ private:
     void LowerMultiply(GenTreeOp* mul);
     void LowerShiftImmediate(GenTreeOp* shift);
     void LowerShiftVariable(GenTreeOp* shift);
+    GenTree* LowerRelop(GenTreeOp* relop);
+    GenTree* OptimizeRelopImm(GenTreeOp* relop);
 #endif
 
     bool TryCreateAddrMode(GenTree* addr, bool isContainable);

--- a/src/coreclr/src/jit/lower.h
+++ b/src/coreclr/src/jit/lower.h
@@ -298,6 +298,8 @@ private:
     void LowerNeg(GenTreeUnOp* neg);
     void LowerArithmetic(GenTreeOp* arith);
     void LowerMultiply(GenTreeOp* mul);
+    void LowerShiftImmediate(GenTreeOp* shift);
+    void LowerShiftVariable(GenTreeOp* shift);
 #endif
 
     bool TryCreateAddrMode(GenTree* addr, bool isContainable);

--- a/src/coreclr/src/jit/lower.h
+++ b/src/coreclr/src/jit/lower.h
@@ -296,6 +296,7 @@ private:
     void LowerNot(GenTreeUnOp* not);
     void LowerLogical(GenTreeOp* logical);
     void LowerNeg(GenTreeUnOp* neg);
+    void LowerArithmetic(GenTreeOp* arith);
     void LowerMultiply(GenTreeOp* mul);
 #endif
 

--- a/src/coreclr/src/jit/lower.h
+++ b/src/coreclr/src/jit/lower.h
@@ -294,6 +294,7 @@ private:
 
 #ifdef TARGET_ARM64
     void LowerNot(GenTreeUnOp* not);
+    void LowerMultiply(GenTreeOp* mul);
 #endif
 
     bool TryCreateAddrMode(GenTree* addr, bool isContainable);

--- a/src/coreclr/src/jit/lowerarm64.cpp
+++ b/src/coreclr/src/jit/lowerarm64.cpp
@@ -1145,13 +1145,13 @@ void Lowering::LowerMultiply(GenTreeOp* mul)
 
     if (mul->OperIs(GT_MULHI))
     {
-        bool isUnsigned = mul->IsUnsigned();
-
-        if (op1->TypeIs(TYP_LONG))
+        if (size == EA_8BYTE)
         {
             assert(mul->TypeIs(TYP_LONG));
+            assert(op1->TypeIs(TYP_LONG));
+            assert(op2->TypeIs(TYP_LONG));
 
-            MakeInstr(mul, isUnsigned ? INS_umulh : INS_smulh, EA_8BYTE, op1, op2);
+            MakeInstr(mul, mul->IsUnsigned() ? INS_umulh : INS_smulh, EA_8BYTE, op1, op2);
         }
         else
         {
@@ -1164,9 +1164,9 @@ void Lowering::LowerMultiply(GenTreeOp* mul)
             // long result. And in some cases magic division follows up with another right shift that currently doesn't
             // combine with this one.
 
-            instruction   ins   = isUnsigned ? INS_umull : INS_smull;
+            instruction   ins   = mul->IsUnsigned() ? INS_umull : INS_smull;
             GenTreeInstr* mull  = NewInstrBefore(mul, TYP_LONG, ins, op1, op2);
-            GenTreeInstr* instr = MakeInstr(mul, isUnsigned ? INS_lsr : INS_asr, EA_8BYTE, mull);
+            GenTreeInstr* instr = MakeInstr(mul, INS_lsr, EA_8BYTE, mull);
             instr->SetImmediate(32);
         }
 

--- a/src/coreclr/src/jit/lowerarm64.cpp
+++ b/src/coreclr/src/jit/lowerarm64.cpp
@@ -22,4 +22,69 @@ void Lowering::LowerNot(GenTreeUnOp* not)
     instr->SetOp(0, op1);
 }
 
+void Lowering::LowerMultiply(GenTreeOp* mul)
+{
+    assert(mul->OperIs(GT_MUL, GT_MULHI));
+
+    if (mul->OperIs(GT_MUL) && mul->gtOverflow())
+    {
+        return;
+    }
+
+    GenTree* op1 = mul->GetOp(0);
+    GenTree* op2 = mul->GetOp(1);
+
+    if (mul->OperIs(GT_MULHI) && !op1->TypeIs(TYP_LONG))
+    {
+        assert(mul->TypeIs(TYP_INT));
+        assert(varActualType(op1->GetType()) == TYP_INT);
+        assert(varActualType(op2->GetType()) == TYP_INT);
+
+        // TODO-MIKE-Cleanup: Magic division should not produce such a MULHI node. There's no corresponding ARM64
+        // instruction for this operation and we need to insert a right shift to obtain the "hi" 32 bits of the
+        // long result. And in some cases magic division follows up with another right shift that currently doesn't
+        // combine with this one.
+
+        GenTreeInstr* mull =
+            new (comp, GT_INSTR) GenTreeInstr(TYP_LONG, mul->IsUnsigned() ? INS_umull : INS_smull, op1, op2);
+        BlockRange().InsertBefore(mul, mull);
+
+        mul->ChangeOper(GT_INSTR);
+
+        GenTreeInstr* instr = mul->AsInstr();
+        instr->SetIns(mul->IsUnsigned() ? INS_lsr : INS_asr, EA_8BYTE);
+        instr->SetImmediate(32);
+        instr->SetNumOps(1);
+        instr->SetOp(0, mull);
+
+        return;
+    }
+
+    instruction ins;
+
+    if (varTypeIsFloating(mul->GetType()))
+    {
+        ins = INS_fmul;
+    }
+    else if (mul->OperIs(GT_MULHI))
+    {
+        assert(mul->TypeIs(TYP_LONG));
+
+        ins = mul->IsUnsigned() ? INS_umulh : INS_smulh;
+    }
+    else
+    {
+        ins = INS_mul;
+    }
+
+    mul->ChangeOper(GT_INSTR);
+
+    GenTreeInstr* instr = mul->AsInstr();
+    instr->SetIns(ins);
+    instr->SetImmediate(0);
+    instr->SetNumOps(2);
+    instr->SetOp(0, op1);
+    instr->SetOp(1, op2);
+}
+
 #endif // TARGET_ARM64

--- a/src/coreclr/src/jit/lowerarm64.cpp
+++ b/src/coreclr/src/jit/lowerarm64.cpp
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "jitpch.h"
+#include "lower.h"
+
+#ifdef TARGET_ARM64 // This file is ONLY used for ARM64 architectures
+
+void Lowering::LowerNot(GenTreeUnOp* not)
+{
+    assert(not->OperIs(GT_NOT));
+
+    GenTree* op1 = not->GetOp(0);
+
+    not->ChangeOper(GT_INSTR);
+
+    GenTreeInstr* instr = not->AsInstr();
+    instr->SetIns(INS_mvn);
+    instr->SetImmediate(0);
+    instr->SetNumOps(1);
+    instr->SetOp(0, op1);
+}
+
+#endif // TARGET_ARM64

--- a/src/coreclr/src/jit/lowerarm64.cpp
+++ b/src/coreclr/src/jit/lowerarm64.cpp
@@ -386,7 +386,24 @@ void Lowering::LowerNeg(GenTreeUnOp* neg)
         return;
     }
 
-    emitAttr      size  = emitActualTypeSize(neg->GetType());
+    emitAttr size = emitActualTypeSize(neg->GetType());
+
+    if (GenTreeInstr* mul = IsInstr(op1, size, INS_mul))
+    {
+        neg->ChangeOper(GT_INSTR);
+
+        GenTreeInstr* instr = neg->AsInstr();
+        instr->SetIns(INS_mneg);
+        instr->SetImmediate(0);
+        instr->SetNumOps(2);
+        instr->SetOp(0, mul->GetOp(0));
+        instr->SetOp(1, mul->GetOp(1));
+
+        BlockRange().Remove(mul);
+
+        return;
+    }
+
     insOpts       opt   = INS_OPTS_NONE;
     unsigned      imm   = 0;
     GenTreeInstr* shift = nullptr;

--- a/src/coreclr/src/jit/lowerarm64.cpp
+++ b/src/coreclr/src/jit/lowerarm64.cpp
@@ -1437,6 +1437,21 @@ GenTree* Lowering::LowerJTrue(GenTreeUnOp* jtrue)
             useJCMP   = true;
             jcmpFlags = relop->OperIs(GT_EQ) ? GTF_JCMP_EQ : 0;
         }
+        else if (relop->OperIs(GT_LT, GT_GE) && !relop->IsUnsigned() && (imm == 0))
+        {
+            // Positive/negative checks can test the sign bit using TBZ/TBNZ
+            useJCMP   = true;
+            jcmpFlags = GTF_JCMP_TST | (relop->OperIs(GT_GE) ? GTF_JCMP_EQ : 0);
+
+            if (varTypeIsLong(relop->AsOp()->GetOp(0)->GetType()))
+            {
+                relopOp2->AsIntCon()->SetValue(63);
+            }
+            else
+            {
+                relopOp2->AsIntCon()->SetValue(31);
+            }
+        }
         else if (relop->OperIs(GT_TEST_EQ, GT_TEST_NE))
         {
             if (!varTypeIsLong(relop->GetOp(0)->GetType()))

--- a/src/coreclr/src/jit/lowerarm64.cpp
+++ b/src/coreclr/src/jit/lowerarm64.cpp
@@ -98,6 +98,32 @@ void Lowering::LowerLogical(GenTreeOp* logical)
     }
 }
 
+void Lowering::LowerNeg(GenTreeUnOp* neg)
+{
+    assert(neg->OperIs(GT_NEG));
+
+    GenTree* op1 = neg->GetOp(0);
+
+    instruction ins;
+
+    if (varTypeIsFloating(neg->GetType()))
+    {
+        ins = INS_fneg;
+    }
+    else
+    {
+        ins = INS_neg;
+    }
+
+    neg->ChangeOper(GT_INSTR);
+
+    GenTreeInstr* instr = neg->AsInstr();
+    instr->SetIns(ins);
+    instr->SetImmediate(0);
+    instr->SetNumOps(1);
+    instr->SetOp(0, op1);
+}
+
 void Lowering::LowerMultiply(GenTreeOp* mul)
 {
     assert(mul->OperIs(GT_MUL, GT_MULHI));

--- a/src/coreclr/src/jit/lsra.h
+++ b/src/coreclr/src/jit/lsra.h
@@ -1629,6 +1629,8 @@ private:
     int BuildPutArgSplit(GenTreePutArgSplit* tree);
 #endif // FEATURE_ARG_SPLIT
     int BuildLclHeap(GenTree* tree);
+
+    int BuildInstr(GenTreeInstr* instr);
 };
 
 /*XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/src/coreclr/src/jit/lsraarm.cpp
+++ b/src/coreclr/src/jit/lsraarm.cpp
@@ -809,6 +809,10 @@ int LinearScan::BuildNode(GenTree* tree)
             BuildDef(tree);
             break;
 
+        case GT_INSTR:
+            srcCount = BuildInstr(tree->AsInstr());
+            break;
+
         default:
 #ifdef DEBUG
             char message[256];

--- a/src/coreclr/src/jit/lsraarm64.cpp
+++ b/src/coreclr/src/jit/lsraarm64.cpp
@@ -748,6 +748,10 @@ int LinearScan::BuildNode(GenTree* tree)
             BuildDef(tree);
             break;
 
+        case GT_INSTR:
+            srcCount = BuildInstr(tree->AsInstr());
+            break;
+
     } // end switch (tree->OperGet())
 
     if (tree->IsUnusedValue() && (dstCount != 0))

--- a/src/coreclr/src/jit/lsraarmarch.cpp
+++ b/src/coreclr/src/jit/lsraarmarch.cpp
@@ -688,20 +688,6 @@ int LinearScan::BuildCast(GenTreeCast* cast)
         buildInternalFloatRegisterDefForNode(cast, RBM_ALLFLOAT);
         setInternalRegsDelayFree = true;
     }
-#else
-    // Overflow checking cast from TYP_LONG to TYP_INT requires a temporary register to
-    // store the min and max immediate values that cannot be encoded in the CMP instruction.
-    if (cast->gtOverflow() && varTypeIsLong(srcType) && !cast->IsUnsigned() && (castType == TYP_INT))
-    {
-        buildInternalIntRegisterDefForNode(cast);
-
-        // If the cast operand ends up being in memory then the value will be loaded directly
-        // into the destination register and thus the internal register has to be different.
-        if (src->isContained() || src->IsRegOptional())
-        {
-            setInternalRegsDelayFree = true;
-        }
-    }
 #endif
 
     int srcCount = BuildOperandUses(src);

--- a/src/coreclr/src/jit/lsrabuild.cpp
+++ b/src/coreclr/src/jit/lsrabuild.cpp
@@ -3867,7 +3867,10 @@ int LinearScan::BuildInstr(GenTreeInstr* instr)
         srcCount++;
     }
 
-    BuildDef(instr);
+    if (!instr->TypeIs(TYP_VOID))
+    {
+        BuildDef(instr);
+    }
 
     return srcCount;
 }

--- a/src/coreclr/src/jit/lsrabuild.cpp
+++ b/src/coreclr/src/jit/lsrabuild.cpp
@@ -3856,3 +3856,18 @@ int LinearScan::BuildCmp(GenTree* tree)
     }
     return srcCount;
 }
+
+int LinearScan::BuildInstr(GenTreeInstr* instr)
+{
+    int srcCount = 0;
+
+    for (GenTreeInstr::Use& use : instr->Uses())
+    {
+        BuildUse(use.GetNode());
+        srcCount++;
+    }
+
+    BuildDef(instr);
+
+    return srcCount;
+}

--- a/src/coreclr/src/jit/lsraxarch.cpp
+++ b/src/coreclr/src/jit/lsraxarch.cpp
@@ -679,6 +679,10 @@ int LinearScan::BuildNode(GenTree* tree)
         }
         break;
 
+        case GT_INSTR:
+            srcCount = BuildInstr(tree->AsInstr());
+            break;
+
     } // end switch (tree->OperGet())
 
     // We need to be sure that we've set srcCount and dstCount appropriately.

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -14805,6 +14805,14 @@ GenTree* Compiler::fgMorphTree(GenTree* tree, MorphAddrContext* mac)
             break;
 #endif // FEATURE_SIMD
 
+        case GT_INSTR:
+            assert(compRationalIRForm);
+            for (GenTreeInstr::Use& use : tree->AsInstr()->Uses())
+            {
+                use.SetNode(fgMorphTree(use.GetNode()));
+            }
+            break;
+
         case GT_CMPXCHG:
             tree->AsCmpXchg()->gtOpLocation  = fgMorphTree(tree->AsCmpXchg()->gtOpLocation);
             tree->AsCmpXchg()->gtOpValue     = fgMorphTree(tree->AsCmpXchg()->gtOpValue);

--- a/src/coreclr/src/jit/rationalize.cpp
+++ b/src/coreclr/src/jit/rationalize.cpp
@@ -740,7 +740,7 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, Compiler::Ge
 
         default:
             // These nodes should not be present in HIR.
-            assert(!node->OperIs(GT_CMP, GT_SETCC, GT_JCC, GT_JCMP, GT_LOCKADD));
+            assert(!node->OperIs(GT_CMP, GT_SETCC, GT_JCC, GT_JCMP, GT_LOCKADD, GT_INSTR));
             break;
     }
 


### PR DESCRIPTION
alt-arm64 diff:
```
Total bytes of diff: -171336 (-0.337% of base)
    diff is an improvement.
Top file improvements (bytes):
      -42592 : System.Private.CoreLib.dasm (-0.912% of base)
      -15484 : System.Private.Xml.dasm (-0.355% of base)
      -10040 : System.Reflection.Metadata.dasm (-2.134% of base)
       -9512 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.157% of base)
       -9248 : System.Data.Common.dasm (-0.583% of base)
       -7048 : Microsoft.CodeAnalysis.CSharp.dasm (-0.126% of base)
       -6648 : System.Linq.Expressions.dasm (-0.574% of base)
       -6492 : Microsoft.CodeAnalysis.dasm (-0.332% of base)
       -5552 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.113% of base)
       -4388 : Microsoft.VisualBasic.Core.dasm (-0.720% of base)
       -3168 : System.Private.DataContractSerialization.dasm (-0.300% of base)
       -2748 : System.Text.RegularExpressions.dasm (-1.041% of base)
       -2356 : System.Runtime.Numerics.dasm (-2.740% of base)
       -1924 : Newtonsoft.Json.dasm (-0.211% of base)
       -1900 : System.Net.Http.dasm (-0.235% of base)
       -1860 : System.Data.OleDb.dasm (-0.473% of base)
       -1704 : System.Collections.Immutable.dasm (-0.366% of base)
       -1704 : System.Linq.Parallel.dasm (-0.238% of base)
       -1664 : System.Text.Json.dasm (-0.458% of base)
       -1348 : Microsoft.CSharp.dasm (-0.293% of base)
161 total files with Code Size differences (161 improved, 0 regressed), 101 unchanged.
Top method improvements (bytes):
       -2712 (-2.243% of base) : System.Linq.Expressions.dasm - FuncCallInstruction`3:Run(InterpretedFrame):int:this (226 methods)
        -660 (-5.168% of base) : System.Private.CoreLib.dasm - DefaultBinder:BindToMethod(int,ref,byref,ref,CultureInfo,ref,byref):MethodBase:this
        -616 (-3.943% of base) : Microsoft.VisualBasic.Core.dasm - VBBinder:BindToMethod(int,ref,byref,ref,CultureInfo,ref,byref):MethodBase:this
        -616 (-7.113% of base) : System.Data.Common.dasm - RBTree`1:RBInsert(int,int,int,int,bool):int:this
        -544 (-13.039% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - TraceEventSession:SetStackTraceIds(int,long,int):int
        -520 (-5.058% of base) : System.Text.RegularExpressions.dasm - RegexInterpreter:Go():this
        -364 (-3.404% of base) : System.Reflection.Metadata.dasm - MetadataReader:InitializeTableReaders(MemoryBlock,ubyte,ref,ref):this
        -344 (-6.600% of base) : System.Data.Common.dasm - RBTree`1:RBDeleteFixup(int,int,int,int):int:this
        -336 (-1.103% of base) : System.Text.RegularExpressions.dasm - RegexCompiler:GenerateOneCode():this
        -320 (-2.442% of base) : System.Private.CoreLib.dasm - Vector128`1:ToString():String:this (12 methods)
        -320 (-2.375% of base) : System.Private.CoreLib.dasm - Vector256`1:ToString():String:this (12 methods)
        -320 (-2.445% of base) : System.Private.CoreLib.dasm - Vector64`1:ToString():String:this (12 methods)
        -316 (-6.026% of base) : System.Private.Xml.dasm - XmlSchemaInference:InferSimpleType(String,byref):int
        -308 (-17.111% of base) : System.Private.CoreLib.dasm - DecCalc:ScaleResult(long,int,int):int
        -304 (-0.996% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:ReportOverloadResolutionFailureForASingleCandidate(VisualBasicSyntaxNode,Location,int,byref,ImmutableArray`1,ImmutableArray`1,bool,bool,bool,bool,DiagnosticBag,Symbol,bool,VisualBasicSyntaxNode,Symbol):this (2 methods)
        -276 (-3.306% of base) : System.Text.RegularExpressions.dasm - RegexWriter:EmitFragment(int,RegexNode,int):this
        -268 (-10.030% of base) : System.Private.CoreLib.dasm - Span`1:.ctor(ref,int,int):this (22 methods)
        -236 (-4.181% of base) : System.Data.Common.dasm - RBTree`1:RBDeleteX(int,int,int):int:this
        -228 (-10.795% of base) : System.Private.CoreLib.dasm - ReadOnlySpan`1:.ctor(ref,int,int):this (19 methods)
        -228 (-9.437% of base) : System.Private.CoreLib.dasm - ReadOnlySpan`1:op_Implicit(ArraySegment`1):ReadOnlySpan`1 (19 methods)
Top method improvements (percentages):
         -16 (-33.333% of base) : System.Private.CoreLib.dasm - IntPtr:op_Explicit(long):int
         -60 (-31.250% of base) : Microsoft.CodeAnalysis.dasm - CachingBase`1:AlignSize(int):int (3 methods)
         -20 (-31.250% of base) : System.Private.CoreLib.dasm - ConcurrentQueueSegment`1:RoundUpToPowerOf2(int):int
         -16 (-30.769% of base) : System.Net.Sockets.dasm - SendPacketsElement:get_Offset():int:this
         -16 (-30.769% of base) : System.Private.CoreLib.dasm - IntPtr:ToInt32():int:this
         -16 (-30.769% of base) : System.Windows.Extensions.dasm - SoundPlayer:mmioFOURCC(ushort,ushort,ushort,ushort):int
         -20 (-29.412% of base) : System.Linq.Expressions.dasm - CacheDict`2:AlignSize(int):int
         -16 (-28.571% of base) : System.Drawing.Primitives.dasm - ColorTranslator:COLORREFToARGB(int):int
          -8 (-28.571% of base) : System.Private.CoreLib.dasm - DecCalc:UInt32x32To64(int,int):long
          -8 (-28.571% of base) : System.Private.CoreLib.dasm - Math:BigMul(int,int):long
          -8 (-28.571% of base) : System.Private.CoreLib.dasm - Half:IsNegative(Half):bool
         -28 (-28.000% of base) : System.Private.CoreLib.dasm - Tuple:CombineHashCodes(int,int,int,int,int,int,int,int):int
         -24 (-27.273% of base) : System.Private.CoreLib.dasm - Tuple:CombineHashCodes(int,int,int,int,int,int,int):int
         -20 (-26.316% of base) : System.Private.CoreLib.dasm - Tuple:CombineHashCodes(int,int,int,int,int,int):int
         -16 (-25.000% of base) : System.Data.Common.dasm - SqlMoney:ToInt32():int:this
         -12 (-25.000% of base) : System.Private.CoreLib.dasm - Utf8Utility:ExtractCharFromFirstThreeByteSequence(int):int
         -16 (-25.000% of base) : System.Private.CoreLib.dasm - Tuple:CombineHashCodes(int,int,int,int,int):int
         -16 (-23.529% of base) : System.Private.CoreLib.dasm - RuntimeHelpers:GetRawObjectDataSize(Object):long
         -12 (-23.077% of base) : System.Private.CoreLib.dasm - Tuple:CombineHashCodes(int,int,int,int):int
         -20 (-22.727% of base) : System.Reflection.Metadata.dasm - SequencePoint:GetHashCode():int:this
14544 total methods with Code Size differences (14544 improved, 0 regressed), 171374 unchanged.
```