### PR TITLE
Fold constant string null checks

### DIFF
--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -13425,6 +13425,22 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
 
             if (op1->gtOper == GT_CNS_STR || op2->gtOper == GT_CNS_STR)
             {
+                if (op1->IsIntegralConst(0) || op2->IsIntegralConst(0))
+                {
+                    // Constant strings cannot be null.
+                    if (tree->OperIs(GT_EQ))
+                    {
+                        i1 = 0;
+                        goto FOLD_COND;
+                    }
+                    else if (tree->OperIs(GT_NE) ||
+                             (tree->OperIs(GT_GT) && tree->IsUnsigned() && op2->IsIntegralConst(0)))
+                    {
+                        i1 = 1;
+                        goto FOLD_COND;
+                    }
+                }
+
                 return tree;
             }
 


### PR DESCRIPTION
win-x64 diff:
```
Total bytes of diff: -7239 (-0.02% of base)
    diff is an improvement.
Top file improvements (bytes):
       -3767 : System.Private.CoreLib.dasm (-0.12% of base)
       -2223 : Newtonsoft.Json.dasm (-0.37% of base)
        -626 : System.Private.Xml.dasm (-0.02% of base)
        -154 : System.Security.Cryptography.Xml.dasm (-0.11% of base)
        -112 : System.DirectoryServices.dasm (-0.03% of base)
         -82 : System.Reflection.Metadata.dasm (-0.03% of base)
         -73 : System.Configuration.ConfigurationManager.dasm (-0.02% of base)
         -50 : System.Data.Common.dasm (-0.00% of base)
         -47 : System.ComponentModel.Composition.dasm (-0.02% of base)
         -46 : System.Drawing.Common.dasm (-0.01% of base)
         -45 : System.Private.DataContractSerialization.dasm (-0.01% of base)
          -9 : System.Private.Xml.Linq.dasm (-0.01% of base)
          -5 : System.Management.dasm (-0.00% of base)
13 total files with Code Size differences (13 improved, 0 regressed), 254 unchanged.
Top method regressions (bytes):
           3 ( 0.64% of base) : System.Configuration.ConfigurationManager.dasm - BaseConfigurationRecord:VerifySectionName(String,IConfigErrorInfo,bool)
Top method improvements (bytes):
        -697 (-8.67% of base) : System.Private.CoreLib.dasm - Vector256`1:ToString():String:this (11 methods)
        -697 (-9.07% of base) : System.Private.CoreLib.dasm - Vector64`1:ToString():String:this (11 methods)
        -633 (-8.32% of base) : System.Private.CoreLib.dasm - Vector128`1:ToString():String:this (11 methods)
        -290 (-28.83% of base) : System.Private.CoreLib.dasm - LicenseInteropProxy:.ctor():this
        -240 (-15.31% of base) : Newtonsoft.Json.dasm - JsonSerializerInternalReader:ReadMetadataPropertiesToken(JTokenReader,byref,byref,JsonProperty,JsonContainerContract,JsonProperty,Object,byref,byref):bool:this
        -204 (-10.15% of base) : Newtonsoft.Json.dasm - JsonSerializerInternalReader:ResolvePropertyAndCreatorValues(JsonObjectContract,JsonProperty,JsonReader,Type):List`1:this
        -157 (-5.62% of base) : Newtonsoft.Json.dasm - JsonTextReader:ReadStringIntoBuffer(ushort):this
        -156 (-2.22% of base) : Newtonsoft.Json.dasm - <ExecuteFilter>d__4:MoveNext():bool:this (8 methods)
        -153 (-3.87% of base) : Newtonsoft.Json.dasm - <ReadStringIntoBufferAsync>d__9:MoveNext():this
        -152 (-6.33% of base) : Newtonsoft.Json.dasm - JsonSerializerInternalReader:PopulateObject(Object,JsonReader,JsonObjectContract,JsonProperty,String):Object:this
        -143 (-17.57% of base) : System.Private.CoreLib.dasm - Enum:ValueToHexString(Object):String
        -128 (-8.30% of base) : Newtonsoft.Json.dasm - JsonSerializerInternalReader:ReadMetadataProperties(JsonReader,byref,byref,JsonProperty,JsonContainerContract,JsonProperty,Object,byref,byref):bool:this
        -127 (-16.10% of base) : System.Private.CoreLib.dasm - GlobalizationMode:LoadAppLocalIcuCore(ReadOnlySpan`1,ReadOnlySpan`1)
        -112 (-2.53% of base) : System.DirectoryServices.dasm - ActiveDirectorySite:GetBridgeheadServers():ReadOnlyDirectoryServerCollection:this
        -108 (-7.61% of base) : Newtonsoft.Json.dasm - ReflectionObject:Create(Type,MethodBase,ref):ReflectionObject
        -104 (-7.19% of base) : Newtonsoft.Json.dasm - DiscriminatedUnionConverter:ReadJson(JsonReader,Type,Object,JsonSerializer):Object:this
         -96 (-6.37% of base) : Newtonsoft.Json.dasm - JsonValidatingReader:WriteToken(IList`1):this
         -96 (-20.69% of base) : System.Private.CoreLib.dasm - AppDomain:GetThreadPrincipal():IPrincipal:this
         -84 (-24.49% of base) : System.Private.CoreLib.dasm - Path:GetUncRootLength(ReadOnlySpan`1):int
         -82 (-27.61% of base) : System.Reflection.Metadata.dasm - ManagedPEBuilder:CreateSections():ImmutableArray`1:this
Top method regressions (percentages):
           3 ( 0.64% of base) : System.Configuration.ConfigurationManager.dasm - BaseConfigurationRecord:VerifySectionName(String,IConfigErrorInfo,bool)
Top method improvements (percentages):
         -13 (-28.89% of base) : System.Private.CoreLib.dasm - Char8:ToString():String:this
        -290 (-28.83% of base) : System.Private.CoreLib.dasm - LicenseInteropProxy:.ctor():this
         -82 (-27.61% of base) : System.Reflection.Metadata.dasm - ManagedPEBuilder:CreateSections():ImmutableArray`1:this
         -45 (-26.16% of base) : System.Private.DataContractSerialization.dasm - JsonReaderWriterFactory:CreateJsonWriter(Stream,Encoding,bool,bool):XmlDictionaryWriter
         -84 (-24.49% of base) : System.Private.CoreLib.dasm - Path:GetUncRootLength(ReadOnlySpan`1):int
         -73 (-23.03% of base) : System.Private.CoreLib.dasm - Enum:ValueToHexString():String:this
         -96 (-20.69% of base) : System.Private.CoreLib.dasm - AppDomain:GetThreadPrincipal():IPrincipal:this
         -60 (-17.86% of base) : System.Private.CoreLib.dasm - ExternalException:ToString():String:this
        -143 (-17.57% of base) : System.Private.CoreLib.dasm - Enum:ValueToHexString(Object):String
          -9 (-17.31% of base) : System.Private.Xml.Linq.dasm - XElement:.ctor():this
        -127 (-16.10% of base) : System.Private.CoreLib.dasm - GlobalizationMode:LoadAppLocalIcuCore(ReadOnlySpan`1,ReadOnlySpan`1)
        -240 (-15.31% of base) : Newtonsoft.Json.dasm - JsonSerializerInternalReader:ReadMetadataPropertiesToken(JTokenReader,byref,byref,JsonProperty,JsonContainerContract,JsonProperty,Object,byref,byref):bool:this
         -60 (-14.12% of base) : System.Private.CoreLib.dasm - COMException:ToString():String:this
         -56 (-12.96% of base) : Newtonsoft.Json.dasm - BinaryConverter:ReadByteArray(JsonReader):ref:this
         -48 (-12.28% of base) : System.Private.CoreLib.dasm - <>c:<InitializeBinaryFormatter>b__6_1():Func`3:this
         -49 (-11.81% of base) : System.Private.CoreLib.dasm - DefaultValueAttribute:<.ctor>g__TryConvertFromInvariantString|2_0(Type,String,byref):bool
         -47 (-11.16% of base) : System.ComponentModel.Composition.dasm - PartCreatorMemberImportDefinition:.ctor(LazyMemberInfo,ICompositionElement,ContractBasedImportDefinition):this
         -75 (-10.78% of base) : System.Private.CoreLib.dasm - ManifestBuilder:AddKeyword(String,long):this
         -36 (-10.37% of base) : System.Private.Xml.dasm - HtmlEncodedRawTextWriter:WriteMetaElement():this
         -36 (-10.37% of base) : System.Private.Xml.dasm - HtmlUtf8RawTextWriter:WriteMetaElement():this
118 total methods with Code Size differences (117 improved, 1 regressed), 197081 unchanged.
```
Regression in `BaseConfigurationRecord:VerifySectionName` caused by layout code changes that turn short conditional jumps in long one and some extra REX prefixes due to changes in register allocation.