### PR TITLE
Improve passing of x86 stack args

### DIFF
--- a/src/coreclr/src/jit/emitxarch.h
+++ b/src/coreclr/src/jit/emitxarch.h
@@ -315,6 +315,8 @@ void emitIns_ARX(instruction ins, emitAttr attr, regNumber base, regNumber index
 
 void emitIns_AR_R_R(instruction ins, emitAttr attr, regNumber op2Reg, regNumber op3Reg, regNumber base, int offs);
 
+void emitIns_A(instruction ins, emitAttr attr, GenTreeIndir* indir);
+
 void emitIns_R_A(instruction ins, emitAttr attr, regNumber reg1, GenTreeIndir* indir);
 
 void emitIns_R_A_I(instruction ins, emitAttr attr, regNumber reg1, GenTreeIndir* indir, int ival);

--- a/src/coreclr/src/jit/lowerxarch.cpp
+++ b/src/coreclr/src/jit/lowerxarch.cpp
@@ -653,6 +653,14 @@ void Lowering::LowerPutArgStk(GenTreePutArgStk* putArgStk)
         src->SetContained();
     }
 #if defined(TARGET_X86)
+    else if (src->IsDblCon() && src->TypeIs(TYP_FLOAT))
+    {
+        float value = static_cast<float>(src->AsDblCon()->GetValue());
+        src->ChangeOperConst(GT_CNS_INT);
+        src->SetType(TYP_INT);
+        src->AsIntCon()->SetValue(jitstd::bit_cast<int>(value));
+        src->SetContained();
+    }
     else
     {
         unsigned srcSize = varTypeSize(src->GetType());

--- a/src/coreclr/src/jit/lowerxarch.cpp
+++ b/src/coreclr/src/jit/lowerxarch.cpp
@@ -650,8 +650,37 @@ void Lowering::LowerPutArgStk(GenTreePutArgStk* putArgStk)
 #endif // TARGET_AMD64
             )
     {
-        MakeSrcContained(putArgStk, src);
+        src->SetContained();
     }
+#if defined(TARGET_X86)
+    else
+    {
+        unsigned srcSize = varTypeSize(src->GetType());
+
+        // For containment we need a slot sized memory operand - INT, FLOAT, REF, BYREF. Yes, it can be FLOAT
+        // because it's a memory operation and the type doesn't really matter, only the size does.
+        //
+        // For reg optional things are a bit more complicated:
+        //    - anything other than LCL_VAR can be reg-optional even if it's a small int type because the
+        //      spilled value is really INT (e.g. ushort IND automatically zero extends to INT and the
+        //      resulting value is spilled to an INT spill temp).
+        //    - LCL_VAR must be slot sized because we don't know yet if the local will be a reg candidate.
+        //      If it's not a reg candidate then it is treated as contained thus the size restriction.
+        //      Note that the local itself may have small int type but if we get a LCL_VAR here then it
+        //      means that it is "normalize on store" or that the frontend elided the normalization cast.
+        //      Most LCL_VARs that reference small int local end up having type INT, with the notable
+        //      exception of promoted struct field which may have small int type.
+
+        if ((srcSize == REGSIZE_BYTES) && IsContainableMemoryOp(src) && IsSafeToContainMem(putArgStk, src))
+        {
+            src->SetContained();
+        }
+        else if (src->OperIs(GT_LCL_VAR) ? (srcSize == REGSIZE_BYTES) : (srcSize <= REGSIZE_BYTES))
+        {
+            src->SetRegOptional();
+        }
+    }
+#endif
 }
 
 #ifdef FEATURE_SIMD

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -6234,6 +6234,11 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
     {
         if (tree->gtFlags & GTF_IND_TLS_REF)
         {
+            // TODO-MIKE-Cleanup: It looks like all this code should be ifdef-ed out on all targets but win-x86.
+            // There's no way it would work on win-x64 because the TLS array's TEB offset isn't 0x2c like on x86.
+            // The name and description of GTF_ICON_TLS_HDL is also messed up, it has nothing to do with TLS,
+            // it just indicates that the constant is an offset in the TEB.
+
             // Thread Local Storage static field reference
             //
             // Field ref is a TLS 'Thread-Local-Storage' reference


### PR DESCRIPTION
x86-diff:
```
Total bytes of diff: -119522 (-0.466% of base)
    diff is an improvement.
Top file improvements (bytes):
      -12180 : System.Private.CoreLib.dasm (-0.446% of base)
      -11544 : System.Linq.Expressions.dasm (-0.508% of base)
      -11463 : System.Private.Xml.dasm (-0.469% of base)
      -11395 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.645% of base)
      -10136 : Microsoft.CodeAnalysis.CSharp.dasm (-0.639% of base)
       -6460 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.251% of base)
       -6193 : System.Drawing.Common.dasm (-2.524% of base)
       -4189 : System.Data.Common.dasm (-0.467% of base)
       -3971 : System.Private.DataContractSerialization.dasm (-0.700% of base)
       -2460 : System.Net.Http.dasm (-0.510% of base)
       -2174 : Microsoft.CodeAnalysis.dasm (-0.374% of base)
       -2164 : Newtonsoft.Json.dasm (-0.454% of base)
       -1663 : Microsoft.VisualBasic.Core.dasm (-0.452% of base)
       -1457 : System.DirectoryServices.dasm (-0.487% of base)
       -1278 : System.Net.Sockets.dasm (-0.885% of base)
       -1219 : System.Management.dasm (-0.459% of base)
       -1124 : System.Text.Json.dasm (-0.481% of base)
       -1048 : System.DirectoryServices.AccountManagement.dasm (-0.555% of base)
        -972 : System.Net.Security.dasm (-0.583% of base)
        -922 : System.Net.HttpListener.dasm (-0.568% of base)
178 total files with Code Size differences (178 improved, 0 regressed), 84 unchanged.
Top method regressions (bytes):
          63 (3.748% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - CodeGenerator:EmitCatchBlock(BoundCatchBlock):this
          59 (4.266% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceFile:BindOptions(SyntaxList`1,Binder,DiagnosticBag,byref,byref,byref,byref,Nullable`1)
          45 (1.585% of base) : System.Private.Xml.dasm - TempAssembly:GenerateSerializerToStream(ref,ref,String,Assembly,Hashtable,Stream):bool
          29 (4.448% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindBlock(VisualBasicSyntaxNode,SyntaxList`1,DiagnosticBag,Binder):BoundBlock:this
          25 (0.274% of base) : System.Private.CoreLib.dasm - DefaultBinder:BindToMethod(int,ref,byref,ref,CultureInfo,ref,byref):MethodBase:this
          24 (0.738% of base) : System.Private.CoreLib.dasm - EventProvider:WriteEvent(byref,int,int,int,ref):bool:this
          20 (5.450% of base) : System.Composition.Convention.dasm - PartConventionBuilder:ConfigureConstructorAttributes(ConstructorInfo,byref,Action`2)
          15 (2.863% of base) : System.Data.OleDb.dasm - PropertyInfoSet:GetValues():Dictionary`2:this
          14 (0.901% of base) : System.Private.CoreLib.dasm - Number:TryParseNumber(byref,int,int,byref,NumberFormatInfo):bool
          13 (0.878% of base) : System.Data.OleDb.dasm - OleDbMetaDataFactory:PrepareCollection(String,ref,DbConnection):DataTable:this
          13 (0.937% of base) : System.Threading.Channels.dasm - AsyncOperation`1:OnCompleted(Action`1,Object,short,int):this (3 methods)
          12 (1.115% of base) : System.Linq.Parallel.dasm - GroupJoinQueryOperator`4:WrapPartitionedStreamHelper(PartitionedStream`2,PartitionedStream`2,IPartitionedStreamRecipient`1,int,CancellationToken):this (2 methods)
          12 (1.275% of base) : System.Private.Xml.dasm - XmlReflectionImporter:ImportMembersMapping(ref,String,bool,bool,bool,RecursionLimiter):MembersMapping:this
          11 (2.511% of base) : System.DirectoryServices.dasm - ActiveDirectorySiteLinkCollection:Remove(ActiveDirectorySiteLink):this
          11 (1.368% of base) : xunit.execution.dotnet.dasm - SerializationHelper:GetType(String):Type
          11 (1.368% of base) : xunit.runner.utility.netcoreapp10.dasm - SerializationHelper:GetType(String):Type
          10 (1.799% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindBinaryOperator(BinaryExpressionSyntax,bool,DiagnosticBag):BoundExpression:this
          10 (2.049% of base) : System.ComponentModel.Annotations.dasm - TypeDescriptorCache:CheckAssociatedMetadataType(Type,Type)
           9 (2.153% of base) : System.Data.Odbc.dasm - DbConnectionOptions:ReplacePasswordPwd(byref,bool):NameValuePair:this
           9 (2.153% of base) : System.Data.OleDb.dasm - DbConnectionOptions:ReplacePasswordPwd(byref,bool):NameValuePair:this
Top method improvements (bytes):
       -5307 (-0.526% of base) : System.Linq.Expressions.dasm - FuncCallInstruction`3:Run(InterpretedFrame):int:this (3375 methods)
       -3375 (-1.639% of base) : System.Linq.Expressions.dasm - FuncCallInstruction`3:ToString():String:this (3375 methods)
       -1349 (-2.557% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - ApplicationServerTraceEventParser:EnumerateTemplates(Func`3,Action`1):this
        -413 (-2.780% of base) : System.Data.Common.dasm - BinaryNode:EvalBinaryOp(int,ExpressionNode,ExpressionNode,DataRow,int,ref):Object:this
        -377 (-1.137% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - KernelTraceEventParser:EnumerateTemplates(Func`3,Action`1):this
        -329 (-0.563% of base) : System.Linq.Expressions.dasm - ActionCallInstruction`2:Run(InterpretedFrame):int:this (225 methods)
        -274 (-3.983% of base) : System.ComponentModel.TypeConverter.dasm - CultureInfoMapper:CreateMap():Dictionary`2
        -255 (-3.667% of base) : System.Private.CoreLib.dasm - CultureData:get_RegionNames():Dictionary`2
        -240 (-2.001% of base) : System.Text.Json.dasm - JsonConverter`1:TryRead(byref,Type,JsonSerializerOptions,byref,byref):bool:this (20 methods)
        -225 (-1.639% of base) : System.Linq.Expressions.dasm - ActionCallInstruction`2:ToString():String:this (225 methods)
        -225 (-1.639% of base) : System.Linq.Expressions.dasm - FuncCallInstruction`2:ToString():String:this (225 methods)
        -210 (-2.610% of base) : System.DirectoryServices.AccountManagement.dasm - ADAMStoreCtx:.cctor()
        -177 (-0.660% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - ClrPrivateTraceEventParser:EnumerateTemplates(Func`3,Action`1):this
        -165 (-2.106% of base) : System.DirectoryServices.AccountManagement.dasm - ADStoreCtx:.cctor()
        -154 (-0.326% of base) : System.Linq.Expressions.dasm - FuncCallInstruction`2:Run(InterpretedFrame):int:this (225 methods)
        -141 (-2.207% of base) : System.Private.DataContractSerialization.dasm - ArrayHelper`2:ReadArray(XmlDictionaryReader,__Canon,__Canon,int):ref:this (12 methods)
        -136 (-4.824% of base) : System.Private.DataContractSerialization.dasm - DataNode`1:GetData(ElementData):this (17 methods)
        -134 (-0.796% of base) : Microsoft.CodeAnalysis.dasm - AttributeDescription:.cctor()
        -127 (-1.026% of base) : System.Private.CoreLib.dasm - ValueTuple`8:ToString():String:this (17 methods)
        -127 (-1.056% of base) : System.Private.CoreLib.dasm - ValueTuple`8:System.IValueTupleInternal.ToStringEnd():String:this (17 methods)
Top method regressions (percentages):
          20 (5.450% of base) : System.Composition.Convention.dasm - PartConventionBuilder:ConfigureConstructorAttributes(ConstructorInfo,byref,Action`2)
           8 (4.598% of base) : System.Private.Xml.dasm - ContainerAction:CompileSpace(Compiler,bool):this
          29 (4.448% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindBlock(VisualBasicSyntaxNode,SyntaxList`1,DiagnosticBag,Binder):BoundBlock:this
          59 (4.266% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceFile:BindOptions(SyntaxList`1,Binder,DiagnosticBag,byref,byref,byref,byref,Nullable`1)
          63 (3.748% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - CodeGenerator:EmitCatchBlock(BoundCatchBlock):this
           6 (3.488% of base) : System.Private.Xml.dasm - XmlNamedNodeMap:InsertNodeAt(int,XmlNode):XmlNode:this
           6 (3.429% of base) : System.Collections.Concurrent.dasm - ConcurrentDictionary`2:CopyToEntries(ref,int):this
           5 (3.205% of base) : System.Net.Mail.dasm - BufferedReadStream:Read(ref,int,int):int:this
          15 (2.863% of base) : System.Data.OleDb.dasm - PropertyInfoSet:GetValues():Dictionary`2:this
           7 (2.632% of base) : System.Private.CoreLib.dasm - RuntimeType:GetEventCandidates(String,int,bool):ListBuilder`1:this
           7 (2.632% of base) : System.Private.CoreLib.dasm - RuntimeType:GetFieldCandidates(String,int,bool):ListBuilder`1:this
          11 (2.511% of base) : System.DirectoryServices.dasm - ActiveDirectorySiteLinkCollection:Remove(ActiveDirectorySiteLink):this
           8 (2.254% of base) : System.Text.RegularExpressions.dasm - Regex:Run(bool,int,String,int,int,int):Match:this
           9 (2.169% of base) : System.Private.Xml.dasm - XmlSchemaValidator:ElementIdentityConstraints():this
           9 (2.153% of base) : System.Data.Odbc.dasm - DbConnectionOptions:ReplacePasswordPwd(byref,bool):NameValuePair:this
           9 (2.153% of base) : System.Data.OleDb.dasm - DbConnectionOptions:ReplacePasswordPwd(byref,bool):NameValuePair:this
           8 (2.128% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:MakeCollectionInitializer(BoundExpression,BoundCollectionElementInitializer):BoundExpression:this
          10 (2.049% of base) : System.ComponentModel.Annotations.dasm - TypeDescriptorCache:CheckAssociatedMetadataType(Type,Type)
          10 (1.799% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindBinaryOperator(BinaryExpressionSyntax,bool,DiagnosticBag):BoundExpression:this
           7 (1.716% of base) : System.DirectoryServices.dasm - ActiveDirectorySiteCollection:Remove(ActiveDirectorySite):this
Top method improvements (percentages):
         -21 (-53.846% of base) : System.Drawing.Common.dasm - LinearGradientBrush:SetSigmaBellShape(float):this
         -21 (-53.846% of base) : System.Drawing.Common.dasm - LinearGradientBrush:SetBlendTriangularShape(float):this
         -21 (-53.846% of base) : System.Drawing.Common.dasm - PathGradientBrush:SetSigmaBellShape(float):this
         -21 (-53.846% of base) : System.Drawing.Common.dasm - PathGradientBrush:SetBlendTriangularShape(float):this
         -20 (-51.282% of base) : System.Drawing.Common.dasm - Graphics:TranslateTransform(float,float):this
         -20 (-51.282% of base) : System.Drawing.Common.dasm - Graphics:ScaleTransform(float,float):this
         -20 (-51.282% of base) : System.Drawing.Common.dasm - Pen:TranslateTransform(float,float):this
         -20 (-51.282% of base) : System.Drawing.Common.dasm - Pen:ScaleTransform(float,float):this
         -20 (-51.282% of base) : System.Drawing.Common.dasm - TextureBrush:TranslateTransform(float,float):this
         -20 (-51.282% of base) : System.Drawing.Common.dasm - TextureBrush:ScaleTransform(float,float):this
         -20 (-51.282% of base) : System.Drawing.Common.dasm - LinearGradientBrush:TranslateTransform(float,float):this
         -20 (-51.282% of base) : System.Drawing.Common.dasm - LinearGradientBrush:ScaleTransform(float,float):this
         -20 (-51.282% of base) : System.Drawing.Common.dasm - Matrix:Translate(float,float):this
         -20 (-51.282% of base) : System.Drawing.Common.dasm - Matrix:Scale(float,float):this
         -20 (-51.282% of base) : System.Drawing.Common.dasm - PathGradientBrush:TranslateTransform(float,float):this
         -20 (-51.282% of base) : System.Drawing.Common.dasm - PathGradientBrush:ScaleTransform(float,float):this
         -20 (-50.000% of base) : System.Private.CoreLib.dasm - ComparisonComparer`1:Compare(float,float):int:this
        -125 (-49.801% of base) : System.Private.CoreLib.dasm - Matrix4x4:.cctor()
         -11 (-47.826% of base) : System.Collections.NonGeneric.dasm - Queue:.ctor(int):this
         -11 (-47.826% of base) : System.Drawing.Common.dasm - Pen:.ctor(Brush):this
33719 total methods with Code Size differences (33651 improved, 68 regressed), 152645 unchanged.
```

Regressions caused by changes in register allocation, such as a variable that's live accross one or more calls ending up in `edx` instead of `edi` and having to be spilled and reloaded.