### PR TITLE
Improve Vector3 load/store codegen

### DIFF
--- a/src/coreclr/src/jit/codegen.h
+++ b/src/coreclr/src/jit/codegen.h
@@ -1018,15 +1018,8 @@ protected:
     void genSIMDIntrinsicWiden(GenTreeSIMD* simdNode);
     void genSIMDIntrinsic(GenTreeSIMD* simdNode);
 
-    // TYP_SIMD12 (i.e Vector3 of size 12 bytes) is not a hardware supported size and requires
-    // two reads/writes on 64-bit targets. These routines abstract reading/writing of Vector3
-    // values through an indirection. Note that Vector3 locals allocated on stack would have
-    // their size rounded to TARGET_POINTER_SIZE (which is 8 bytes on 64-bit targets) and hence
-    // Vector3 locals could be treated as TYP_SIMD16 while reading/writing.
-    void genStoreIndTypeSIMD12(GenTreeStoreInd* store);
-    void genLoadIndTypeSIMD12(GenTreeIndir* load);
-    void genStoreLclTypeSIMD12(GenTreeLclVarCommon* store);
-    void genLoadLclTypeSIMD12(GenTreeLclVarCommon* load);
+    void genStoreSIMD12(GenTree* store, GenTree* value);
+    void genLoadSIMD12(GenTree* load);
 #ifdef TARGET_X86
     void genStoreSIMD12ToStack(regNumber operandReg, regNumber tmpReg);
 #endif // TARGET_X86
@@ -1448,6 +1441,59 @@ public:
     void inst_mov_RV_ST(regNumber reg, GenTree* tree);
 
     void inst_set_SV_var(GenTree* tree);
+
+    class GenAddrMode
+    {
+        regNumber m_base;
+        regNumber m_index;
+        unsigned  m_scale;
+        int       m_disp;
+        unsigned  m_lclNum;
+
+    public:
+        GenAddrMode(GenTree* tree, CodeGen* codeGen);
+
+        regNumber Base() const
+        {
+            return m_base;
+        }
+
+        regNumber Index() const
+        {
+            return m_index;
+        }
+
+        int Scale() const
+        {
+            return m_scale;
+        }
+
+        int Disp() const
+        {
+            return m_disp;
+        }
+
+        int Disp(unsigned offset) const
+        {
+            assert(offset <= INT32_MAX);
+            assert(m_disp <= INT32_MAX - static_cast<int>(offset));
+
+            return m_disp + offset;
+        }
+
+        bool IsLcl() const
+        {
+            return m_lclNum != BAD_VAR_NUM;
+        }
+
+        unsigned LclNum() const
+        {
+            return m_lclNum;
+        }
+    };
+
+    void inst_R_AM(instruction ins, emitAttr size, regNumber reg, const GenAddrMode& addrMode, unsigned offset = 0);
+    void inst_AM_R(instruction ins, emitAttr size, regNumber reg, const GenAddrMode& addrMode, unsigned offset = 0);
 
 #ifdef TARGET_ARM
     bool arm_Valid_Imm_For_Instr(instruction ins, target_ssize_t imm, insFlags flags);

--- a/src/coreclr/src/jit/codegen.h
+++ b/src/coreclr/src/jit/codegen.h
@@ -1023,10 +1023,10 @@ protected:
     // values through an indirection. Note that Vector3 locals allocated on stack would have
     // their size rounded to TARGET_POINTER_SIZE (which is 8 bytes on 64-bit targets) and hence
     // Vector3 locals could be treated as TYP_SIMD16 while reading/writing.
-    void genStoreIndTypeSIMD12(GenTree* treeNode);
-    void genLoadIndTypeSIMD12(GenTree* treeNode);
-    void genStoreLclTypeSIMD12(GenTree* treeNode);
-    void genLoadLclTypeSIMD12(GenTree* treeNode);
+    void genStoreIndTypeSIMD12(GenTreeStoreInd* store);
+    void genLoadIndTypeSIMD12(GenTreeIndir* load);
+    void genStoreLclTypeSIMD12(GenTreeLclVarCommon* store);
+    void genLoadLclTypeSIMD12(GenTreeLclVarCommon* load);
 #ifdef TARGET_X86
     void genStoreSIMD12ToStack(regNumber operandReg, regNumber tmpReg);
 #endif // TARGET_X86

--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -3188,10 +3188,13 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
             genConsumeRegs(data);
         }
 
+        var_types type = tree->GetType();
         regNumber dataReg;
-        if (data->isContained() && data->OperIs(GT_CNS_INT, GT_CNS_DBL))
+
+        if (data->isContained() && data->OperIs(GT_CNS_INT, GT_CNS_DBL, GT_HWINTRINSIC))
         {
-            assert(data->IsIntegralConst(0) || data->IsDblConPositiveZero());
+            assert(data->IsIntegralConst(0) || data->IsDblConPositiveZero() || data->IsHWIntrinsicZero());
+            assert(varTypeSize(type) <= REGSIZE_BYTES);
             dataReg = REG_ZR;
         }
         else // data is not contained, so evaluate it into a register
@@ -3200,8 +3203,7 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
             dataReg = data->GetRegNum();
         }
 
-        var_types   type = tree->TypeGet();
-        instruction ins  = ins_Store(type);
+        instruction ins = ins_Store(type);
 
         if (tree->IsVolatile())
         {

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -1560,6 +1560,14 @@ void CodeGen::genCodeForLclFld(GenTreeLclFld* tree)
 {
     assert(tree->OperIs(GT_LCL_FLD));
 
+#ifdef FEATURE_SIMD
+    if (tree->TypeIs(TYP_SIMD12))
+    {
+        genLoadLclTypeSIMD12(tree);
+        return;
+    }
+#endif
+
     var_types targetType = tree->TypeGet();
     regNumber targetReg  = tree->GetRegNum();
     emitter*  emit       = GetEmitter();

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -4312,7 +4312,7 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
                 noway_assert(regArgTab[nextArgNum].varNum == varNum);
                 // Emit a shufpd with a 0 immediate, which preserves the 0th element of the dest reg
                 // and moves the 0th element of the src reg into the 1st element of the dest reg.
-                GetEmitter()->emitIns_R_R_I(INS_shufpd, emitActualTypeSize(varDsc->lvType), destRegNum, nextRegNum, 0);
+                GetEmitter()->emitIns_R_R(INS_movlhps, EA_16BYTE, destRegNum, nextRegNum);
                 // Set destRegNum to regNum so that we skip the setting of the register below,
                 // but mark argNum as processed and clear regNum from the live mask.
                 destRegNum = regNum;

--- a/src/coreclr/src/jit/codegenlinear.cpp
+++ b/src/coreclr/src/jit/codegenlinear.cpp
@@ -1578,7 +1578,7 @@ void CodeGen::genConsumeRegs(GenTree* tree)
 #ifdef FEATURE_SIMD
             // (In)Equality operation that produces bool result, when compared
             // against Vector zero, marks its Vector Zero operand as contained.
-            assert(tree->OperIsLeaf() || tree->IsSIMDZero());
+            assert(tree->OperIsLeaf() || tree->IsSIMDZero() || tree->IsHWIntrinsicZero());
 #else
             assert(tree->OperIsLeaf());
 #endif

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -1432,7 +1432,7 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
     if (treeNode->IsReuseRegVal())
     {
         // For now, this is only used for constant nodes.
-        assert((treeNode->OperIsConst()));
+        assert(treeNode->OperIsConst() || treeNode->IsHWIntrinsicZero());
         JITDUMP("  TreeNode is marked ReuseReg\n");
         return;
     }

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -3994,19 +3994,18 @@ void CodeGen::genCodeForLclFld(GenTreeLclFld* tree)
 {
     assert(tree->OperIs(GT_LCL_FLD));
 
-    var_types targetType = tree->TypeGet();
-    regNumber targetReg  = tree->GetRegNum();
-
-    noway_assert(targetReg != REG_NA);
-
 #ifdef FEATURE_SIMD
-    // Loading of TYP_SIMD12 (i.e. Vector3) field
-    if (targetType == TYP_SIMD12)
+    if (tree->TypeIs(TYP_SIMD12))
     {
         genLoadLclTypeSIMD12(tree);
         return;
     }
 #endif
+
+    var_types targetType = tree->TypeGet();
+    regNumber targetReg  = tree->GetRegNum();
+
+    noway_assert(targetReg != REG_NA);
 
     noway_assert(targetType != TYP_STRUCT);
 
@@ -4042,13 +4041,12 @@ void CodeGen::genCodeForLclVar(GenTreeLclVar* tree)
     if (!isRegCandidate && !tree->IsMultiReg() && !(tree->gtFlags & GTF_SPILLED))
     {
 #if defined(FEATURE_SIMD) && defined(TARGET_X86)
-        // Loading of TYP_SIMD12 (i.e. Vector3) variable
-        if (tree->TypeGet() == TYP_SIMD12)
+        if (tree->TypeIs(TYP_SIMD12))
         {
             genLoadLclTypeSIMD12(tree);
             return;
         }
-#endif // defined(FEATURE_SIMD) && defined(TARGET_X86)
+#endif
 
         var_types type = varDsc->GetRegisterType(tree);
         GetEmitter()->emitIns_R_S(ins_Load(type, compiler->isSIMDTypeLocalAligned(tree->GetLclNum())),
@@ -4067,19 +4065,18 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
 {
     assert(tree->OperIs(GT_STORE_LCL_FLD));
 
-    var_types targetType = tree->TypeGet();
-    GenTree*  op1        = tree->gtGetOp1();
-
-    noway_assert(targetType != TYP_STRUCT);
-
 #ifdef FEATURE_SIMD
-    // storing of TYP_SIMD12 (i.e. Vector3) field
-    if (tree->TypeGet() == TYP_SIMD12)
+    if (tree->TypeIs(TYP_SIMD12))
     {
         genStoreLclTypeSIMD12(tree);
         return;
     }
-#endif // FEATURE_SIMD
+#endif
+
+    var_types targetType = tree->TypeGet();
+    GenTree*  op1        = tree->gtGetOp1();
+
+    noway_assert(targetType != TYP_STRUCT);
 
     assert(varTypeUsesFloatReg(targetType) == varTypeUsesFloatReg(op1));
     assert(genTypeSize(genActualType(targetType)) == genTypeSize(genActualType(op1->TypeGet())));
@@ -4318,13 +4315,12 @@ void CodeGen::genCodeForIndir(GenTreeIndir* tree)
     assert(tree->OperIs(GT_IND));
 
 #ifdef FEATURE_SIMD
-    // Handling of Vector3 type values loaded through indirection.
-    if (tree->TypeGet() == TYP_SIMD12)
+    if (tree->TypeIs(TYP_SIMD12))
     {
         genLoadIndTypeSIMD12(tree);
         return;
     }
-#endif // FEATURE_SIMD
+#endif
 
     var_types targetType = tree->TypeGet();
     emitter*  emit       = GetEmitter();
@@ -4356,13 +4352,12 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
     assert(tree->OperIs(GT_STOREIND));
 
 #ifdef FEATURE_SIMD
-    // Storing Vector3 of size 12 bytes through indirection
-    if (tree->TypeGet() == TYP_SIMD12)
+    if (tree->TypeIs(TYP_SIMD12))
     {
         genStoreIndTypeSIMD12(tree);
         return;
     }
-#endif // FEATURE_SIMD
+#endif
 
     GenTree*  data       = tree->Data();
     GenTree*  addr       = tree->Addr();

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -17461,9 +17461,9 @@ bool GenTree::isContainableHWIntrinsic() const
 {
     assert(gtOper == GT_HWINTRINSIC);
 
-#ifdef TARGET_XARCH
     switch (AsHWIntrinsic()->gtHWIntrinsicId)
     {
+#ifdef TARGET_XARCH
         case NI_SSE_LoadAlignedVector128:
         case NI_SSE_LoadScalarVector128:
         case NI_SSE_LoadVector128:
@@ -17474,18 +17474,17 @@ bool GenTree::isContainableHWIntrinsic() const
         case NI_AVX_LoadVector256:
         case NI_AVX_ExtractVector128:
         case NI_AVX2_ExtractVector128:
-        {
+        case NI_Vector256_get_Zero:
+#endif
+#ifdef TARGET_ARM64
+        case NI_Vector64_get_Zero:
+#endif
+        case NI_Vector128_get_Zero:
             return true;
-        }
 
         default:
-        {
             return false;
-        }
     }
-#else
-    return false;
-#endif // TARGET_XARCH
 }
 
 bool GenTree::isRMWHWIntrinsic(Compiler* comp)

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -10177,11 +10177,11 @@ void Compiler::gtDispTree(GenTree*     tree,
 
 #ifdef FEATURE_HW_INTRINSICS
         case GT_HWINTRINSIC:
-            printf(" %s %s %u", HWIntrinsicInfo::lookupName(tree->AsHWIntrinsic()->gtHWIntrinsicId),
-                   tree->AsHWIntrinsic()->gtSIMDBaseType == TYP_UNKNOWN
+            printf(" %s %s %u", GetHWIntrinsicIdName(tree->AsHWIntrinsic()->GetIntrinsic()),
+                   tree->AsHWIntrinsic()->GetSIMDBaseType() == TYP_UNKNOWN
                        ? ""
-                       : varTypeName(tree->AsHWIntrinsic()->gtSIMDBaseType),
-                   tree->AsHWIntrinsic()->gtSIMDSize);
+                       : varTypeName(tree->AsHWIntrinsic()->GetSIMDBaseType()),
+                   tree->AsHWIntrinsic()->GetSIMDSize());
 
             gtDispCommonEndLine(tree);
 

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -1668,6 +1668,7 @@ public:
 
     bool IsDblConPositiveZero() const;
     bool IsSIMDZero() const;
+    bool IsHWIntrinsicZero() const;
     bool IsIntegralConst(ssize_t constVal);
     bool IsIntegralConstVector(ssize_t constVal);
 
@@ -7264,11 +7265,31 @@ inline bool GenTree::IsDblConPositiveZero() const
 inline bool GenTree::IsSIMDZero() const
 {
 #ifdef FEATURE_SIMD
-    return OperIs(GT_SIMD) && (AsSIMD()->gtSIMDIntrinsicID == SIMDIntrinsicInit) &&
-           (AsSIMD()->GetOp(0)->IsIntegralConst(0) || AsSIMD()->GetOp(0)->IsDblConPositiveZero());
-#else
-    return false;
+    if (OperIs(GT_SIMD))
+    {
+        return (AsSIMD()->gtSIMDIntrinsicID == SIMDIntrinsicInit) &&
+               (AsSIMD()->GetOp(0)->IsIntegralConst(0) || AsSIMD()->GetOp(0)->IsDblConPositiveZero());
+    }
 #endif
+    return false;
+}
+
+inline bool GenTree::IsHWIntrinsicZero() const
+{
+#ifdef FEATURE_HW_INTRINSICS
+    if (OperIs(GT_HWINTRINSIC))
+    {
+        NamedIntrinsic intrinsic = AsHWIntrinsic()->GetIntrinsic();
+        return (intrinsic == NI_Vector128_get_Zero)
+#if defined(TARGET_XARCH)
+               || (intrinsic == NI_Vector256_get_Zero)
+#elif defined(TARGET_ARM64)
+               || (intrinsic == NI_Vector64_get_Zero)
+#endif
+            ;
+    }
+#endif
+    return false;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -2120,23 +2120,26 @@ private:
 public:
     bool Precedes(GenTree* other);
 
+    bool IsReuseRegValCandidate() const
+    {
+        return OperIsConst() || IsHWIntrinsicZero();
+    }
+
     bool IsReuseRegVal() const
     {
         // This can be extended to non-constant nodes, but not to local or indir nodes.
-        if (OperIsConst() && ((gtFlags & GTF_REUSE_REG_VAL) != 0))
-        {
-            return true;
-        }
-        return false;
+        return ((gtFlags & GTF_REUSE_REG_VAL) != 0) && IsReuseRegValCandidate();
     }
+
     void SetReuseRegVal()
     {
-        assert(OperIsConst());
+        assert(IsReuseRegValCandidate());
         gtFlags |= GTF_REUSE_REG_VAL;
     }
+
     void ResetReuseRegVal()
     {
-        assert(OperIsConst());
+        assert(IsReuseRegValCandidate());
         gtFlags &= ~GTF_REUSE_REG_VAL;
     }
 

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -5803,6 +5803,11 @@ struct GenTreeAddrMode : public GenTreeOp
         return static_cast<int>(gtOffset);
     }
 
+    int GetOffset() const
+    {
+        return static_cast<int>(gtOffset);
+    }
+
     void SetOffset(int offset)
     {
         gtOffset = offset;

--- a/src/coreclr/src/jit/hwintrinsic.cpp
+++ b/src/coreclr/src/jit/hwintrinsic.cpp
@@ -1065,4 +1065,21 @@ GenTree* Compiler::impHWIntrinsic(NamedIntrinsic        intrinsic,
     return impSpecialIntrinsic(intrinsic, clsHnd, method, sig, baseType, retType, simdSize);
 }
 
+#ifdef DEBUG
+const char* GetHWIntrinsicIdName(NamedIntrinsic id)
+{
+    static const char* const names[] = {
+#if defined(TARGET_XARCH)
+#define HARDWARE_INTRINSIC(isa, name, ...) #isa "_" #name,
+#include "hwintrinsiclistxarch.h"
+#elif defined(TARGET_ARM64)
+#define HARDWARE_INTRINSIC(isa, name, ...) #isa "_" #name,
+#include "hwintrinsiclistarm64.h"
+#endif // !defined(TARGET_XARCH) && !defined(TARGET_ARM64)
+    };
+
+    return (id > NI_HW_INTRINSIC_START && id < NI_HW_INTRINSIC_END) ? names[id - NI_HW_INTRINSIC_START - 1] : "NI_???";
+}
+#endif
+
 #endif // FEATURE_HW_INTRINSICS

--- a/src/coreclr/src/jit/hwintrinsic.h
+++ b/src/coreclr/src/jit/hwintrinsic.h
@@ -780,6 +780,8 @@ private:
 
 #endif // TARGET_ARM64
 
+INDEBUG(const char* GetHWIntrinsicIdName(NamedIntrinsic id);)
+
 #endif // FEATURE_HW_INTRINSICS
 
 #endif // _HW_INTRINSIC_H_

--- a/src/coreclr/src/jit/lower.h
+++ b/src/coreclr/src/jit/lower.h
@@ -90,7 +90,7 @@ private:
     void ContainCheckStoreIndir(GenTreeIndir* indirNode);
     void ContainCheckMul(GenTreeOp* node);
     void ContainCheckShiftRotate(GenTreeOp* node);
-    void ContainCheckStoreLoc(GenTreeLclVarCommon* storeLoc) const;
+    void ContainCheckStoreLoc(GenTreeLclVarCommon* storeLoc);
     void ContainCheckCast(GenTreeCast* node);
     void ContainCheckCompare(GenTreeOp* node);
     void ContainCheckBinary(GenTreeOp* node);
@@ -101,6 +101,7 @@ private:
 #endif // TARGET_XARCH
 #ifdef FEATURE_SIMD
     void ContainCheckSIMD(GenTreeSIMD* simdNode);
+    bool ContainSIMD12MemToMemCopy(GenTree* store, GenTree* value);
 #endif // FEATURE_SIMD
 #ifdef FEATURE_HW_INTRINSICS
     void ContainCheckHWIntrinsicAddr(GenTreeHWIntrinsic* node, GenTree* addr);
@@ -138,7 +139,7 @@ private:
     void LowerCallStruct(GenTreeCall* call);
     void LowerStoreSingleRegCallStruct(GenTreeBlk* store);
 #if !defined(WINDOWS_AMD64_ABI)
-    GenTreeLclVar* SpillStructCallResult(GenTreeCall* call) const;
+    GenTreeLclVar* SpillStructCallResult(GenTreeCall* call);
 #endif // WINDOWS_AMD64_ABI
     GenTree* LowerDelegateInvoke(GenTreeCall* call);
     GenTree* LowerIndirectNonvirtCall(GenTreeCall* call);

--- a/src/coreclr/src/jit/lowerarmarch.cpp
+++ b/src/coreclr/src/jit/lowerarmarch.cpp
@@ -1223,10 +1223,10 @@ void Lowering::ContainCheckStoreIndir(GenTreeIndir* node)
 {
 #ifdef TARGET_ARM64
     GenTree* src = node->AsOp()->gtOp2;
-    // TODO-MIKE-CQ-ARM64: SIMD 0 is problematic to contain because for SIMD16 we need
+    // TODO-MIKE-CQ-ARM64: SIMD16 0 is problematic to contain because we need
     // stp xzr, xzr, [...] but emitInsLoadStoreOp does not support stp. Currently
     // STORE_BLK.struct<16> works better than STOREIND.simd16 because of this.
-    if (node->TypeIs(TYP_SIMD12))
+    if (node->TypeIs(TYP_SIMD8, TYP_SIMD12))
     {
         if (src->IsSIMDZero() || src->IsHWIntrinsicZero())
         {

--- a/src/coreclr/src/jit/lowerarmarch.cpp
+++ b/src/coreclr/src/jit/lowerarmarch.cpp
@@ -1226,7 +1226,14 @@ void Lowering::ContainCheckStoreIndir(GenTreeIndir* node)
     // TODO-MIKE-CQ-ARM64: SIMD 0 is problematic to contain because for SIMD16 we need
     // stp xzr, xzr, [...] but emitInsLoadStoreOp does not support stp. Currently
     // STORE_BLK.struct<16> works better than STOREIND.simd16 because of this.
-    if (src->IsIntegralConst(0) || src->IsDblConPositiveZero())
+    if (node->TypeIs(TYP_SIMD12))
+    {
+        if (src->IsSIMDZero() || src->IsHWIntrinsicZero())
+        {
+            src->SetContained();
+        }
+    }
+    else if (src->IsIntegralConst(0) || src->IsDblConPositiveZero())
     {
         src->SetContained();
     }
@@ -1406,7 +1413,7 @@ void Lowering::ContainCheckStoreLoc(GenTreeLclVarCommon* storeLoc) const
 #endif
 
 #ifdef TARGET_ARM64
-    if (op1->IsIntegralConst(0) || op1->IsDblConPositiveZero() || op1->IsSIMDZero())
+    if (op1->IsIntegralConst(0) || op1->IsDblConPositiveZero() || op1->IsSIMDZero() || op1->IsHWIntrinsicZero())
     {
         op1->SetContained();
         return;

--- a/src/coreclr/src/jit/lsra.cpp
+++ b/src/coreclr/src/jit/lsra.cpp
@@ -2757,6 +2757,13 @@ bool LinearScan::isMatchingConstant(RegRecord* physRegRecord, RefPosition* refPo
                 // equal.  So we compare the bits.
                 return (refPosition->treeNode->GetType() == otherTreeNode->GetType()) &&
                        (refPosition->treeNode->AsDblCon()->GetBits() == otherTreeNode->AsDblCon()->GetBits());
+
+#if defined(FEATURE_HW_INTRINSICS) && defined(TARGET_XARCH)
+            case GT_HWINTRINSIC:
+                // XARCH only for now, doesn't seem to be useful on ARM64 due to XZR.
+                return refPosition->treeNode->IsHWIntrinsicZero() && otherTreeNode->IsHWIntrinsicZero();
+#endif
+
             default:
                 break;
         }

--- a/src/coreclr/src/jit/lsraarmarch.cpp
+++ b/src/coreclr/src/jit/lsraarmarch.cpp
@@ -102,11 +102,8 @@ int LinearScan::BuildIndir(GenTreeIndir* indirTree)
     }
 
 #ifdef FEATURE_SIMD
-    if (indirTree->TypeGet() == TYP_SIMD12)
+    if (indirTree->TypeIs(TYP_SIMD12))
     {
-        // If indirTree is of TYP_SIMD12, addr is not contained. See comment in LowerIndir().
-        assert(!addr->isContained());
-
         // Vector3 is read/written as two reads/writes: 8 byte and 4 byte.
         // To assemble the vector properly we would need an additional int register
         buildInternalIntRegisterDefForNode(indirTree);

--- a/src/coreclr/src/jit/lsraarmarch.cpp
+++ b/src/coreclr/src/jit/lsraarmarch.cpp
@@ -107,6 +107,19 @@ int LinearScan::BuildIndir(GenTreeIndir* indirTree)
         // Vector3 is read/written as two reads/writes: 8 byte and 4 byte.
         // To assemble the vector properly we would need an additional int register
         buildInternalIntRegisterDefForNode(indirTree);
+
+        if (indirTree->OperIs(GT_STOREIND))
+        {
+            GenTree* value = indirTree->AsStoreInd()->GetValue();
+
+            if (value->isContained())
+            {
+                int srcCount = BuildIndirUses(indirTree);
+                srcCount += value->OperIs(GT_IND) ? BuildIndirUses(value->AsIndir()) : 0;
+                buildInternalRegisterUses();
+                return srcCount;
+            }
+        }
     }
 #endif // FEATURE_SIMD
 

--- a/src/coreclr/src/jit/lsrabuild.cpp
+++ b/src/coreclr/src/jit/lsrabuild.cpp
@@ -3278,6 +3278,16 @@ int LinearScan::BuildStoreLoc(GenTreeLclVarCommon* storeLoc)
         return BuildMultiRegStoreLoc(storeLoc->AsLclVar());
     }
 
+#ifdef FEATURE_SIMD
+    if (storeLoc->TypeIs(TYP_SIMD12) && op1->isContained() && op1->OperIs(GT_IND, GT_LCL_FLD, GT_LCL_VAR))
+    {
+        buildInternalIntRegisterDefForNode(storeLoc);
+        int srcCount = op1->OperIs(GT_IND) ? BuildIndirUses(op1->AsIndir()) : 0;
+        buildInternalRegisterUses();
+        return srcCount;
+    }
+#endif
+
 // First, define internal registers.
 #ifdef FEATURE_SIMD
     RefPosition* internalFloatDef = nullptr;

--- a/src/coreclr/src/jit/lsrabuild.cpp
+++ b/src/coreclr/src/jit/lsrabuild.cpp
@@ -3329,7 +3329,7 @@ int LinearScan::BuildStoreLoc(GenTreeLclVarCommon* storeLoc)
         {
             // This is the zero-init case, and we need a register to hold the zero.
             // (On Arm64 we can just store REG_ZR.)
-            assert(op1->IsSIMDZero());
+            assert(op1->IsSIMDZero() || op1->IsHWIntrinsicZero());
             singleUseRef = BuildUse(op1->AsSIMD()->GetOp(0));
             srcCount     = 1;
         }

--- a/src/coreclr/src/jit/lsraxarch.cpp
+++ b/src/coreclr/src/jit/lsraxarch.cpp
@@ -2751,11 +2751,8 @@ int LinearScan::BuildIndir(GenTreeIndir* indirTree)
 
 #ifdef FEATURE_SIMD
     RefPosition* internalFloatDef = nullptr;
-    if (indirTree->TypeGet() == TYP_SIMD12)
+    if (indirTree->TypeIs(TYP_SIMD12))
     {
-        // If indirTree is of TYP_SIMD12, addr is not contained. See comment in LowerIndir().
-        assert(!indirTree->Addr()->isContained());
-
         // Vector3 is read/written as two reads/writes: 8 byte and 4 byte.
         // To assemble the vector properly we would need an additional
         // XMM register.
@@ -2763,7 +2760,7 @@ int LinearScan::BuildIndir(GenTreeIndir* indirTree)
 
         // In case of GT_IND we need an internal register different from targetReg and
         // both of the registers are used at the same time.
-        if (indirTree->OperGet() == GT_IND)
+        if (indirTree->OperIs(GT_IND))
         {
             setInternalRegsDelayFree = true;
         }

--- a/src/coreclr/src/jit/lsraxarch.cpp
+++ b/src/coreclr/src/jit/lsraxarch.cpp
@@ -2670,7 +2670,12 @@ int LinearScan::BuildHWIntrinsic(GenTreeHWIntrinsic* intrinsicTree)
 
     if (dstCount == 1)
     {
-        BuildDef(intrinsicTree, dstCandidates);
+        RefPosition* def = BuildDef(intrinsicTree, dstCandidates);
+
+        if (intrinsicTree->IsHWIntrinsicZero())
+        {
+            def->getInterval()->isConstant = true;
+        }
     }
     else
     {

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -8868,6 +8868,23 @@ GenTree* Compiler::fgMorphInitBlock(GenTreeOp* asg)
                 }
             }
 
+            if (initType == TYP_UNDEF)
+            {
+                // TODO-MIKE-Review: The backend was changed in master to no longer support zeroing SIMD
+                // typed locals by assigning a CNS_INT(0) so we have to change this to be a SIMD init.
+                // Still, zeroing a Vector2/3 in memory using GPRs produces smaller code so perhaps we
+                // need to do something else - if it's a LCL_FLD (or a LCL_VAR if the local is already
+                // DNER) we can change its type to TYP_STRUCT to get the normal block initialization.
+                // But then retyping can cause other issues (VN, CSE etc.) so perhaps we should actually
+                // convert it here to SIMD init and then deal with it in lowering/codegen.
+
+                if (!dest->OperIs(GT_BLK) && varTypeIsSIMD(dest->GetType()))
+                {
+                    initType     = dest->GetType();
+                    initBaseType = TYP_FLOAT;
+                }
+            }
+
             if (initType != TYP_UNDEF)
             {
                 destLclNode->SetType(initType);

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -9046,7 +9046,14 @@ GenTree* Compiler::fgMorphInitBlockConstant(GenTreeIntCon* initVal,
 #ifdef FEATURE_SIMD
     if (varTypeIsSIMD(type))
     {
-        return gtNewSIMDNode(type, SIMDIntrinsicInit, initPatternType, genTypeSize(type), initVal);
+        if (initPattern == 0)
+        {
+            return gtNewSimdHWIntrinsicNode(type, NI_Vector128_get_Zero, initPatternType, genTypeSize(type));
+        }
+        else
+        {
+            return gtNewSIMDNode(type, SIMDIntrinsicInit, initPatternType, genTypeSize(type), initVal);
+        }
     }
 #endif
 


### PR DESCRIPTION
win-x64 diff:
```
Total bytes of diff: -392 (-0.001% of base)
    diff is an improvement.
Top file improvements (bytes):
        -392 : System.Private.CoreLib.dasm (-0.012% of base)
1 total files with Code Size differences (1 improved, 0 regressed), 261 unchanged.
Top method improvements (bytes):
         -65 (-3.109% of base) : System.Private.CoreLib.dasm - Matrix4x4:Decompose(Matrix4x4,byref,byref,byref):bool
         -23 (-1.625% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateConstrainedBillboard(Vector3,Vector3,Vector3,Vector3,Vector3):Matrix4x4
         -22 (-3.125% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateBillboard(Vector3,Vector3,Vector3,Vector3):Matrix4x4
         -22 (-3.554% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateWorld(Vector3,Vector3,Vector3):Matrix4x4
         -18 (-56.250% of base) : System.Private.CoreLib.dasm - Matrix4x4:set_Translation(Vector3):this
         -18 (-50.000% of base) : System.Private.CoreLib.dasm - Quaternion:.ctor(Vector3,float):this
         -18 (-50.000% of base) : System.Private.CoreLib.dasm - Vector4:.ctor(Vector3,float):this
         -15 (-7.653% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateTranslation(Vector3):Matrix4x4
         -15 (-45.455% of base) : System.Private.CoreLib.dasm - Plane:.ctor(Vector3,float):this
         -15 (-48.387% of base) : System.Private.CoreLib.dasm - Vector128:AsVector3(Vector128`1):Vector3
          -6 (-17.143% of base) : System.Private.CoreLib.dasm - Matrix4x4:get_Translation():Vector3:this
          -6 (-14.634% of base) : System.Private.CoreLib.dasm - Plane:.ctor(Vector4):this
          -6 (-1.824% of base) : System.Private.CoreLib.dasm - Plane:CreateFromVertices(Vector3,Vector3,Vector3):Plane
          -6 (-3.896% of base) : System.Private.CoreLib.dasm - Vector3:Reflect(Vector3,Vector3):Vector3
          -5 (-0.573% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateLookAt(Vector3,Vector3,Vector3):Matrix4x4
          -5 (-2.439% of base) : System.Private.CoreLib.dasm - Plane:Normalize(Plane):Plane
          -5 (-4.237% of base) : System.Private.CoreLib.dasm - Vector3:Equals(Object):bool:this
          -5 (-3.788% of base) : System.Private.CoreLib.dasm - Vector3:Normalize(Vector3):Vector3
          -5 (-7.463% of base) : System.Private.CoreLib.dasm - Vector3:Clamp(Vector3,Vector3,Vector3):Vector3
          -4 (-4.211% of base) : System.Private.CoreLib.dasm - Vector3:Lerp(Vector3,Vector3,float):Vector3
Top method improvements (percentages):
         -18 (-56.250% of base) : System.Private.CoreLib.dasm - Matrix4x4:set_Translation(Vector3):this
         -18 (-50.000% of base) : System.Private.CoreLib.dasm - Quaternion:.ctor(Vector3,float):this
         -18 (-50.000% of base) : System.Private.CoreLib.dasm - Vector4:.ctor(Vector3,float):this
         -15 (-48.387% of base) : System.Private.CoreLib.dasm - Vector128:AsVector3(Vector128`1):Vector3
         -15 (-45.455% of base) : System.Private.CoreLib.dasm - Plane:.ctor(Vector3,float):this
          -6 (-17.143% of base) : System.Private.CoreLib.dasm - Matrix4x4:get_Translation():Vector3:this
          -6 (-14.634% of base) : System.Private.CoreLib.dasm - Plane:.ctor(Vector4):this
          -4 (-8.163% of base) : System.Private.CoreLib.dasm - Vector3:Add(Vector3,Vector3):Vector3
          -4 (-8.163% of base) : System.Private.CoreLib.dasm - Vector3:Subtract(Vector3,Vector3):Vector3
          -4 (-8.163% of base) : System.Private.CoreLib.dasm - Vector3:Multiply(Vector3,Vector3):Vector3
          -3 (-8.108% of base) : System.Private.CoreLib.dasm - Vector3:Negate(Vector3):Vector3
          -3 (-8.108% of base) : System.Private.CoreLib.dasm - Vector3:op_UnaryNegation(Vector3):Vector3
          -2 (-8.000% of base) : System.Private.CoreLib.dasm - Vector3:get_One():Vector3
          -2 (-8.000% of base) : System.Private.CoreLib.dasm - Vector3:get_UnitX():Vector3
          -2 (-8.000% of base) : System.Private.CoreLib.dasm - Vector3:get_UnitY():Vector3
          -2 (-8.000% of base) : System.Private.CoreLib.dasm - Vector3:get_UnitZ():Vector3
         -15 (-7.653% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateTranslation(Vector3):Matrix4x4
          -5 (-7.463% of base) : System.Private.CoreLib.dasm - Vector3:Clamp(Vector3,Vector3,Vector3):Vector3
          -4 (-6.780% of base) : System.Private.CoreLib.dasm - Vector3:Divide(Vector3,Vector3):Vector3
          -3 (-6.250% of base) : System.Private.CoreLib.dasm - Vector3:Multiply(Vector3,float):Vector3
67 total methods with Code Size differences (67 improved, 0 regressed), 186399 unchanged.
```
`for (int i = 0; i < a1.Length; i++) s += Vector3.Dot(a1[i], a2[i]);` is ~1.18x faster.