### PR TITLE
Improve passing of multireg OBJ call args

### DIFF
--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -3214,6 +3214,7 @@ public:
     bool lvaHaveManyLocals() const;
 
     unsigned lvaNewTemp(var_types type, bool shortLifetime DEBUGARG(const char* reason));
+    unsigned lvaNewTemp(ClassLayout* layout, bool shortLifetime DEBUGARG(const char* reason));
 
     unsigned lvaGrabTemp(bool shortLifetime DEBUGARG(const char* reason));
     unsigned lvaGrabTemps(unsigned cnt DEBUGARG(const char* reason));

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -9920,6 +9920,7 @@ public:
 #if FEATURE_MULTIREG_ARGS
     void fgMorphMultiregStructArgs(GenTreeCall* call);
     GenTree* fgMorphMultiregStructArg(GenTree* arg, fgArgTabEntry* fgEntryPtr);
+    GenTree* abiNewMultiloadIndir(GenTree* addr, ssize_t addrOffset, unsigned indirSize);
     GenTreeFieldList* fgMorphLclArgToFieldlist(GenTreeLclVarCommon* lcl);
 #if defined(TARGET_ARMARCH) || defined(UNIX_AMD64_ABI)
     bool abiCanMorphPromotedStructArgToFieldList(LclVarDsc* lcl, CallArgInfo* argInfo);

--- a/src/coreclr/src/jit/compiler.hpp
+++ b/src/coreclr/src/jit/compiler.hpp
@@ -1578,6 +1578,15 @@ inline unsigned Compiler::lvaNewTemp(var_types type, bool shortLifetime DEBUGARG
     return lclNum;
 }
 
+inline unsigned Compiler::lvaNewTemp(ClassLayout* layout, bool shortLifetime DEBUGARG(const char* reason))
+{
+    assert(layout->IsValueClass());
+
+    unsigned lclNum = lvaGrabTemp(shortLifetime DEBUGARG(reason));
+    lvaSetStruct(lclNum, layout->GetClassHandle(), false);
+    return lclNum;
+}
+
 /*****************************************************************************
  *
  *  Allocate a temporary variable or a set of temp variables.

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -902,7 +902,7 @@ GenTreeCall::Use* Compiler::impPopCallArgs(unsigned count, CORINFO_SIG_INFO* sig
 #ifdef DEBUG
             if (verbose)
             {
-                printf("Calling impNormStructVal on:\n");
+                printf("Calling impNormStructVal(%s) on:\n", eeGetClassName(structType));
                 gtDispTree(temp);
             }
 #endif

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -3144,11 +3144,10 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
                     }
                     else
                     {
-                        // This should only be the case of a value directly producing a known struct type.
-                        if (argEntry->numRegs > 1)
-                        {
-                            copyBlkClass = objClass;
-                        }
+                        // We can't get a SIMD arg here, Vector2 is in the "canTransform" path, Vector3/4 are
+                        // passed in 2 XMM regs and have been special cased above, Vector/Vector128/Vector256
+                        // are passed on stack due to the VM's ABI being broken.
+                        unreached();
                     }
 #endif // UNIX_AMD64_ABI
 #elif defined(TARGET_ARM64)

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -4803,7 +4803,7 @@ GenTree* Compiler::fgMorphMultiregStructArg(GenTree* arg, fgArgTabEntry* fgEntry
         if (!addrTempRequired)
         {
             gtPrepareCost(addr);
-            addrTempRequired = addr->GetCostEx() > 6 * IND_COST_EX;
+            addrTempRequired = addr->GetCostEx() > 4 * IND_COST_EX;
         }
 
         GenTree* addrAsg = nullptr;

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -1059,9 +1059,8 @@ void fgArgInfo::ArgsComplete(Compiler* compiler)
 #if defined(TARGET_ARM64) || (UNIX_AMD64_ABI)
         if (!curArgTabEntry->needTmp && (curArgTabEntry->GetRegCount() > 1) && varTypeIsSIMD(argx->GetType()))
         {
-            if (argx->OperIsSimdOrHWintrinsic() ||
-                (argx->OperIs(GT_OBJ) && argx->AsObj()->GetAddr()->OperIs(GT_ADDR) &&
-                 argx->AsObj()->GetAddr()->AsUnOp()->GetOp(0)->OperIsSimdOrHWintrinsic()))
+            if (argx->OperIs(GT_OBJ) && argx->AsObj()->GetAddr()->OperIs(GT_ADDR) &&
+                argx->AsObj()->GetAddr()->AsUnOp()->GetOp(0)->OperIsSimdOrHWintrinsic())
             {
                 curArgTabEntry->needTmp = true;
                 needsTemps              = true;

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -1056,7 +1056,7 @@ void fgArgInfo::ArgsComplete(Compiler* compiler)
             }
         }
 
-#ifdef TARGET_ARM64
+#if defined(TARGET_ARM64) || (UNIX_AMD64_ABI)
         if (!curArgTabEntry->needTmp && (curArgTabEntry->GetRegCount() > 1) && varTypeIsSIMD(argx->GetType()))
         {
             if (argx->OperIsSimdOrHWintrinsic() ||

--- a/src/coreclr/src/jit/vartype.h
+++ b/src/coreclr/src/jit/vartype.h
@@ -403,6 +403,11 @@ inline var_types varTypeToUnsigned(var_types type)
     return type;
 }
 
+inline var_types varTypePointerAdd(var_types type)
+{
+    return (type == TYP_REF) ? TYP_BYREF : type;
+}
+
 /*****************************************************************************/
 #endif // _VARTYPE_H_
 /*****************************************************************************/


### PR DESCRIPTION
alt-linux-x64 diff:
```
Total bytes of diff: -638 (-0.001% of base)
    diff is an improvement.
Top file improvements (bytes):
        -120 : System.Net.HttpListener.dasm (-0.045% of base)
        -104 : System.Private.CoreLib.dasm (-0.003% of base)
         -82 : System.Collections.Immutable.dasm (-0.022% of base)
         -66 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.001% of base)
         -42 : System.Data.Common.dasm (-0.003% of base)
         -38 : System.Data.OleDb.dasm (-0.011% of base)
         -32 : Microsoft.CodeAnalysis.CSharp.dasm (-0.001% of base)
         -32 : System.Linq.Parallel.dasm (-0.005% of base)
         -28 : System.Collections.dasm (-0.017% of base)
         -24 : System.Drawing.Common.dasm (-0.006% of base)
         -21 : System.Net.Sockets.dasm (-0.009% of base)
         -16 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.000% of base)
         -12 : System.Private.DataContractSerialization.dasm (-0.001% of base)
         -11 : Microsoft.CSharp.dasm (-0.003% of base)
         -10 : System.Security.Cryptography.Pkcs.dasm (-0.003% of base)
15 total files with Code Size differences (15 improved, 0 regressed), 247 unchanged.
Top method improvements (bytes):
         -87 (-1.557% of base) : System.Net.HttpListener.dasm - <Process>d__19:MoveNext():this
         -42 (-2.014% of base) : System.Data.Common.dasm - DecimalStorage:Aggregate(ref,int):Object:this
         -35 (-2.402% of base) : System.Collections.Immutable.dasm - ImmutableArray`1:Sort(int,int,IComparer`1):ImmutableArray`1:this (3 methods)
         -33 (-2.603% of base) : System.Net.HttpListener.dasm - ReceiveOperation:ProcessAction_IndicateReceiveComplete(Nullable`1,int,int,ref,int,long):this
         -32 (-5.424% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:GetConstantOneForBinOp(int):ConstantValue (2 methods)
         -32 (-2.105% of base) : System.Linq.Parallel.dasm - OrderPreservingPipeliningSpoolingTask`2:SpoolingWork():this (2 methods)
         -28 (-1.142% of base) : System.Collections.dasm - SortedSet`1:.ctor(IEnumerable`1,IComparer`1):this (3 methods)
         -27 (-0.721% of base) : System.Data.OleDb.dasm - OleDbMetaDataFactory:.ctor(Stream,String,String,ref):this
         -24 (-1.530% of base) : System.Drawing.Common.dasm - Image:EnsureSave(Image,String,Stream)
         -22 (-1.063% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Conversions:ToBoolean(Object):bool (2 methods)
         -22 (-1.099% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Conversions:ToLong(Object):long (2 methods)
         -22 (-1.148% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Conversions:ToInteger(Object):int (2 methods)
         -21 (-3.318% of base) : System.Net.Sockets.dasm - OverlappedAsyncResult:SetUnmanagedStructures(IList`1):this
         -16 (-3.175% of base) : System.Collections.Immutable.dasm - ImmutableArray`1:IndexOf(KeyValuePair`2,int,int,IEqualityComparer`1):int:this
         -16 (-3.156% of base) : System.Collections.Immutable.dasm - ImmutableArray`1:LastIndexOf(KeyValuePair`2,int,int,IEqualityComparer`1):int:this
         -16 (-10.191% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:IndexOf(ref,ValueTuple`2,int,int):int:this
         -16 (-9.877% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:LastIndexOf(ref,ValueTuple`2,int,int):int:this
         -15 (-1.571% of base) : System.Collections.Immutable.dasm - ImmutableArray`1:RemoveAll(Predicate`1):ImmutableArray`1:this (3 methods)
         -12 (-4.364% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:IndexOf(ref,Nullable`1,int,int):int:this (2 methods)
         -12 (-4.211% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:LastIndexOf(ref,Nullable`1,int,int):int:this (2 methods)
Top method improvements (percentages):
         -16 (-10.191% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:IndexOf(ref,ValueTuple`2,int,int):int:this
         -16 (-9.877% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:LastIndexOf(ref,ValueTuple`2,int,int):int:this
         -11 (-9.016% of base) : Microsoft.CSharp.dasm - UnsafeMethods:GetNullInterfaceId():long
         -12 (-7.843% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:IndexOf(ref,ResourceLocator,int,int):int:this
         -12 (-7.843% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:IndexOf(ref,KeyValuePair`2,int,int):int:this
         -12 (-7.595% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:LastIndexOf(ref,ResourceLocator,int,int):int:this
         -12 (-7.595% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:LastIndexOf(ref,KeyValuePair`2,int,int):int:this
         -32 (-5.424% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:GetConstantOneForBinOp(int):ConstantValue (2 methods)
         -12 (-4.364% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:IndexOf(ref,Nullable`1,int,int):int:this (2 methods)
         -12 (-4.211% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:LastIndexOf(ref,Nullable`1,int,int):int:this (2 methods)
          -5 (-3.571% of base) : System.Data.OleDb.dasm - OleDbConnectionInternal:SupportSchemaRowset(Guid):bool:this
         -10 (-3.559% of base) : System.Security.Cryptography.Pkcs.dasm - HelpersWindows:AddCryptAttribute(CryptographicAttributeObjectCollection,long)
         -21 (-3.318% of base) : System.Net.Sockets.dasm - OverlappedAsyncResult:SetUnmanagedStructures(IList`1):this
         -16 (-3.175% of base) : System.Collections.Immutable.dasm - ImmutableArray`1:IndexOf(KeyValuePair`2,int,int,IEqualityComparer`1):int:this
         -16 (-3.156% of base) : System.Collections.Immutable.dasm - ImmutableArray`1:LastIndexOf(KeyValuePair`2,int,int,IEqualityComparer`1):int:this
         -33 (-2.603% of base) : System.Net.HttpListener.dasm - ReceiveOperation:ProcessAction_IndicateReceiveComplete(Nullable`1,int,int,ref,int,long):this
          -6 (-2.532% of base) : System.Data.OleDb.dasm - PropertyIDSet:.ctor(ref):this
         -35 (-2.402% of base) : System.Collections.Immutable.dasm - ImmutableArray`1:Sort(int,int,IComparer`1):ImmutableArray`1:this (3 methods)
         -32 (-2.105% of base) : System.Linq.Parallel.dasm - OrderPreservingPipeliningSpoolingTask`2:SpoolingWork():this (2 methods)
         -42 (-2.014% of base) : System.Data.Common.dasm - DecimalStorage:Aggregate(ref,int):Object:this
31 total methods with Code Size differences (31 improved, 0 regressed), 185984 unchanged.
```
alt-win-arm-x64 diff:
```
Total bytes of diff: -1332 (-0.003% of base)
    diff is an improvement.
Top file improvements (bytes):
        -384 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.006% of base)
        -288 : Microsoft.CodeAnalysis.CSharp.dasm (-0.005% of base)
        -148 : System.Private.CoreLib.dasm (-0.003% of base)
         -80 : System.Collections.Immutable.dasm (-0.017% of base)
         -72 : System.Data.Common.dasm (-0.005% of base)
         -40 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.001% of base)
         -40 : Newtonsoft.Json.dasm (-0.004% of base)
         -40 : System.Security.Cryptography.Pkcs.dasm (-0.011% of base)
         -32 : System.Net.HttpListener.dasm (-0.011% of base)
         -28 : System.Collections.dasm (-0.014% of base)
         -28 : System.Data.OleDb.dasm (-0.007% of base)
         -24 : Microsoft.CodeAnalysis.dasm (-0.001% of base)
         -24 : System.Linq.Parallel.dasm (-0.003% of base)
         -20 : System.Net.Sockets.dasm (-0.007% of base)
         -16 : System.Private.DataContractSerialization.dasm (-0.002% of base)
         -12 : System.Diagnostics.PerformanceCounter.dasm (-0.012% of base)
         -12 : System.Drawing.Common.dasm (-0.003% of base)
          -8 : System.ServiceProcess.ServiceController.dasm (-0.021% of base)
          -8 : System.Windows.Extensions.dasm (-0.018% of base)
          -4 : Microsoft.CSharp.dasm (-0.001% of base)
26 total files with Code Size differences (26 improved, 0 regressed), 236 unchanged.
Top method improvements (bytes):
        -104 (-4.797% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CSharpCompilation:GetDiagnosticsForSyntaxTree(int,SyntaxTree,Nullable`1,bool,CancellationToken):ImmutableArray`1:this (2 methods)
         -40 (-1.538% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceModuleSymbol:GetDeclarationErrorsInTree(SyntaxTree,Nullable`1,Func`4,CancellationToken):ImmutableArray`1:this (2 methods)
         -32 (-2.759% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CSharpCompilation:GetDiagnosticsForMethodBodiesInTree(SyntaxTree,Nullable`1,CancellationToken):ImmutableArray`1:this (2 methods)
         -32 (-3.077% of base) : Microsoft.CodeAnalysis.CSharp.dasm - DocumentationCommentCompiler:VisitNamedType(NamedTypeSymbol):this (2 methods)
         -32 (-0.633% of base) : Microsoft.CodeAnalysis.CSharp.dasm - DocumentationCommentCompiler:DefaultVisit(Symbol):this (2 methods)
         -32 (-16.000% of base) : Microsoft.CodeAnalysis.CSharp.dasm - <>c__DisplayClass173_0:<GetDiagnosticsForMethodBodiesInTree>b__0(Symbol):bool:this (2 methods)
         -32 (-12.500% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ClsComplianceChecker:IsSyntacticallyFilteredOut(Symbol):bool:this (2 methods)
         -32 (-5.970% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - ClsComplianceChecker:DoNotVisit(Symbol):bool:this (2 methods)
         -32 (-1.550% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DocumentationCommentCompiler:VisitNamespace(NamespaceSymbol):this (2 methods)
         -32 (-3.361% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DocumentationCommentCompiler:VisitNamedType(NamedTypeSymbol):this (2 methods)
         -32 (-5.970% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DocumentationCommentCompiler:VisitMethod(MethodSymbol):this (2 methods)
         -32 (-1.439% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DocumentationCommentCompiler:GetDocumentationCommentForSymbol(Symbol,DocumentationCommentTriviaSyntax,Dictionary`2):String:this (2 methods)
         -32 (-6.780% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DocumentationCommentCompiler:VisitField(FieldSymbol):this (2 methods)
         -32 (-6.780% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DocumentationCommentCompiler:VisitProperty(PropertySymbol):this (2 methods)
         -32 (-4.878% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - _Closure$__77-0:_Lambda$__0(NamespaceOrTypeSymbol):this (2 methods)
         -32 (-16.000% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - _Closure$__17-0:_Lambda$__0(Symbol):bool:this (2 methods)
         -32 (-6.780% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DocumentationCommentCompiler:VisitEvent(EventSymbol):this (2 methods)
         -32 (-1.951% of base) : System.Collections.Immutable.dasm - ImmutableArray`1:Sort(int,int,IComparer`1):ImmutableArray`1:this (3 methods)
         -32 (-14.545% of base) : System.Data.Common.dasm - SqlDateTime:CompareTo(SqlDateTime):int:this
         -28 (-1.000% of base) : System.Collections.dasm - SortedSet`1:.ctor(IEnumerable`1,IComparer`1):this (3 methods)
Top method improvements (percentages):
         -32 (-16.000% of base) : Microsoft.CodeAnalysis.CSharp.dasm - <>c__DisplayClass173_0:<GetDiagnosticsForMethodBodiesInTree>b__0(Symbol):bool:this (2 methods)
         -32 (-16.000% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - _Closure$__17-0:_Lambda$__0(Symbol):bool:this (2 methods)
         -32 (-14.545% of base) : System.Data.Common.dasm - SqlDateTime:CompareTo(SqlDateTime):int:this
          -8 (-14.286% of base) : System.Data.Common.dasm - SqlDateTime:ToSqlString():SqlString:this
         -32 (-12.500% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ClsComplianceChecker:IsSyntacticallyFilteredOut(Symbol):bool:this (2 methods)
         -16 (-9.302% of base) : System.Data.Common.dasm - SqlDateTimeStorage:CompareValueTo(int,Object):int:this
          -4 (-9.091% of base) : System.Security.Cryptography.Pkcs.dasm - <>c:<get_EncryptedKey>b__8_0(long):ref:this
         -16 (-7.843% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:IndexOf(ref,ValueTuple`2,int,int):int:this
          -4 (-7.692% of base) : System.Console.dasm - ValueStringBuilder:GetPinnableReference():byref:this
         -16 (-7.692% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:LastIndexOf(ref,ValueTuple`2,int,int):int:this
          -4 (-7.692% of base) : System.ServiceProcess.ServiceController.dasm - ValueStringBuilder:GetPinnableReference():byref:this
          -4 (-7.692% of base) : System.Windows.Extensions.dasm - ValueStringBuilder:GetPinnableReference():byref:this
         -32 (-6.780% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DocumentationCommentCompiler:VisitField(FieldSymbol):this (2 methods)
         -32 (-6.780% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DocumentationCommentCompiler:VisitProperty(PropertySymbol):this (2 methods)
         -32 (-6.780% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DocumentationCommentCompiler:VisitEvent(EventSymbol):this (2 methods)
          -4 (-6.667% of base) : System.Security.Cryptography.Pkcs.dasm - KeyAgreeRecipientInfoPalWindows:<get_EncryptedKey>b__8_0(long):ref:this
          -8 (-6.452% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - MapKey:Equals(MapKey):bool:this
         -12 (-6.000% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:IndexOf(ref,ResourceLocator,int,int):int:this
         -12 (-6.000% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:IndexOf(ref,KeyValuePair`2,int,int):int:this
         -32 (-5.970% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - ClsComplianceChecker:DoNotVisit(Symbol):bool:this (2 methods)
84 total methods with Code Size differences (84 improved, 0 regressed), 185834 unchanged.
```
alt-win-arm32 diff:
```
Total bytes of diff: -4086 (-0.012% of base)
    diff is an improvement.
Top file improvements (bytes):
       -1998 : System.Private.CoreLib.dasm (-0.063% of base)
        -460 : Microsoft.CodeAnalysis.dasm (-0.034% of base)
        -212 : Microsoft.CSharp.dasm (-0.070% of base)
        -168 : System.Data.Common.dasm (-0.015% of base)
        -166 : System.Security.Cryptography.Pkcs.dasm (-0.060% of base)
        -140 : System.Net.Http.dasm (-0.025% of base)
        -134 : Newtonsoft.Json.dasm (-0.022% of base)
        -116 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.003% of base)
        -108 : System.Text.Json.dasm (-0.040% of base)
         -92 : System.Reflection.Metadata.dasm (-0.030% of base)
         -58 : System.Collections.Immutable.dasm (-0.019% of base)
         -48 : System.Private.DataContractSerialization.dasm (-0.007% of base)
         -46 : System.Net.HttpListener.dasm (-0.023% of base)
         -44 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.001% of base)
         -40 : Microsoft.CodeAnalysis.CSharp.dasm (-0.001% of base)
         -40 : System.Runtime.Caching.dasm (-0.073% of base)
         -36 : System.Diagnostics.PerformanceCounter.dasm (-0.049% of base)
         -28 : System.Linq.Parallel.dasm (-0.005% of base)
         -22 : Microsoft.Extensions.Configuration.Json.dasm (-0.499% of base)
         -22 : System.Collections.dasm (-0.017% of base)
32 total files with Code Size differences (32 improved, 0 regressed), 230 unchanged.
Top method regressions (bytes):
           4 (0.051% of base) : System.Private.CoreLib.dasm - Enumerator:MoveNext():bool:this (110 methods)
Top method improvements (bytes):
        -722 (-35.672% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:IndexOf(ref,ValueTuple`8,int,int):int:this (7 methods)
        -722 (-35.427% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:LastIndexOf(ref,ValueTuple`8,int,int):int:this (7 methods)
        -140 (-11.094% of base) : System.Security.Cryptography.Pkcs.dasm - Rfc3161TimestampToken:TryGetCertIds(SignerInfo,byref,byref):bool
        -132 (-6.256% of base) : System.Net.Http.dasm - <ProcessIncomingFramesAsync>d__35:MoveNext():this
         -92 (-18.699% of base) : Microsoft.CodeAnalysis.dasm - MethodSpecComparer:Equals(IGenericMethodInstanceReference,IGenericMethodInstanceReference):bool:this (2 methods)
         -88 (-1.993% of base) : System.Text.Json.dasm - JsonSerializer:ReadValueCore(JsonSerializerOptions,byref,byref):__Canon (2 methods)
         -76 (-8.407% of base) : Microsoft.CodeAnalysis.dasm - PdbMetadataWrapper:Microsoft.Cci.IMetaDataImport.GetTypeDefProps(int,int,int,byref,int):int:this (2 methods)
         -52 (-18.571% of base) : Microsoft.CodeAnalysis.dasm - PdbMetadataWrapper:Microsoft.Cci.IMetaDataImport.GetNestedClassProps(int):int:this (2 methods)
         -48 (-9.917% of base) : Microsoft.CodeAnalysis.dasm - PdbMetadataWrapper:Microsoft.Cci.IMetaDataImport.GetMethodProps(int,byref,int,int,byref,int,int,int,int):int:this (2 methods)
         -48 (-5.000% of base) : Microsoft.CodeAnalysis.dasm - PdbWriter:SerializeVisualBasicImportTypeReference(ITypeReference):String:this (2 methods)
         -48 (-4.545% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - ProviderManifest:ComputeFieldInfo(XmlReader,Dictionary`2):TemplateInfo
         -44 (-13.750% of base) : Microsoft.CodeAnalysis.dasm - SyntaxDiffer:Combine(Stack`1,Stack`1):Stack`1 (2 methods)
         -44 (-1.237% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - OverloadResolution:CollectOverloadedCandidates(Binder,ArrayBuilder`1,ArrayBuilder`1,ImmutableArray`1,ImmutableArray`1,ImmutableArray`1,TypeSymbol,BoundNode,bool,bool,bool,byref,byref) (2 methods)
         -44 (-22.222% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:IndexOf(ref,ValueTuple`7,int,int):int:this
         -44 (-22.000% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:LastIndexOf(ref,ValueTuple`7,int,int):int:this
         -40 (-2.195% of base) : Microsoft.CodeAnalysis.CSharp.dasm - PEMethodSymbol:LoadSignature():SignatureData:this (2 methods)
         -40 (-1.329% of base) : System.Data.Common.dasm - SqlDoubleStorage:Aggregate(ref,int):Object:this
         -40 (-2.283% of base) : System.Private.DataContractSerialization.dasm - XmlDictionaryWriter:WriteArray(String,String,String,ref,int,int):this (10 methods)
         -38 (-10.674% of base) : Microsoft.CSharp.dasm - RuntimeBinder:BindAssignment(ICSharpBinder,ref,ref):Expr:this
         -38 (-1.054% of base) : System.Net.HttpListener.dasm - <Process>d__19:MoveNext():this
Top method regressions (percentages):
           4 (0.051% of base) : System.Private.CoreLib.dasm - Enumerator:MoveNext():bool:this (110 methods)
Top method improvements (percentages):
        -722 (-35.672% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:IndexOf(ref,ValueTuple`8,int,int):int:this (7 methods)
        -722 (-35.427% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:LastIndexOf(ref,ValueTuple`8,int,int):int:this (7 methods)
         -26 (-23.636% of base) : System.Reflection.Metadata.dasm - MetadataBuilder:AddParameter(int,int,int):int:this
         -26 (-22.807% of base) : System.Reflection.Metadata.dasm - MetadataBuilder:AddLocalVariable(int,int,int):int:this
         -44 (-22.222% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:IndexOf(ref,ValueTuple`7,int,int):int:this
         -44 (-22.000% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:LastIndexOf(ref,ValueTuple`7,int,int):int:this
         -38 (-20.430% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:IndexOf(ref,ValueTuple`6,int,int):int:this
         -38 (-20.213% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:LastIndexOf(ref,ValueTuple`6,int,int):int:this
         -28 (-20.000% of base) : System.Reflection.Metadata.dasm - MetadataBuilder:AddGenericParameter(int,int,int,int):int:this
         -34 (-19.540% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:IndexOf(ref,ValueTuple`5,int,int):int:this
         -34 (-19.318% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:LastIndexOf(ref,ValueTuple`5,int,int):int:this
         -12 (-18.750% of base) : System.Security.Cryptography.Pkcs.dasm - <>c:<get_KeyEncryptionAlgorithm>b__6_0(int):AlgorithmIdentifier:this (2 methods)
         -92 (-18.699% of base) : Microsoft.CodeAnalysis.dasm - MethodSpecComparer:Equals(IGenericMethodInstanceReference,IGenericMethodInstanceReference):bool:this (2 methods)
         -52 (-18.571% of base) : Microsoft.CodeAnalysis.dasm - PdbMetadataWrapper:Microsoft.Cci.IMetaDataImport.GetNestedClassProps(int):int:this (2 methods)
         -16 (-18.182% of base) : System.Data.Common.dasm - SqlDouble:NotEquals(SqlDouble,SqlDouble):SqlBoolean
         -32 (-17.204% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:IndexOf(ref,GCGenerationInfo,int,int):int:this
         -32 (-17.021% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:LastIndexOf(ref,GCGenerationInfo,int,int):int:this
          -6 (-15.789% of base) : System.Security.Cryptography.Algorithms.dasm - AlgorithmIdentifierAsn:HasNullEquivalentParameters():bool:this
          -6 (-15.789% of base) : System.Security.Cryptography.Cng.dasm - AlgorithmIdentifierAsn:HasNullEquivalentParameters():bool:this
          -6 (-15.789% of base) : System.Security.Cryptography.Pkcs.dasm - AlgorithmIdentifierAsn:HasNullEquivalentParameters():bool:this
131 total methods with Code Size differences (130 improved, 1 regressed), 185798 unchanged.
```