### PR TITLE
Make GenTreeIndexAddr small

### DIFF
--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -4234,13 +4234,13 @@ void CodeGen::genCodeForIndexAddr(GenTreeIndexAddr* node)
         // is a native int on a 64-bit platform, we will need to widen the array length and then compare.
         if (index->TypeGet() == TYP_I_IMPL)
         {
-            GetEmitter()->emitIns_R_AR(INS_mov, EA_4BYTE, tmpReg, baseReg, static_cast<int>(node->gtLenOffset));
+            GetEmitter()->emitIns_R_AR(INS_mov, EA_4BYTE, tmpReg, baseReg, node->gtLenOffset);
             GetEmitter()->emitIns_R_R(INS_cmp, EA_8BYTE, indexReg, tmpReg);
         }
         else
 #endif // TARGET_64BIT
         {
-            GetEmitter()->emitIns_R_AR(INS_cmp, EA_4BYTE, indexReg, baseReg, static_cast<int>(node->gtLenOffset));
+            GetEmitter()->emitIns_R_AR(INS_cmp, EA_4BYTE, indexReg, baseReg, node->gtLenOffset);
         }
 
         genJumpToThrowHlpBlk(EJ_jae, SCK_RNGCHK_FAIL, node->gtIndRngFailBB);

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -8584,12 +8584,6 @@ void cTreeFlags(Compiler* comp, GenTree* tree)
                 break;
 
             case GT_INDEX:
-
-                if (tree->gtFlags & GTF_INX_STRING_LAYOUT)
-                {
-                    chars += printf("[INX_STRING_LAYOUT]");
-                }
-                __fallthrough;
             case GT_INDEX_ADDR:
                 if (tree->gtFlags & GTF_INX_RNGCHK)
                 {

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -9154,22 +9154,14 @@ public:
     //    True if the `GT_IND` node represents an array access; false otherwise.
     bool TryGetArrayInfo(GenTreeIndir* indir, ArrayInfo* arrayInfo)
     {
-        if ((indir->gtFlags & GTF_IND_ARR_INDEX) == 0)
+        if ((indir->gtFlags & GTF_IND_ARR_INDEX) != 0)
         {
-            return false;
-        }
-
-        if (indir->gtOp1->OperIs(GT_INDEX_ADDR))
-        {
-            GenTreeIndexAddr* const indexAddr = indir->gtOp1->AsIndexAddr();
-            *arrayInfo = ArrayInfo(indexAddr->gtElemType, indexAddr->gtElemSize, indexAddr->gtElemOffset,
-                                   indexAddr->gtStructElemClass);
+            bool found = GetArrayInfoMap()->Lookup(indir, arrayInfo);
+            assert(found);
             return true;
         }
 
-        bool found = GetArrayInfoMap()->Lookup(indir, arrayInfo);
-        assert(found);
-        return true;
+        return false;
     }
 
     NodeToUnsignedMap* m_memorySsaMap[MemoryKindCount];

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -2164,7 +2164,8 @@ public:
 
     GenTreeField* gtNewFieldRef(var_types typ, CORINFO_FIELD_HANDLE fldHnd, GenTree* obj = nullptr, DWORD offset = 0);
 
-    GenTree* gtNewIndexRef(var_types typ, GenTree* arrayOp, GenTree* indexOp);
+    GenTreeIndex* gtNewArrayIndex(var_types type, GenTree* arr, GenTree* ind);
+    GenTreeIndex* gtNewStringIndex(GenTree* arr, GenTree* ind);
 
     GenTreeArrLen* gtNewArrLen(var_types typ, GenTree* arrayOp, int lenOffset, BasicBlock* block);
 

--- a/src/coreclr/src/jit/compiler.hpp
+++ b/src/coreclr/src/jit/compiler.hpp
@@ -1222,16 +1222,16 @@ inline GenTreeField* Compiler::gtNewFieldRef(var_types typ, CORINFO_FIELD_HANDLE
     return tree;
 }
 
-/*****************************************************************************
- *
- *  A little helper to create an array index node.
- */
-
-inline GenTree* Compiler::gtNewIndexRef(var_types typ, GenTree* arrayOp, GenTree* indexOp)
+inline GenTreeIndex* Compiler::gtNewArrayIndex(var_types type, GenTree* arr, GenTree* ind)
 {
-    GenTreeIndex* gtIndx = new (this, GT_INDEX) GenTreeIndex(typ, arrayOp, indexOp, genTypeSize(typ));
+    return new (this, GT_INDEX)
+        GenTreeIndex(type, arr, ind, OFFSETOF__CORINFO_Array__length, OFFSETOF__CORINFO_Array__data);
+}
 
-    return gtIndx;
+inline GenTreeIndex* Compiler::gtNewStringIndex(GenTree* arr, GenTree* ind)
+{
+    return new (this, GT_INDEX)
+        GenTreeIndex(TYP_USHORT, arr, ind, OFFSETOF__CORINFO_String__stringLen, OFFSETOF__CORINFO_String__chars);
 }
 
 //------------------------------------------------------------------------------

--- a/src/coreclr/src/jit/flowgraph.cpp
+++ b/src/coreclr/src/jit/flowgraph.cpp
@@ -7389,6 +7389,11 @@ bool Compiler::fgAddrCouldBeNull(GenTree* addr)
             }
         }
     }
+    else if (addr->OperIs(GT_INDEX_ADDR))
+    {
+        return false;
+    }
+
     return true; // default result: addr could be null
 }
 

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -6947,9 +6947,8 @@ GenTree* Compiler::gtCloneExpr(
                 GenTreeIndexAddr* asIndAddr = tree->AsIndexAddr();
 
                 copy = new (this, GT_INDEX_ADDR)
-                    GenTreeIndexAddr(asIndAddr->Arr(), asIndAddr->Index(), asIndAddr->gtElemType,
-                                     asIndAddr->gtStructElemClass, asIndAddr->gtElemSize, asIndAddr->gtLenOffset,
-                                     asIndAddr->gtElemOffset);
+                    GenTreeIndexAddr(asIndAddr->Arr(), asIndAddr->Index(), asIndAddr->gtElemSize,
+                                     asIndAddr->gtLenOffset, asIndAddr->gtElemOffset);
                 copy->AsIndexAddr()->gtIndRngFailBB = asIndAddr->gtIndRngFailBB;
             }
             break;
@@ -7086,7 +7085,7 @@ GenTree* Compiler::gtCloneExpr(
             case GT_STORE_OBJ:
             {
                 ArrayInfo arrInfo;
-                if (!tree->AsIndir()->gtOp1->OperIs(GT_INDEX_ADDR) && TryGetArrayInfo(tree->AsIndir(), &arrInfo))
+                if (TryGetArrayInfo(tree->AsIndir(), &arrInfo))
                 {
                     GetArrayInfoMap()->Set(copy, arrInfo);
                 }

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -1378,7 +1378,7 @@ AGAIN:
                     }
                     break;
                 case GT_INDEX:
-                    if (op1->AsIndex()->gtIndElemSize != op2->AsIndex()->gtIndElemSize)
+                    if (op1->AsIndex()->GetElemSize() != op2->AsIndex()->GetElemSize())
                     {
                         return false;
                     }
@@ -2023,7 +2023,7 @@ AGAIN:
                     hash ^= tree->AsCast()->gtCastType;
                     break;
                 case GT_INDEX:
-                    hash += tree->AsIndex()->gtIndElemSize;
+                    hash += tree->AsIndex()->GetElemSize();
                     break;
                 case GT_INDEX_ADDR:
                     hash += tree->AsIndexAddr()->GetElemSize();
@@ -6933,13 +6933,8 @@ GenTree* Compiler::gtCloneExpr(
             // The nodes below this are not bashed, so they can be allocated at their individual sizes.
 
             case GT_INDEX:
-            {
-                GenTreeIndex* asInd = tree->AsIndex();
-                copy                = new (this, GT_INDEX)
-                    GenTreeIndex(asInd->TypeGet(), asInd->Arr(), asInd->Index(), asInd->gtIndElemSize);
-                copy->AsIndex()->gtStructElemClass = asInd->gtStructElemClass;
-            }
-            break;
+                copy = new (this, GT_INDEX) GenTreeIndex(tree->AsIndex());
+                break;
 
             case GT_INDEX_ADDR:
                 copy = new (this, GT_INDEX_ADDR) GenTreeIndexAddr(tree->AsIndexAddr());
@@ -16341,7 +16336,7 @@ CORINFO_CLASS_HANDLE Compiler::gtGetStructHandleIfPresent(GenTree* tree)
                 structHnd = tree->AsRetExpr()->gtRetClsHnd;
                 break;
             case GT_INDEX:
-                structHnd = tree->AsIndex()->gtStructElemClass;
+                structHnd = tree->AsIndex()->GetElemClassHandle();
                 break;
             case GT_FIELD:
                 info.compCompHnd->getFieldType(tree->AsField()->gtFldHnd, &structHnd);
@@ -16721,14 +16716,10 @@ CORINFO_CLASS_HANDLE Compiler::gtGetClassHandle(GenTree* tree, bool* pIsExact, b
         }
 
         case GT_INDEX:
-        {
-            GenTree* array = obj->AsIndex()->Arr();
-
-            objClass    = gtGetArrayElementClassHandle(array);
+            objClass    = gtGetArrayElementClassHandle(obj->AsIndex()->GetArray());
             *pIsExact   = false;
             *pIsNonNull = false;
             break;
-        }
 
         default:
         {

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -1384,7 +1384,7 @@ AGAIN:
                     }
                     break;
                 case GT_INDEX_ADDR:
-                    if (op1->AsIndexAddr()->gtElemSize != op2->AsIndexAddr()->gtElemSize)
+                    if (op1->AsIndexAddr()->GetElemSize() != op2->AsIndexAddr()->GetElemSize())
                     {
                         return false;
                     }
@@ -2026,7 +2026,7 @@ AGAIN:
                     hash += tree->AsIndex()->gtIndElemSize;
                     break;
                 case GT_INDEX_ADDR:
-                    hash += tree->AsIndexAddr()->gtElemSize;
+                    hash += tree->AsIndexAddr()->GetElemSize();
                     break;
                 case GT_ALLOCOBJ:
                     hash = genTreeHashAdd(hash, static_cast<unsigned>(
@@ -4684,17 +4684,17 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
             costEx = 6; // cmp reg,reg; jae throw; mov reg, [addrmode]  (not taken)
             costSz = 9; // jump to cold section
 
-            level = gtSetEvalOrder(tree->AsIndexAddr()->Index());
-            costEx += tree->AsIndexAddr()->Index()->GetCostEx();
-            costSz += tree->AsIndexAddr()->Index()->GetCostSz();
+            level = gtSetEvalOrder(tree->AsIndexAddr()->GetIndex());
+            costEx += tree->AsIndexAddr()->GetIndex()->GetCostEx();
+            costSz += tree->AsIndexAddr()->GetIndex()->GetCostSz();
 
-            lvl2 = gtSetEvalOrder(tree->AsIndexAddr()->Arr());
+            lvl2 = gtSetEvalOrder(tree->AsIndexAddr()->GetArray());
             if (level < lvl2)
             {
                 level = lvl2;
             }
-            costEx += tree->AsIndexAddr()->Arr()->GetCostEx();
-            costSz += tree->AsIndexAddr()->Arr()->GetCostSz();
+            costEx += tree->AsIndexAddr()->GetArray()->GetCostEx();
+            costSz += tree->AsIndexAddr()->GetArray()->GetCostSz();
             break;
 
         default:
@@ -6942,15 +6942,8 @@ GenTree* Compiler::gtCloneExpr(
             break;
 
             case GT_INDEX_ADDR:
-            {
-                GenTreeIndexAddr* asIndAddr = tree->AsIndexAddr();
-
-                copy = new (this, GT_INDEX_ADDR)
-                    GenTreeIndexAddr(asIndAddr->Arr(), asIndAddr->Index(), asIndAddr->gtElemSize,
-                                     asIndAddr->gtLenOffset, asIndAddr->gtElemOffset);
-                copy->AsIndexAddr()->gtIndRngFailBB = asIndAddr->gtIndRngFailBB;
-            }
-            break;
+                copy = new (this, GT_INDEX_ADDR) GenTreeIndexAddr(tree->AsIndexAddr());
+                break;
 
             case GT_ALLOCOBJ:
             {

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -241,7 +241,6 @@ void GenTree::InitNodeSize()
 
     GenTree::s_gtNodeSizes[GT_CALL]             = TREE_NODE_SZ_LARGE;
     GenTree::s_gtNodeSizes[GT_BOX]              = TREE_NODE_SZ_LARGE;
-    GenTree::s_gtNodeSizes[GT_INDEX_ADDR]       = TREE_NODE_SZ_LARGE;
     GenTree::s_gtNodeSizes[GT_ARR_ELEM]         = TREE_NODE_SZ_LARGE;
     GenTree::s_gtNodeSizes[GT_DYN_BLK]          = TREE_NODE_SZ_LARGE;
     GenTree::s_gtNodeSizes[GT_STORE_DYN_BLK]    = TREE_NODE_SZ_LARGE;
@@ -289,7 +288,7 @@ void GenTree::InitNodeSize()
     static_assert_no_msg(sizeof(GenTreeQmark)        <= TREE_NODE_SZ_SMALL);
     static_assert_no_msg(sizeof(GenTreeIntrinsic)    <= TREE_NODE_SZ_LARGE); // *** large node
     static_assert_no_msg(sizeof(GenTreeIndex)        <= TREE_NODE_SZ_SMALL);
-    static_assert_no_msg(sizeof(GenTreeIndexAddr)    <= TREE_NODE_SZ_LARGE); // *** large node
+    static_assert_no_msg(sizeof(GenTreeIndexAddr)    <= TREE_NODE_SZ_SMALL);
     static_assert_no_msg(sizeof(GenTreeArrLen)       <= TREE_NODE_SZ_SMALL);
     static_assert_no_msg(sizeof(GenTreeBoundsChk)    <= TREE_NODE_SZ_SMALL);
     static_assert_no_msg(sizeof(GenTreeArrElem)      <= TREE_NODE_SZ_LARGE); // *** large node

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -5904,10 +5904,10 @@ struct GenTreeIndexAddr : public GenTreeOp
     BasicBlock* gtIndRngFailBB; // Basic block to jump to for array-index-out-of-range
 
     unsigned gtElemSize;   // size of elements in the array
-    unsigned gtLenOffset;  // The offset from the array's base address to its length.
-    unsigned gtElemOffset; // The offset from the array's base address to its first element.
+    uint8_t  gtLenOffset;  // The offset from the array's base address to its length.
+    uint8_t  gtElemOffset; // The offset from the array's base address to its first element.
 
-    GenTreeIndexAddr(GenTree* arr, GenTree* ind, unsigned elemSize, unsigned lenOffset, unsigned elemOffset)
+    GenTreeIndexAddr(GenTree* arr, GenTree* ind, unsigned elemSize, uint8_t lenOffset, uint8_t elemOffset)
         : GenTreeOp(GT_INDEX_ADDR, TYP_BYREF, arr, ind)
         , gtIndRngFailBB(nullptr)
         , gtElemSize(elemSize)

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -5893,7 +5893,6 @@ struct GenTreeIndexAddr : public GenTreeOp
 {
 private:
     BasicBlock* m_throwBlock;
-    uint8_t     m_lenOffs;
     uint8_t     m_dataOffs;
     unsigned    m_elemSize;
 
@@ -5901,17 +5900,18 @@ public:
     GenTreeIndexAddr(GenTree* arr, GenTree* ind, uint8_t lenOffs, uint8_t dataOffs, unsigned elemSize)
         : GenTreeOp(GT_INDEX_ADDR, TYP_BYREF, arr, ind)
         , m_throwBlock(nullptr)
-        , m_lenOffs(lenOffs)
         , m_dataOffs(dataOffs)
         , m_elemSize(elemSize)
     {
+        // The offset of length is always the same for both strings and arrays.
+        assert(lenOffs == TARGET_POINTER_SIZE);
+
         gtFlags |= GTF_EXCEPT | GTF_GLOB_REF | ((arr->gtFlags | ind->gtFlags) & GTF_ALL_EFFECT);
     }
 
     GenTreeIndexAddr(const GenTreeIndexAddr* copyFrom)
         : GenTreeOp(GT_INDEX_ADDR, TYP_BYREF, copyFrom->gtOp1, copyFrom->gtOp2)
         , m_throwBlock(copyFrom->m_throwBlock)
-        , m_lenOffs(copyFrom->m_lenOffs)
         , m_dataOffs(copyFrom->m_dataOffs)
         , m_elemSize(copyFrom->m_elemSize)
     {
@@ -5951,7 +5951,7 @@ public:
 
     uint8_t GetLenOffs() const
     {
-        return m_lenOffs;
+        return TARGET_POINTER_SIZE;
     }
 
     uint8_t GetDataOffs() const

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -5901,26 +5901,15 @@ struct GenTreeIndexAddr : public GenTreeOp
         return gtOp2;
     }
 
-    CORINFO_CLASS_HANDLE gtStructElemClass; // If the element type is a struct, this is the struct type.
-
     BasicBlock* gtIndRngFailBB; // Basic block to jump to for array-index-out-of-range
 
-    var_types gtElemType;   // The element type of the array.
-    unsigned  gtElemSize;   // size of elements in the array
-    unsigned  gtLenOffset;  // The offset from the array's base address to its length.
-    unsigned  gtElemOffset; // The offset from the array's base address to its first element.
+    unsigned gtElemSize;   // size of elements in the array
+    unsigned gtLenOffset;  // The offset from the array's base address to its length.
+    unsigned gtElemOffset; // The offset from the array's base address to its first element.
 
-    GenTreeIndexAddr(GenTree*             arr,
-                     GenTree*             ind,
-                     var_types            elemType,
-                     CORINFO_CLASS_HANDLE structElemClass,
-                     unsigned             elemSize,
-                     unsigned             lenOffset,
-                     unsigned             elemOffset)
+    GenTreeIndexAddr(GenTree* arr, GenTree* ind, unsigned elemSize, unsigned lenOffset, unsigned elemOffset)
         : GenTreeOp(GT_INDEX_ADDR, TYP_BYREF, arr, ind)
-        , gtStructElemClass(structElemClass)
         , gtIndRngFailBB(nullptr)
-        , gtElemType(elemType)
         , gtElemSize(elemSize)
         , gtLenOffset(lenOffset)
         , gtElemOffset(elemOffset)

--- a/src/coreclr/src/jit/lclmorph.cpp
+++ b/src/coreclr/src/jit/lclmorph.cpp
@@ -863,7 +863,7 @@ private:
                 case GT_LCL_FLD:
                     return genTypeSize(indir->TypeGet());
                 case GT_INDEX:
-                    return indir->AsIndex()->gtIndElemSize;
+                    return indir->AsIndex()->GetElemSize();
                 default:
                     break;
             }

--- a/src/coreclr/src/jit/loopcloning.cpp
+++ b/src/coreclr/src/jit/loopcloning.cpp
@@ -37,8 +37,8 @@ GenTree* LC_Array::ToGenTree(Compiler* comp, BasicBlock* bb)
         int      rank = GetDimRank();
         for (int i = 0; i < rank; ++i)
         {
-            arr = comp->gtNewIndexRef(TYP_REF, arr, comp->gtNewLclvNode(arrIndex->indLcls[i],
-                                                                        comp->lvaTable[arrIndex->indLcls[i]].lvType));
+            arr = comp->gtNewArrayIndex(TYP_REF, arr, comp->gtNewLclvNode(arrIndex->indLcls[i],
+                                                                          comp->lvaTable[arrIndex->indLcls[i]].lvType));
         }
         // If asked for arrlen invoke arr length operator.
         if (oper == ArrLen)

--- a/src/coreclr/src/jit/lsraxarch.cpp
+++ b/src/coreclr/src/jit/lsraxarch.cpp
@@ -658,8 +658,8 @@ int LinearScan::BuildNode(GenTree* tree)
             //     it to `long` to peform the address calculation
             internalDef = buildInternalIntRegisterDefForNode(tree);
 #else  // !TARGET_64BIT
-            assert(!varTypeIsLong(tree->AsIndexAddr()->Index()->TypeGet()));
-            switch (tree->AsIndexAddr()->gtElemSize)
+            assert(!varTypeIsLong(tree->AsIndexAddr()->GetIndex()->GetType()));
+            switch (tree->AsIndexAddr()->GetElemSize())
             {
                 case 1:
                 case 2:

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -4898,9 +4898,9 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
 
     // Set up the array length's offset into lenOffs
     // And    the first element's offset into elemOffs
-    ssize_t lenOffs;
-    ssize_t elemOffs;
-    if (tree->gtFlags & GTF_INX_STRING_LAYOUT)
+    uint8_t lenOffs;
+    uint8_t elemOffs;
+    if ((tree->gtFlags & GTF_INX_STRING_LAYOUT) != 0)
     {
         lenOffs  = OFFSETOF__CORINFO_String__stringLen;
         elemOffs = OFFSETOF__CORINFO_String__chars;
@@ -4936,8 +4936,8 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
         GenTree* array = fgMorphTree(asIndex->Arr());
         GenTree* index = fgMorphTree(asIndex->Index());
 
-        GenTreeIndexAddr* indexAddr = new (this, GT_INDEX_ADDR)
-            GenTreeIndexAddr(array, index, elemSize, static_cast<unsigned>(lenOffs), static_cast<unsigned>(elemOffs));
+        GenTreeIndexAddr* indexAddr =
+            new (this, GT_INDEX_ADDR) GenTreeIndexAddr(array, index, elemSize, lenOffs, elemOffs);
         indexAddr->gtFlags |= (array->gtFlags | index->gtFlags) & GTF_ALL_EFFECT;
         INDEBUG(indexAddr->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;)
 

--- a/src/coreclr/src/jit/simd.cpp
+++ b/src/coreclr/src/jit/simd.cpp
@@ -1480,13 +1480,11 @@ bool Compiler::areArrayElementsContiguous(GenTree* op1, GenTree* op2)
     GenTreeIndex* op1Index = op1->AsIndex();
     GenTreeIndex* op2Index = op2->AsIndex();
 
-    GenTree* op1ArrayRef = op1Index->Arr();
-    GenTree* op2ArrayRef = op2Index->Arr();
-    assert(op1ArrayRef->TypeGet() == TYP_REF);
-    assert(op2ArrayRef->TypeGet() == TYP_REF);
+    GenTree* op1ArrayRef = op1Index->GetArray();
+    GenTree* op2ArrayRef = op2Index->GetArray();
 
-    GenTree* op1IndexNode = op1Index->Index();
-    GenTree* op2IndexNode = op2Index->Index();
+    GenTree* op1IndexNode = op1Index->GetIndex();
+    GenTree* op2IndexNode = op2Index->GetIndex();
     if ((op1IndexNode->OperGet() == GT_CNS_INT && op2IndexNode->OperGet() == GT_CNS_INT) &&
         op1IndexNode->AsIntCon()->gtIconVal + 1 == op2IndexNode->AsIntCon()->gtIconVal)
     {
@@ -1589,13 +1587,13 @@ GenTree* Compiler::createAddressNodeForSIMDInit(GenTree* tree, unsigned simdSize
     else if (tree->OperGet() == GT_INDEX)
     {
 
-        GenTree* index = tree->AsIndex()->Index();
+        GenTree* index = tree->AsIndex()->GetIndex();
         assert(index->OperGet() == GT_CNS_INT);
 
         GenTree* checkIndexExpr = nullptr;
         unsigned indexVal       = (unsigned)(index->AsIntCon()->gtIconVal);
         offset                  = indexVal * genTypeSize(tree->TypeGet());
-        GenTree* arrayRef       = tree->AsIndex()->Arr();
+        GenTree* arrayRef       = tree->AsIndex()->GetArray();
 
         // Generate the boundary check exception.
         // The length for boundary check should be the maximum index number which should be


### PR DESCRIPTION
x64 minopts diff:
```
Total bytes of diff: -11 (-0.00% of base)
    diff is an improvement.

Top file regressions (bytes):
           3 : Microsoft.CodeAnalysis.CSharp.dasm (0.00% of base)
           3 : System.Runtime.Serialization.Formatters.dasm (0.00% of base)
           2 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (0.00% of base)

Top file improvements (bytes):
         -15 : System.Security.Cryptography.X509Certificates.dasm (-0.01% of base)
          -3 : Microsoft.CSharp.dasm (-0.00% of base)
          -1 : System.Private.CoreLib.dasm (-0.00% of base)

6 total files with Code Size differences (3 improved, 3 regressed), 261 unchanged.

Top method regressions (bytes):
           3 ( 0.31% of base) : Microsoft.CodeAnalysis.CSharp.dasm - PEMethodSymbol:LoadSignature():SignatureData:this
           3 ( 0.43% of base) : System.Runtime.Serialization.Formatters.dasm - BinaryObjectWithMapTyped:Read(BinaryParser):this
           2 ( 0.84% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - NativeSymbolModule:GetEmbeddedILImage():MemoryStream:this
           2 ( 0.83% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - NativeSymbolModule:GetPseudoAssembly():MemoryStream:this
           1 ( 0.22% of base) : System.Private.CoreLib.dasm - ConcurrentQueueSegment`1:TryDequeue(byref):bool:this

Top method improvements (bytes):
         -15 (-2.97% of base) : System.Security.Cryptography.X509Certificates.dasm - ChainPal:GetChainStatusInformation(int):ref
          -3 (-0.63% of base) : Microsoft.CSharp.dasm - RuntimeBinder:BindIsEvent(CSharpIsEventBinder,ref,ref):Expr:this
          -2 (-1.80% of base) : System.Private.CoreLib.dasm - Vector64DebugView`1:get_ByteView():ref:this
          -1 (-0.49% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - NativeSymbolModule:GetFuncMDTokenMap():ref:this
          -1 (-0.49% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - NativeSymbolModule:GetTypeMDTokenMap():ref:this

Top method regressions (percentages):
           2 ( 0.84% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - NativeSymbolModule:GetEmbeddedILImage():MemoryStream:this
           2 ( 0.83% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - NativeSymbolModule:GetPseudoAssembly():MemoryStream:this
           3 ( 0.43% of base) : System.Runtime.Serialization.Formatters.dasm - BinaryObjectWithMapTyped:Read(BinaryParser):this
           3 ( 0.31% of base) : Microsoft.CodeAnalysis.CSharp.dasm - PEMethodSymbol:LoadSignature():SignatureData:this
           1 ( 0.22% of base) : System.Private.CoreLib.dasm - ConcurrentQueueSegment`1:TryDequeue(byref):bool:this

Top method improvements (percentages):
         -15 (-2.97% of base) : System.Security.Cryptography.X509Certificates.dasm - ChainPal:GetChainStatusInformation(int):ref
          -2 (-1.80% of base) : System.Private.CoreLib.dasm - Vector64DebugView`1:get_ByteView():ref:this
          -3 (-0.63% of base) : Microsoft.CSharp.dasm - RuntimeBinder:BindIsEvent(CSharpIsEventBinder,ref,ref):Expr:this
          -1 (-0.49% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - NativeSymbolModule:GetFuncMDTokenMap():ref:this
          -1 (-0.49% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - NativeSymbolModule:GetTypeMDTokenMap():ref:this

10 total methods with Code Size differences (5 improved, 5 regressed), 196330 unchanged.
```
Changes in the tree shape affect call arg evaluation order, which in turn affects register allocation. In ChainPal:GetChainStatusInformation the new evaluation order avoids introducing a byref temp and its prolog initialization.