### PR TITLE
Cleanup some field sequence mess

### DIFF
--- a/src/coreclr/src/jit/assertionprop.cpp
+++ b/src/coreclr/src/jit/assertionprop.cpp
@@ -2691,7 +2691,6 @@ GenTree* Compiler::optConstantAssertionProp(AssertionDsc*        curAssertion,
             }
             else
             {
-                bool isArrIndex = ((tree->gtFlags & GTF_VAR_ARR_INDEX) != 0);
                 // If we have done constant propagation of a struct type, it is only valid for zero-init,
                 // and we have to ensure that we have the right zero for the type.
                 if (varTypeIsStruct(tree))
@@ -2723,13 +2722,6 @@ GenTree* Compiler::optConstantAssertionProp(AssertionDsc*        curAssertion,
                         newTree->ChangeType(TYP_INT);
                     }
                 }
-                // If we're doing an array index address, assume any constant propagated contributes to the index.
-                if (isArrIndex)
-                {
-                    newTree->AsIntCon()->gtFieldSeq =
-                        GetFieldSeqStore()->CreateSingleton(FieldSeqStore::ConstantIndexPseudoField);
-                }
-                newTree->gtFlags &= ~GTF_VAR_ARR_INDEX;
             }
 
             // Constant ints are of type TYP_INT, not any of the short forms.

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -8577,6 +8577,10 @@ void cTreeFlags(Compiler* comp, GenTree* tree)
                 {
                     chars += printf("[FLD_VOLATILE]");
                 }
+                if (tree->gtFlags & GTF_FLD_TLS_REF)
+                {
+                    chars += printf("[FLD_TLS_REF]");
+                }
                 break;
 
             case GT_INDEX:
@@ -8601,10 +8605,6 @@ void cTreeFlags(Compiler* comp, GenTree* tree)
                 if (tree->gtFlags & GTF_IND_TGT_NOT_HEAP)
                 {
                     chars += printf("[IND_TGT_NOT_HEAP]");
-                }
-                if (tree->gtFlags & GTF_IND_TLS_REF)
-                {
-                    chars += printf("[IND_TLS_REF]");
                 }
                 if (tree->gtFlags & GTF_IND_ASG_LHS)
                 {

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -8577,10 +8577,12 @@ void cTreeFlags(Compiler* comp, GenTree* tree)
                 {
                     chars += printf("[FLD_VOLATILE]");
                 }
+#if defined(TARGET_X86) && defined(TARGET_WINDOWS)
                 if (tree->gtFlags & GTF_FLD_TLS_REF)
                 {
                     chars += printf("[FLD_TLS_REF]");
                 }
+#endif
                 break;
 
             case GT_INDEX:

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -8562,11 +8562,6 @@ void cTreeFlags(Compiler* comp, GenTree* tree)
                 break;
 
             case GT_NOP:
-
-                if (tree->gtFlags & GTF_NOP_DEATH)
-                {
-                    chars += printf("[NOP_DEATH]");
-                }
                 break;
 
             case GT_NO_OP:

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -8782,11 +8782,6 @@ void cTreeFlags(Compiler* comp, GenTree* tree)
 
                         chars += printf("[ICON_BBC_PTR]");
                         break;
-
-                    case GTF_ICON_FIELD_OFF:
-
-                        chars += printf("[ICON_FIELD_OFF]");
-                        break;
                 }
             }
             break;

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -8553,10 +8553,6 @@ void cTreeFlags(Compiler* comp, GenTree* tree)
                 {
                     chars += printf("[VAR_DEATH]");
                 }
-                if (tree->gtFlags & GTF_VAR_ARR_INDEX)
-                {
-                    chars += printf("[VAR_ARR_INDEX]");
-                }
 #if defined(DEBUG)
                 if (tree->gtDebugFlags & GTF_DEBUG_VAR_CSE_REF)
                 {

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -2315,6 +2315,46 @@ public:
     // the given "fldHnd", is such an object pointer.
     bool gtIsStaticFieldPtrToBoxedStruct(var_types fieldNodeType, CORINFO_FIELD_HANDLE fldHnd);
 
+    // If returns "true", "addr" may represent the address of a static or instance field
+    // (or a field of such a field, in the case of an object field of type struct).
+    // If returns "true", then either "*pObj" is set to the object reference,
+    // or "*pStatic" is set to the baseAddr or offset to be added to the "*pFldSeq"
+    // Only one of "*pObj" or "*pStatic" will be set, the other one will be null.
+    // The boolean return value only indicates that "this" *may* be a field address
+    // -- the field sequence must also be checked.
+    // If it is a field address, the field sequence will be a sequence of length >= 1,
+    // starting with an instance or static field, and optionally continuing with struct fields.
+    bool optIsFieldAddr(GenTree* addr, GenTree** pObj, GenTree** pStatic, FieldSeqNode** pFldSeq);
+
+    // Requires "addr" to be the address of an array (the child of a GT_IND labeled with GTF_IND_ARR_INDEX).
+    // Sets "pArr" to the node representing the array (either an array object pointer, or perhaps a byref to the some
+    // element).
+    // Sets "*pArrayType" to the class handle for the array type.
+    // Sets "*inxVN" to the value number inferred for the array index.
+    // Sets "*pFldSeq" to the sequence, if any, of struct fields used to index into the array element.
+    bool optParseArrayAddress(
+        GenTree* addr, const ArrayInfo* arrayInfo, GenTree** pArr, ValueNum* pInxVN, FieldSeqNode** pFldSeq);
+
+    // Helper method for the above.
+    void optParseArrayAddressWork(GenTree*        addr,
+                                  target_ssize_t  scale,
+                                  GenTree**       pArr,
+                                  ValueNum*       pInxVN,
+                                  target_ssize_t* pOffset,
+                                  FieldSeqNode**  pFldSeq);
+
+    // Requires "indir" to be a GT_IND.
+    // Returns true if it is an array index expression. If it returns true, sets *arrayInfo to the
+    // array information.
+    bool optIsArrayElem(GenTreeIndir* indir, ArrayInfo* arrayInfo);
+
+    // Requires "addr" to be the address of a (possible) array element (or struct field within that).
+    // If it is, sets "*arrayInfo" to the array access info and returns true.  If not, returns "false".
+    bool optIsArrayElemAddr(GenTree* addr, ArrayInfo* arrayInfo);
+
+    // Requires "offset" to be an int expression.
+    bool optIsOffset(GenTree* offset) const;
+
     // Return true if call is a recursive call; return false otherwise.
     // Note when inlining, this looks for calls back to the root method.
     bool gtIsRecursiveCall(GenTreeCall* call)

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -9091,9 +9091,7 @@ public:
         Compiler* compRoot = impInlineRoot();
         if (compRoot->m_fieldSeqStore == nullptr)
         {
-            // Create a CompAllocator that labels sub-structure with CMK_FieldSeqStore, and use that for allocation.
-            CompAllocator ialloc(getAllocator(CMK_FieldSeqStore));
-            compRoot->m_fieldSeqStore = new (ialloc) FieldSeqStore(ialloc);
+            compRoot->m_fieldSeqStore = new (this, CMK_FieldSeqStore) FieldSeqStore(this);
         }
         return compRoot->m_fieldSeqStore;
     }

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -1204,17 +1204,21 @@ LinearScanInterface* getLinearScanAllocator(Compiler* comp);
 struct ArrayInfo
 {
     var_types            m_elemType;
-    CORINFO_CLASS_HANDLE m_elemStructType;
+    uint8_t              m_elemOffset;
     unsigned             m_elemSize;
-    unsigned             m_elemOffset;
+    CORINFO_CLASS_HANDLE m_elemStructType;
 
-    ArrayInfo() : m_elemType(TYP_UNDEF), m_elemStructType(nullptr), m_elemSize(0), m_elemOffset(0)
+    ArrayInfo() : m_elemType(TYP_UNDEF), m_elemOffset(0), m_elemSize(0), m_elemStructType(nullptr)
     {
     }
 
     ArrayInfo(var_types elemType, unsigned elemSize, unsigned elemOffset, CORINFO_CLASS_HANDLE elemStructType)
-        : m_elemType(elemType), m_elemStructType(elemStructType), m_elemSize(elemSize), m_elemOffset(elemOffset)
+        : m_elemType(elemType)
+        , m_elemOffset(static_cast<uint8_t>(elemOffset))
+        , m_elemSize(elemSize)
+        , m_elemStructType(elemStructType)
     {
+        assert(elemOffset <= UINT8_MAX);
     }
 };
 

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -4955,6 +4955,7 @@ public:
 
 private:
     GenTree* fgMorphField(GenTree* tree, MorphAddrContext* mac);
+    GenTree* fgMorphStaticField(GenTreeField* field, MorphAddrContext* mac);
     bool fgCanFastTailCall(GenTreeCall* call, const char** failReason);
 #if FEATURE_FASTTAILCALL
     bool fgCallHasMustCopyByrefParameter(CallInfo* callInfo);

--- a/src/coreclr/src/jit/compiler.hpp
+++ b/src/coreclr/src/jit/compiler.hpp
@@ -1001,7 +1001,7 @@ inline GenTree* Compiler::gtNewLargeOperNode(genTreeOps oper, var_types type, Ge
 inline GenTree* Compiler::gtNewIconHandleNode(size_t value, unsigned flags, FieldSeqNode* fields)
 {
     GenTree* node;
-    assert((flags & (GTF_ICON_HDL_MASK | GTF_ICON_FIELD_OFF)) != 0);
+    assert((flags & GTF_ICON_HDL_MASK) != 0);
 
     // Interpret "fields == NULL" as "not a field."
     if (fields == nullptr)

--- a/src/coreclr/src/jit/earlyprop.cpp
+++ b/src/coreclr/src/jit/earlyprop.cpp
@@ -431,16 +431,6 @@ GenTree* Compiler::optEarlyPropRewriteTree(GenTree* tree, LocalNumberToNullCheck
             actualValClone->gtType = tree->gtType;
         }
 
-        // Propagating a constant into an array index expression requires calling
-        // LabelIndex to update the FieldSeq annotations.  EarlyProp may replace
-        // array length expressions with constants, so check if this is an array
-        // length operator that is part of an array index expression.
-        bool isIndexExpr = (tree->OperGet() == GT_ARR_LENGTH && ((tree->gtFlags & GTF_ARRLEN_ARR_IDX) != 0));
-        if (isIndexExpr)
-        {
-            actualValClone->LabelIndex(this);
-        }
-
         // actualValClone has small tree node size, it is safe to use CopyFrom here.
         tree->ReplaceWith(actualValClone, this);
 

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -15972,7 +15972,7 @@ bool Compiler::optIsFieldAddr(GenTree* addr, GenTree** pObj, GenTree** pStatic, 
         return true;
     }
 
-    if ((baseAddr == nullptr) || mustBeStatic)
+    if (mustBeStatic)
     {
         return false;
     }

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -5807,15 +5807,7 @@ GenTreeLclFld* Compiler::gtNewLclFldAddrNode(unsigned lclNum, unsigned lclOffs, 
 
 GenTreeLclFld* Compiler::gtNewLclFldNode(unsigned lnum, var_types type, unsigned offset)
 {
-    GenTreeLclFld* node = new (this, GT_LCL_FLD) GenTreeLclFld(GT_LCL_FLD, type, lnum, offset);
-
-    /* Cannot have this assert because the inliner uses this function
-     * to add temporaries */
-
-    // assert(lnum < lvaCount);
-
-    node->SetFieldSeq(FieldSeqStore::NotAField());
-    return node;
+    return new (this, GT_LCL_FLD) GenTreeLclFld(GT_LCL_FLD, type, lnum, offset);
 }
 
 GenTreeRetExpr* Compiler::gtNewInlineCandidateReturnExpr(GenTree* inlineCandidate, var_types type, uint64_t bbFlags)

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -6638,8 +6638,7 @@ GenTree* Compiler::gtClone(GenTree* tree, bool complexOK)
             break;
 
         case GT_CLS_VAR:
-            copy = new (this, GT_CLS_VAR)
-                GenTreeClsVar(tree->gtType, tree->AsClsVar()->gtClsVarHnd, tree->AsClsVar()->gtFieldSeq);
+            copy = new (this, GT_CLS_VAR) GenTreeClsVar(tree->AsClsVar());
             break;
 
         default:
@@ -6655,12 +6654,12 @@ GenTree* Compiler::gtClone(GenTree* tree, bool complexOK)
                 // copied from line 9850
 
                 objp = nullptr;
-                if (tree->AsField()->gtFldObj)
+                if (tree->AsField()->gtFldObj != nullptr)
                 {
                     objp = gtClone(tree->AsField()->gtFldObj, false);
-                    if (!objp)
+                    if (objp == nullptr)
                     {
-                        return objp;
+                        return nullptr;
                     }
                 }
 
@@ -6826,8 +6825,7 @@ GenTree* Compiler::gtCloneExpr(
                 goto DONE;
 
             case GT_CLS_VAR:
-                copy = new (this, GT_CLS_VAR)
-                    GenTreeClsVar(tree->TypeGet(), tree->AsClsVar()->gtClsVarHnd, tree->AsClsVar()->gtFieldSeq);
+                copy = new (this, GT_CLS_VAR) GenTreeClsVar(tree->AsClsVar());
                 goto DONE;
 
             case GT_RET_EXPR:
@@ -7109,7 +7107,7 @@ GenTree* Compiler::gtCloneExpr(
 
             copy = gtNewFieldRef(tree->TypeGet(), tree->AsField()->gtFldHnd, nullptr, tree->AsField()->gtFldOffset);
 
-            copy->AsField()->gtFldObj = tree->AsField()->gtFldObj
+            copy->AsField()->gtFldObj = tree->AsField()->gtFldObj != nullptr
                                             ? gtCloneExpr(tree->AsField()->gtFldObj, addFlags, deepVarNum, deepVarVal)
                                             : nullptr;
             copy->AsField()->gtFldMayOverlap = tree->AsField()->gtFldMayOverlap;
@@ -10016,8 +10014,8 @@ void Compiler::gtDispLeaf(GenTree* tree, IndentStack* indentStack)
         break;
 
         case GT_CLS_VAR:
-            printf(" Hnd=%#x", dspPtr(tree->AsClsVar()->gtClsVarHnd));
-            gtDispFieldSeq(tree->AsClsVar()->gtFieldSeq);
+            printf(" Hnd=%#x", dspPtr(tree->AsClsVar()->GetFieldHandle()));
+            gtDispFieldSeq(tree->AsClsVar()->GetFieldSeq());
             break;
 
         case GT_CLS_VAR_ADDR:
@@ -15878,12 +15876,7 @@ bool Compiler::optIsFieldAddr(GenTree* addr, GenTree** pObj, GenTree** pStatic, 
         }
         else if (GenTreeClsVar* clsVar = addr->IsClsVar())
         {
-            FieldSeqNode* fieldSeq = clsVar->GetFieldSeq();
-
-            if ((fieldSeq != nullptr) && (fieldSeq->m_next == nullptr))
-            {
-                staticStructFldSeq = fieldSeq;
-            }
+            staticStructFldSeq = clsVar->GetFieldSeq();
         }
         else if (addr->OperIsLocal())
         {

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -15846,7 +15846,7 @@ bool Compiler::optIsFieldAddr(GenTree* addr, GenTree** pObj, GenTree** pStatic, 
 
     if ((fieldSeq == nullptr) || (fieldSeq == FieldSeqStore::NotAField()))
     {
-        // If we can't find a field sequence then it's not a field addres.
+        // If we can't find a field sequence then it's not a field address.
         return false;
     }
 
@@ -15967,6 +15967,15 @@ bool Compiler::optIsFieldAddr(GenTree* addr, GenTree** pObj, GenTree** pStatic, 
     }
     else
     {
+        if (fieldSeq->IsBoxedValueField())
+        {
+            // Ignore boxed value fields, the same (pseudo) field is used for all boxed types
+            // so a store to such a field may alias multiple actual fields. These can only be
+            // disambiguated when used together with a static field.
+
+            return false;
+        }
+
         assert(!info.compCompHnd->isValueClass(info.compCompHnd->getFieldClass(fieldSeq->GetFieldHandle())));
 
         *pObj    = addr;

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -9097,12 +9097,6 @@ int Compiler::gtDispNodeHeader(GenTree* tree, IndentStack* indentStack, int msgL
                         --msgLength;
                         break;
                     }
-                    else if ((tree->gtFlags & GTF_ICON_FIELD_OFF) != 0)
-                    {
-                        printf("O");
-                        --msgLength;
-                        break;
-                    }
                     else
                     {
                         // Some other handle
@@ -9796,11 +9790,6 @@ void Compiler::gtDispConst(GenTree* tree)
                             printf(" UNKNOWN");
                             break;
                     }
-                }
-
-                if ((tree->gtFlags & GTF_ICON_FIELD_OFF) != 0)
-                {
-                    printf(" field offset");
                 }
 
 #ifdef FEATURE_SIMD

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -15967,6 +15967,8 @@ bool Compiler::optIsFieldAddr(GenTree* addr, GenTree** pObj, GenTree** pStatic, 
     }
     else
     {
+        assert(!info.compCompHnd->isValueClass(info.compCompHnd->getFieldClass(fieldSeq->GetFieldHandle())));
+
         *pObj    = addr;
         *pStatic = nullptr;
         *pFldSeq = fieldSeq;

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -17105,44 +17105,15 @@ void Compiler::optParseArrayAddressWork(GenTree*        addr,
         GenTree*       nonConstOp = nullptr;
         GenTreeIntCon* constOp    = nullptr;
 
-        if (op1->OperIs(GT_CNS_INT))
-        {
-            if (op2->OperIs(GT_CNS_INT))
-            {
-                // If the other arg is an int constant, and is a "not-a-field", choose
-                // that as the multiplier, thus preserving constant index offsets...
-
-                GenTreeIntCon* fieldSeqOp;
-
-                if (op2->AsIntCon()->GetFieldSeq() == FieldSeqStore::NotAField())
-                {
-                    fieldSeqOp = op1->AsIntCon();
-                }
-                else
-                {
-                    fieldSeqOp = op2->AsIntCon();
-                }
-
-                *pFldSeq = GetFieldSeqStore()->Append(*pFldSeq, fieldSeqOp->GetFieldSeq());
-
-                assert(!op1->AsIntCon()->ImmedValNeedsReloc(this));
-                assert(!op2->AsIntCon()->ImmedValNeedsReloc(this));
-
-                // TODO-CrossBitness: we wouldn't need the cast below if GenTreeIntConCommon::gtIconVal had
-                // target_ssize_t type.
-                *pOffset += static_cast<target_ssize_t>(op1->AsIntCon()->GetValue()) *
-                            static_cast<target_ssize_t>(op2->AsIntCon()->GetValue());
-
-                return;
-            }
-
-            constOp    = op1->AsIntCon();
-            nonConstOp = op2;
-        }
-        else if (op2->OperIs(GT_CNS_INT))
+        if (op2->OperIs(GT_CNS_INT))
         {
             nonConstOp = op1;
             constOp    = op2->AsIntCon();
+        }
+        else if (op1->OperIs(GT_CNS_INT))
+        {
+            constOp    = op1->AsIntCon();
+            nonConstOp = op2;
         }
 
         if (nonConstOp != nullptr)

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -17260,7 +17260,7 @@ void GenTree::ParseArrayAddressWork(Compiler*       comp,
     }
 }
 
-bool GenTree::ParseArrayElemForm(Compiler* comp, ArrayInfo* arrayInfo, FieldSeqNode** pFldSeq)
+bool GenTree::ParseArrayElemForm(Compiler* comp, ArrayInfo* arrayInfo)
 {
     if (OperIsIndir())
     {
@@ -17273,7 +17273,7 @@ bool GenTree::ParseArrayElemForm(Compiler* comp, ArrayInfo* arrayInfo, FieldSeqN
 
         // Otherwise...
         GenTree* addr = AsIndir()->Addr();
-        return addr->ParseArrayElemAddrForm(comp, arrayInfo, pFldSeq);
+        return addr->ParseArrayElemAddrForm(comp, arrayInfo);
     }
     else
     {
@@ -17281,7 +17281,7 @@ bool GenTree::ParseArrayElemForm(Compiler* comp, ArrayInfo* arrayInfo, FieldSeqN
     }
 }
 
-bool GenTree::ParseArrayElemAddrForm(Compiler* comp, ArrayInfo* arrayInfo, FieldSeqNode** pFldSeq)
+bool GenTree::ParseArrayElemAddrForm(Compiler* comp, ArrayInfo* arrayInfo)
 {
     switch (OperGet())
     {
@@ -17303,11 +17303,11 @@ bool GenTree::ParseArrayElemAddrForm(Compiler* comp, ArrayInfo* arrayInfo, Field
             {
                 return false;
             }
-            if (!offset->ParseOffsetForm(comp, pFldSeq))
+            if (!offset->ParseOffsetForm(comp))
             {
                 return false;
             }
-            return arrAddr->ParseArrayElemAddrForm(comp, arrayInfo, pFldSeq);
+            return arrAddr->ParseArrayElemAddrForm(comp, arrayInfo);
         }
 
         case GT_ADDR:
@@ -17319,13 +17319,7 @@ bool GenTree::ParseArrayElemAddrForm(Compiler* comp, ArrayInfo* arrayInfo, Field
             }
             else
             {
-                // The "Addr" node might be annotated with a zero-offset field sequence.
-                FieldSeqNode* zeroOffsetFldSeq = nullptr;
-                if (comp->GetZeroOffsetFieldMap()->Lookup(this, &zeroOffsetFldSeq))
-                {
-                    *pFldSeq = comp->GetFieldSeqStore()->Append(*pFldSeq, zeroOffsetFldSeq);
-                }
-                return addrArg->ParseArrayElemForm(comp, arrayInfo, pFldSeq);
+                return addrArg->ParseArrayElemForm(comp, arrayInfo);
             }
         }
 
@@ -17334,23 +17328,19 @@ bool GenTree::ParseArrayElemAddrForm(Compiler* comp, ArrayInfo* arrayInfo, Field
     }
 }
 
-bool GenTree::ParseOffsetForm(Compiler* comp, FieldSeqNode** pFldSeq)
+bool GenTree::ParseOffsetForm(Compiler* comp)
 {
     switch (OperGet())
     {
         case GT_CNS_INT:
-        {
-            GenTreeIntCon* icon = AsIntCon();
-            *pFldSeq            = comp->GetFieldSeqStore()->Append(*pFldSeq, icon->gtFieldSeq);
             return true;
-        }
 
         case GT_ADD:
-            if (!AsOp()->gtOp1->ParseOffsetForm(comp, pFldSeq))
+            if (!AsOp()->gtOp1->ParseOffsetForm(comp))
             {
                 return false;
             }
-            return AsOp()->gtOp2->ParseOffsetForm(comp, pFldSeq);
+            return AsOp()->gtOp2->ParseOffsetForm(comp);
 
         default:
             return false;

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -3061,6 +3061,11 @@ struct GenTreeIntCon : public GenTreeIntConCommon
         return gtFieldSeq;
     }
 
+    void SetFieldSeq(FieldSeqNode* fieldSeq)
+    {
+        gtFieldSeq = fieldSeq;
+    }
+
     void FixupInitBlkValue(var_types asgType);
 
 #ifdef TARGET_64BIT

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -850,6 +850,7 @@ public:
 
 #define GTF_NOP_DEATH               0x40000000 // GT_NOP -- operand dies here
 
+#define GTF_FLD_TLS_REF             0x08000000 // GT_FIELD            -- the target is accessed via TLS
 #define GTF_FLD_VOLATILE            0x40000000 // GT_FIELD/GT_CLS_VAR -- same as GTF_IND_VOLATILE
 #define GTF_FLD_INITCLASS           0x20000000 // GT_FIELD/GT_CLS_VAR -- field access requires preceding class/static init helper
 
@@ -860,7 +861,6 @@ public:
 #define GTF_IND_NONFAULTING         0x20000000 // Operations for which OperIsIndir() is true  -- An indir that cannot fault.
                                                // Same as GTF_ARRLEN_NONFAULTING.
 #define GTF_IND_TGT_HEAP            0x10000000 // GT_IND   -- the target is known to be on the heap
-#define GTF_IND_TLS_REF             0x08000000 // GT_IND   -- the target is accessed via TLS
 #define GTF_IND_ASG_LHS             0x04000000 // GT_IND   -- this GT_IND node is (the effective val) of the LHS of an
                                                //             assignment; don't evaluate it independently.
 #define GTF_IND_REQ_ADDR_IN_REG GTF_IND_ASG_LHS // GT_IND  -- requires its addr operand to be evaluated
@@ -875,7 +875,7 @@ public:
 #define GTF_IND_ARR_INDEX           0x00800000 // GT_IND   -- the indirection represents an (SZ) array index
 
 #define GTF_IND_FLAGS \
-    (GTF_IND_VOLATILE | GTF_IND_TGT_HEAP | GTF_IND_NONFAULTING | GTF_IND_TLS_REF |          \
+    (GTF_IND_VOLATILE | GTF_IND_TGT_HEAP | GTF_IND_NONFAULTING |           \
      GTF_IND_UNALIGNED | GTF_IND_INVARIANT | GTF_IND_ARR_INDEX | GTF_IND_TGT_NOT_HEAP)
 
 #define GTF_CLS_VAR_VOLATILE        0x40000000 // GT_FIELD/GT_CLS_VAR -- same as GTF_IND_VOLATILE

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -3597,6 +3597,11 @@ public:
         }
     }
 
+    CORINFO_FIELD_HANDLE GetFieldHandle() const
+    {
+        return gtFldHnd;
+    }
+
     unsigned GetOffset() const
     {
         return gtFldOffset;

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -1911,19 +1911,16 @@ public:
                                FieldSeqNode**  pFldSeq);
 
     // Requires "this" to be a GT_IND.  Requires the outermost caller to set "*pFldSeq" to nullptr.
-    // Returns true if it is an array index expression, or access to a (sequence of) struct field(s)
-    // within a struct array element.  If it returns true, sets *arrayInfo to the array information, and sets *pFldSeq
-    // to the sequence of struct field accesses.
-    bool ParseArrayElemForm(Compiler* comp, ArrayInfo* arrayInfo, FieldSeqNode** pFldSeq);
+    // Returns true if it is an array index expression. If it returns true, sets *arrayInfo to the
+    // array information.
+    bool ParseArrayElemForm(Compiler* comp, ArrayInfo* arrayInfo);
 
     // Requires "this" to be the address of a (possible) array element (or struct field within that).
-    // If it is, sets "*arrayInfo" to the array access info, "*pFldSeq" to the sequence of struct fields
-    // accessed within the array element, and returns true.  If not, returns "false".
-    bool ParseArrayElemAddrForm(Compiler* comp, ArrayInfo* arrayInfo, FieldSeqNode** pFldSeq);
+    // If it is, sets "*arrayInfo" to the array access info and returns true.  If not, returns "false".
+    bool ParseArrayElemAddrForm(Compiler* comp, ArrayInfo* arrayInfo);
 
-    // Requires "this" to be an int expression.  If it is a sequence of one or more integer constants added together,
-    // returns true and sets "*pFldSeq" to the sequence of fields with which those constants are annotated.
-    bool ParseOffsetForm(Compiler* comp, FieldSeqNode** pFldSeq);
+    // Requires "this" to be an int expression.
+    bool ParseOffsetForm(Compiler* comp);
 
     // Labels "*this" as an array index expression: label all constants and variables that could contribute, as part of
     // an affine expression, to the value of the of the index.

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -1899,29 +1899,33 @@ public:
     // Sets "*pArrayType" to the class handle for the array type.
     // Sets "*inxVN" to the value number inferred for the array index.
     // Sets "*pFldSeq" to the sequence, if any, of struct fields used to index into the array element.
-    void ParseArrayAddress(
-        Compiler* comp, struct ArrayInfo* arrayInfo, GenTree** pArr, ValueNum* pInxVN, FieldSeqNode** pFldSeq);
+    bool ParseArrayAddress(
+        Compiler* comp, const struct ArrayInfo* arrayInfo, GenTree** pArr, ValueNum* pInxVN, FieldSeqNode** pFldSeq);
 
+private:
     // Helper method for the above.
     void ParseArrayAddressWork(Compiler*       comp,
-                               target_ssize_t  inputMul,
+                               target_ssize_t  scale,
                                GenTree**       pArr,
                                ValueNum*       pInxVN,
                                target_ssize_t* pOffset,
                                FieldSeqNode**  pFldSeq);
 
+public:
     // Requires "this" to be a GT_IND.  Requires the outermost caller to set "*pFldSeq" to nullptr.
     // Returns true if it is an array index expression. If it returns true, sets *arrayInfo to the
     // array information.
-    bool ParseArrayElemForm(Compiler* comp, ArrayInfo* arrayInfo);
+    bool ParseArrayElemForm(Compiler* comp, ArrayInfo* arrayInfo) const;
 
+private:
     // Requires "this" to be the address of a (possible) array element (or struct field within that).
     // If it is, sets "*arrayInfo" to the array access info and returns true.  If not, returns "false".
-    bool ParseArrayElemAddrForm(Compiler* comp, ArrayInfo* arrayInfo);
+    bool ParseArrayElemAddrForm(Compiler* comp, ArrayInfo* arrayInfo) const;
 
     // Requires "this" to be an int expression.
-    bool ParseOffsetForm(Compiler* comp);
+    bool ParseOffsetForm(Compiler* comp) const;
 
+public:
     // Labels "*this" as an array index expression: label all constants and variables that could contribute, as part of
     // an affine expression, to the value of the of the index.
     void LabelIndex(Compiler* comp, bool isConst = true);

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -239,10 +239,8 @@ struct FieldSeqNode
     {
     }
 
-    // returns true when this is the pseudo #FirstElem field sequence
-    bool IsFirstElemFieldSeq();
+    bool IsBoxedValueField();
 
-    // returns true when this is the the pseudo #FirstElem field sequence or the pseudo #ConstantIndex field sequence
     bool IsPseudoField() const;
 
     CORINFO_FIELD_HANDLE GetFieldHandle() const
@@ -285,8 +283,8 @@ class FieldSeqStore
 
     static FieldSeqNode s_notAField; // No value, just exists to provide an address.
 
-    // Dummy variables to provide the addresses for the "pseudo field handle" statics below.
-    static int FirstElemPseudoFieldStruct;
+    // Dummy variable to provide an address for the "Boxed Value" pseudo field handle.
+    static int BoxedValuePseudoFieldStruct;
 
 public:
     FieldSeqStore(Compiler* compiler);
@@ -312,14 +310,10 @@ public:
 
     // We have a few "pseudo" field handles:
 
-    // This treats the constant offset of the first element of something as if it were a field.
-    // Works for method table offsets of boxed structs, or first elem offset of arrays/strings.
-    static CORINFO_FIELD_HANDLE FirstElemPseudoField;
-
-    static bool IsPseudoField(CORINFO_FIELD_HANDLE hnd)
-    {
-        return hnd == FirstElemPseudoField;
-    }
+    // The boxed value field identifies the value part of a boxed value object.
+    // Used with static struct fields which are implemented as static reference
+    // fields pointing to boxed structs allocated by the runtime.
+    static const CORINFO_FIELD_HANDLE BoxedValuePseudoFieldHandle;
 };
 
 class GenTreeUseEdgeIterator;

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -850,7 +850,9 @@ public:
 
 #define GTF_NOP_DEATH               0x40000000 // GT_NOP -- operand dies here
 
+#if defined(TARGET_X86) && defined(TARGET_WINDOWS)
 #define GTF_FLD_TLS_REF             0x08000000 // GT_FIELD            -- the target is accessed via TLS
+#endif
 #define GTF_FLD_VOLATILE            0x40000000 // GT_FIELD/GT_CLS_VAR -- same as GTF_IND_VOLATILE
 #define GTF_FLD_INITCLASS           0x20000000 // GT_FIELD/GT_CLS_VAR -- field access requires preceding class/static init helper
 

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -6965,6 +6965,11 @@ struct GenTreeClsVar : public GenTree
         gtFlags |= GTF_GLOB_REF;
     }
 
+    FieldSeqNode* GetFieldSeq() const
+    {
+        return gtFieldSeq;
+    }
+
 #if DEBUGGABLE_GENTREE
     GenTreeClsVar() : GenTree()
     {

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -921,7 +921,6 @@ public:
 #define GTF_ICON_CIDMID_HDL         0xE0000000 // GT_CNS_INT -- constant is a class ID or a module ID
 #define GTF_ICON_BBC_PTR            0xF0000000 // GT_CNS_INT -- constant is a basic block count pointer
 
-#define GTF_ICON_FIELD_OFF          0x08000000 // GT_CNS_INT -- constant is a field offset
 #define GTF_ICON_SIMD_COUNT         0x04000000 // GT_CNS_INT -- constant is Vector<T>.Count
 
 #define GTF_ICON_INITCLASS          0x02000000 // GT_CNS_INT -- Constant is used to access a static that requires preceding

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -3431,7 +3431,7 @@ public:
         : GenTreeLclVarCommon(oper, type, lclNum)
         , m_lclOffs(static_cast<uint16_t>(lclOffs))
         , m_layoutNum(0)
-        , m_fieldSeq(nullptr)
+        , m_fieldSeq(FieldSeqStore::NotAField())
     {
         assert(lclOffs <= UINT16_MAX);
     }

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -848,8 +848,6 @@ public:
 
 #define GTF_MEMORYBARRIER_LOAD      0x40000000 // GT_MEMORYBARRIER -- Load barrier
 
-#define GTF_NOP_DEATH               0x40000000 // GT_NOP -- operand dies here
-
 #if defined(TARGET_X86) && defined(TARGET_WINDOWS)
 #define GTF_FLD_TLS_REF             0x08000000 // GT_FIELD            -- the target is accessed via TLS
 #endif

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -1872,50 +1872,6 @@ public:
     // where Y is an arbitrary tree, and X is a lclVar.
     unsigned IsLclVarUpdateTree(GenTree** otherTree, genTreeOps* updateOper);
 
-    // If returns "true", "this" may represent the address of a static or instance field
-    // (or a field of such a field, in the case of an object field of type struct).
-    // If returns "true", then either "*pObj" is set to the object reference,
-    // or "*pStatic" is set to the baseAddr or offset to be added to the "*pFldSeq"
-    // Only one of "*pObj" or "*pStatic" will be set, the other one will be null.
-    // The boolean return value only indicates that "this" *may* be a field address
-    // -- the field sequence must also be checked.
-    // If it is a field address, the field sequence will be a sequence of length >= 1,
-    // starting with an instance or static field, and optionally continuing with struct fields.
-    bool IsFieldAddr(Compiler* comp, GenTree** pObj, GenTree** pStatic, FieldSeqNode** pFldSeq);
-
-    // Requires "this" to be the address of an array (the child of a GT_IND labeled with GTF_IND_ARR_INDEX).
-    // Sets "pArr" to the node representing the array (either an array object pointer, or perhaps a byref to the some
-    // element).
-    // Sets "*pArrayType" to the class handle for the array type.
-    // Sets "*inxVN" to the value number inferred for the array index.
-    // Sets "*pFldSeq" to the sequence, if any, of struct fields used to index into the array element.
-    bool ParseArrayAddress(
-        Compiler* comp, const struct ArrayInfo* arrayInfo, GenTree** pArr, ValueNum* pInxVN, FieldSeqNode** pFldSeq);
-
-private:
-    // Helper method for the above.
-    void ParseArrayAddressWork(Compiler*       comp,
-                               target_ssize_t  scale,
-                               GenTree**       pArr,
-                               ValueNum*       pInxVN,
-                               target_ssize_t* pOffset,
-                               FieldSeqNode**  pFldSeq);
-
-public:
-    // Requires "this" to be a GT_IND.  Requires the outermost caller to set "*pFldSeq" to nullptr.
-    // Returns true if it is an array index expression. If it returns true, sets *arrayInfo to the
-    // array information.
-    bool ParseArrayElemForm(Compiler* comp, ArrayInfo* arrayInfo) const;
-
-private:
-    // Requires "this" to be the address of a (possible) array element (or struct field within that).
-    // If it is, sets "*arrayInfo" to the array access info and returns true.  If not, returns "false".
-    bool ParseArrayElemAddrForm(Compiler* comp, ArrayInfo* arrayInfo) const;
-
-    // Requires "this" to be an int expression.
-    bool ParseOffsetForm(Compiler* comp) const;
-
-public:
     // Assumes that "this" occurs in a context where it is being dereferenced as the LHS of an assignment-like
     // statement (assignment, initblk, or copyblk).  The "width" should be the number of bytes copied by the
     // operation.  Returns "true" if "this" is an address of (or within)

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -279,6 +279,7 @@ class FieldSeqStore
 {
     typedef JitHashTable<FieldSeqNode, /*KeyFuncs*/ FieldSeqNode, FieldSeqNode*> FieldSeqNodeCanonMap;
 
+    Compiler*             m_compiler;
     CompAllocator         m_alloc;
     FieldSeqNodeCanonMap* m_canonMap;
 
@@ -288,7 +289,7 @@ class FieldSeqStore
     static int FirstElemPseudoFieldStruct;
 
 public:
-    FieldSeqStore(CompAllocator alloc);
+    FieldSeqStore(Compiler* compiler);
 
     // Returns the (canonical in the store) singleton field sequence for the given handle.
     FieldSeqNode* CreateSingleton(CORINFO_FIELD_HANDLE fieldHnd);
@@ -306,6 +307,8 @@ public:
     // they are the results of CreateSingleton, NotAField, or Append calls.  If either of the arguments
     // are the "NotAField" value, so is the result.
     FieldSeqNode* Append(FieldSeqNode* a, FieldSeqNode* b);
+
+    INDEBUG(void DebugCheck(FieldSeqNode* f);)
 
     // We have a few "pseudo" field handles:
 

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -6116,14 +6116,12 @@ GenTree* Compiler::impImportStaticFieldAccess(CORINFO_RESOLVED_TOKEN* pResolvedT
                     op1->gtFlags |= GTF_FLD_INITCLASS;
                 }
 
-                if (pFieldInfo->fieldFlags & CORINFO_FLG_FIELD_STATIC_IN_HEAP)
+                if ((pFieldInfo->fieldFlags & CORINFO_FLG_FIELD_STATIC_IN_HEAP) != 0)
                 {
-                    op1->gtType = TYP_REF; // points at boxed object
-                    FieldSeqNode* firstElemFldSeq =
-                        GetFieldSeqStore()->CreateSingleton(FieldSeqStore::FirstElemPseudoField);
-                    op1 = gtNewOperNode(GT_ADD, TYP_BYREF, op1,
-                                        new (this, GT_CNS_INT)
-                                            GenTreeIntCon(TYP_I_IMPL, TARGET_POINTER_SIZE, firstElemFldSeq));
+                    op1->SetType(TYP_REF); // points at boxed object
+                    FieldSeqNode* fieldSeq =
+                        GetFieldSeqStore()->CreateSingleton(FieldSeqStore::BoxedValuePseudoFieldHandle);
+                    op1 = gtNewOperNode(GT_ADD, TYP_BYREF, op1, gtNewIconNode(TARGET_POINTER_SIZE, fieldSeq));
 
                     if (varTypeIsStruct(lclTyp))
                     {
@@ -6144,14 +6142,13 @@ GenTree* Compiler::impImportStaticFieldAccess(CORINFO_RESOLVED_TOKEN* pResolvedT
         }
     }
 
-    if (pFieldInfo->fieldFlags & CORINFO_FLG_FIELD_STATIC_IN_HEAP)
+    if ((pFieldInfo->fieldFlags & CORINFO_FLG_FIELD_STATIC_IN_HEAP) != 0)
     {
         op1 = gtNewOperNode(GT_IND, TYP_REF, op1);
 
-        FieldSeqNode* fldSeq = GetFieldSeqStore()->CreateSingleton(FieldSeqStore::FirstElemPseudoField);
+        FieldSeqNode* fieldSeq = GetFieldSeqStore()->CreateSingleton(FieldSeqStore::BoxedValuePseudoFieldHandle);
 
-        op1 = gtNewOperNode(GT_ADD, TYP_BYREF, op1,
-                            new (this, GT_CNS_INT) GenTreeIntCon(TYP_I_IMPL, TARGET_POINTER_SIZE, fldSeq));
+        op1 = gtNewOperNode(GT_ADD, TYP_BYREF, op1, gtNewIconNode(TARGET_POINTER_SIZE, fieldSeq));
     }
 
     if (!(access & CORINFO_ACCESS_ADDRESS))

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -12543,7 +12543,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
                         /* Create the data member node */
                         op1 = gtNewFieldRef(lclTyp, resolvedToken.hField, nullptr, fieldInfo.offset);
-                        op1->gtFlags |= GTF_IND_TLS_REF; // fgMorphField will handle the transformation
+                        op1->gtFlags |= GTF_FLD_TLS_REF; // fgMorphField will handle the transformation
 
                         if (isLoadAddress)
                         {
@@ -12838,7 +12838,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
                         /* Create the data member node */
                         op1 = gtNewFieldRef(lclTyp, resolvedToken.hField, nullptr, fieldInfo.offset);
-                        op1->gtFlags |= GTF_IND_TLS_REF; // fgMorphField will handle the transformation
+                        op1->gtFlags |= GTF_FLD_TLS_REF; // fgMorphField will handle the transformation
 
                         break;
 #else

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -12542,7 +12542,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         // Legacy TLS access is implemented as intrinsic on x86 only
 
                         /* Create the data member node */
-                        op1 = gtNewFieldRef(lclTyp, resolvedToken.hField, NULL, fieldInfo.offset);
+                        op1 = gtNewFieldRef(lclTyp, resolvedToken.hField, nullptr, fieldInfo.offset);
                         op1->gtFlags |= GTF_IND_TLS_REF; // fgMorphField will handle the transformation
 
                         if (isLoadAddress)
@@ -12837,7 +12837,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         // Legacy TLS access is implemented as intrinsic on x86 only
 
                         /* Create the data member node */
-                        op1 = gtNewFieldRef(lclTyp, resolvedToken.hField, NULL, fieldInfo.offset);
+                        op1 = gtNewFieldRef(lclTyp, resolvedToken.hField, nullptr, fieldInfo.offset);
                         op1->gtFlags |= GTF_IND_TLS_REF; // fgMorphField will handle the transformation
 
                         break;

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -12538,7 +12538,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     break;
 
                     case CORINFO_FIELD_STATIC_TLS:
-#ifdef TARGET_X86
+#if defined(TARGET_X86) && defined(TARGET_WINDOWS)
                         // Legacy TLS access is implemented as intrinsic on x86 only
 
                         /* Create the data member node */
@@ -12833,7 +12833,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     break;
 
                     case CORINFO_FIELD_STATIC_TLS:
-#ifdef TARGET_X86
+#if defined(TARGET_X86) && defined(TARGET_WINDOWS)
                         // Legacy TLS access is implemented as intrinsic on x86 only
 
                         /* Create the data member node */

--- a/src/coreclr/src/jit/lclmorph.cpp
+++ b/src/coreclr/src/jit/lclmorph.cpp
@@ -1115,10 +1115,8 @@ private:
 
         if ((fieldSeq != nullptr) && (fieldSeq != FieldSeqStore::NotAField()))
         {
-            // TODO-ADDR: ObjectAllocator produces FIELD nodes with FirstElemPseudoField as field
-            // handle so we cannot use FieldSeqNode::GetFieldHandle() because it asserts on such
-            // handles. ObjectAllocator should be changed to create LCL_FLD nodes directly.
-            assert(!indir->OperIs(GT_FIELD) || (indir->AsField()->gtFldHnd == fieldSeq->GetTail()->m_fieldHnd));
+            assert(!indir->OperIs(GT_FIELD) ||
+                   (indir->AsField()->GetFieldHandle() == fieldSeq->GetTail()->GetFieldHandle()));
         }
         else
         {

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -5632,6 +5632,7 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
             }
 
             tlsRef = gtNewOperNode(GT_IND, TYP_I_IMPL, tlsRef);
+            tlsRef->gtFlags |= GTF_IND_NONFAULTING | GTF_IND_INVARIANT;
 
             if (dllRef != nullptr)
             {

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -5309,7 +5309,7 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
         GenTree* addr;
         objIsLocal = objRef->IsLocal();
 
-        if (tree->gtFlags & GTF_IND_TLS_REF)
+        if ((tree->gtFlags & GTF_FLD_TLS_REF) != 0)
         {
             NO_WAY("instance field can not be a TLS ref.");
         }
@@ -5559,8 +5559,10 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
     }
     else /* This is a static data member */
     {
-        if ((tree->gtFlags & GTF_IND_TLS_REF) != 0)
+        if ((tree->gtFlags & GTF_FLD_TLS_REF) != 0)
         {
+            tree->gtFlags &= ~GTF_FLD_TLS_REF;
+
             // TODO-MIKE-Cleanup: It looks like all this code should be ifdef-ed out on all targets but win-x86.
             // There's no way it would work on win-x64 because the TLS array's TEB offset isn't 0x2c like on x86.
             // The name and description of GTF_ICON_TLS_HDL is also messed up, it has nothing to do with TLS,
@@ -5652,8 +5654,6 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
 
             tree->SetOper(GT_IND);
             tree->AsIndir()->SetAddr(tlsRef);
-
-            noway_assert((tree->gtFlags & GTF_IND_TLS_REF) != 0);
 
             return fgMorphSmpOp(tree, mac);
         }

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -5523,8 +5523,8 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
         {
             FieldSeqNode* fieldSeq =
                 fieldMayOverlap ? FieldSeqStore::NotAField() : GetFieldSeqStore()->CreateSingleton(fldHandle);
-            addr = gtNewOperNode(GT_ADD, (var_types)(objRefType == TYP_I_IMPL ? TYP_I_IMPL : TYP_BYREF), addr,
-                                 gtNewIconHandleNode(fldOffset, GTF_ICON_FIELD_OFF, fieldSeq));
+            addr = gtNewOperNode(GT_ADD, (objRefType == TYP_I_IMPL) ? TYP_I_IMPL : TYP_BYREF, addr,
+                                 gtNewIconNode(fldOffset, fieldSeq));
         }
 
         // Now let's set the "tree" as a GT_IND tree.

--- a/src/coreclr/src/jit/objectalloc.cpp
+++ b/src/coreclr/src/jit/objectalloc.cpp
@@ -545,26 +545,10 @@ unsigned int ObjectAllocator::MorphAllocObjNodeIntoStackAlloc(GenTreeAllocObj* a
         comp->compSuppressedZeroInit = true;
     }
 
-    //------------------------------------------------------------------------
-    // STMTx (IL 0x... ???)
-    //   * ASG       long
-    //   +--*  FIELD     long   #PseudoField:0x0
-    //   |  \--*  ADDR      byref
-    //   |     \--*  LCL_VAR   struct
-    //   \--*  CNS_INT(h) long
-    //------------------------------------------------------------------------
+    GenTreeOp* methodTableAssignment =
+        comp->gtNewAssignNode(comp->gtNewLclFldNode(lclNum, TYP_I_IMPL, 0), allocObj->GetOp(0));
 
-    // Create a local representing the object
-    GenTree* tree = comp->gtNewLclvNode(lclNum, TYP_STRUCT);
-
-    // Add a pseudo-field for the method table pointer and initialize it
-    tree = comp->gtNewOperNode(GT_ADDR, TYP_BYREF, tree);
-    tree = comp->gtNewFieldRef(TYP_I_IMPL, FieldSeqStore::FirstElemPseudoField, tree, 0);
-    tree = comp->gtNewAssignNode(tree, allocObj->gtGetOp1());
-
-    Statement* newStmt = comp->gtNewStmt(tree);
-
-    comp->fgInsertStmtBefore(block, stmt, newStmt);
+    comp->fgInsertStmtBefore(block, stmt, comp->gtNewStmt(methodTableAssignment));
 
     return lclNum;
 }

--- a/src/coreclr/src/jit/optimizer.cpp
+++ b/src/coreclr/src/jit/optimizer.cpp
@@ -7753,14 +7753,6 @@ bool Compiler::optComputeLoopSideEffectsOfBlock(BasicBlock* blk)
 
                         if (optIsFieldAddr(arg, &obj, &staticOffset, &fldSeq))
                         {
-                            // Get the first (object) field from field seq.  GcHeap[field] will yield the "field map".
-                            assert(fldSeq != nullptr);
-                            if (fldSeq->IsBoxedValueField())
-                            {
-                                fldSeq = fldSeq->m_next;
-                                assert(fldSeq != nullptr);
-                            }
-
                             AddModifiedFieldAllContainingLoops(mostNestedLoop, fldSeq->m_fieldHnd);
                             // Conservatively assume byrefs may alias this object.
                             memoryHavoc |= memoryKindSet(ByrefExposed);

--- a/src/coreclr/src/jit/optimizer.cpp
+++ b/src/coreclr/src/jit/optimizer.cpp
@@ -7755,7 +7755,7 @@ bool Compiler::optComputeLoopSideEffectsOfBlock(BasicBlock* blk)
                         {
                             // Get the first (object) field from field seq.  GcHeap[field] will yield the "field map".
                             assert(fldSeq != nullptr);
-                            if (fldSeq->IsFirstElemFieldSeq())
+                            if (fldSeq->IsBoxedValueField())
                             {
                                 fldSeq = fldSeq->m_next;
                                 assert(fldSeq != nullptr);

--- a/src/coreclr/src/jit/optimizer.cpp
+++ b/src/coreclr/src/jit/optimizer.cpp
@@ -7699,8 +7699,7 @@ bool Compiler::optComputeLoopSideEffectsOfBlock(BasicBlock* blk)
 
                 if (lhs->OperGet() == GT_IND)
                 {
-                    GenTree*      arg           = lhs->AsOp()->gtOp1->gtEffectiveVal(/*commaOnly*/ true);
-                    FieldSeqNode* fldSeqArrElem = nullptr;
+                    GenTree* arg = lhs->AsOp()->gtOp1->gtEffectiveVal(/*commaOnly*/ true);
 
                     if ((tree->gtFlags & GTF_IND_VOLATILE) != 0)
                     {
@@ -7736,7 +7735,7 @@ bool Compiler::optComputeLoopSideEffectsOfBlock(BasicBlock* blk)
                         memoryHavoc |= memoryKindSet(GcHeap, ByrefExposed);
                     }
                     // Is the LHS an array index expression?
-                    else if (lhs->ParseArrayElemForm(this, &arrInfo, &fldSeqArrElem))
+                    else if (lhs->ParseArrayElemForm(this, &arrInfo))
                     {
                         // We actually ignore "fldSeq" -- any modification to an S[], at any
                         // field of "S", will lose all information about the array type.

--- a/src/coreclr/src/jit/optimizer.cpp
+++ b/src/coreclr/src/jit/optimizer.cpp
@@ -7751,7 +7751,7 @@ bool Compiler::optComputeLoopSideEffectsOfBlock(BasicBlock* blk)
                         GenTree*      staticOffset = nullptr; // unused
                         FieldSeqNode* fldSeq       = nullptr;
 
-                        if (optIsFieldAddr(arg, &obj, &staticOffset, &fldSeq) && (fldSeq != FieldSeqStore::NotAField()))
+                        if (optIsFieldAddr(arg, &obj, &staticOffset, &fldSeq))
                         {
                             // Get the first (object) field from field seq.  GcHeap[field] will yield the "field map".
                             assert(fldSeq != nullptr);

--- a/src/coreclr/src/jit/optimizer.cpp
+++ b/src/coreclr/src/jit/optimizer.cpp
@@ -7734,10 +7734,9 @@ bool Compiler::optComputeLoopSideEffectsOfBlock(BasicBlock* blk)
                         // Otherwise...
                         memoryHavoc |= memoryKindSet(GcHeap, ByrefExposed);
                     }
-                    // Is the LHS an array index expression?
-                    else if (lhs->ParseArrayElemForm(this, &arrInfo))
+                    else if (optIsArrayElem(lhs->AsIndir(), &arrInfo))
                     {
-                        // We actually ignore "fldSeq" -- any modification to an S[], at any
+                        // We actually ignore field sequences -- any modification to an S[], at any
                         // field of "S", will lose all information about the array type.
                         CORINFO_CLASS_HANDLE elemTypeEq = EncodeElemType(arrInfo.m_elemType, arrInfo.m_elemStructType);
                         AddModifiedElemTypeAllContainingLoops(mostNestedLoop, elemTypeEq);
@@ -7752,8 +7751,7 @@ bool Compiler::optComputeLoopSideEffectsOfBlock(BasicBlock* blk)
                         GenTree*      staticOffset = nullptr; // unused
                         FieldSeqNode* fldSeq       = nullptr;
 
-                        if (arg->IsFieldAddr(this, &obj, &staticOffset, &fldSeq) &&
-                            (fldSeq != FieldSeqStore::NotAField()))
+                        if (optIsFieldAddr(arg, &obj, &staticOffset, &fldSeq) && (fldSeq != FieldSeqStore::NotAField()))
                         {
                             // Get the first (object) field from field seq.  GcHeap[field] will yield the "field map".
                             assert(fldSeq != nullptr);

--- a/src/coreclr/src/jit/valuenum.cpp
+++ b/src/coreclr/src/jit/valuenum.cpp
@@ -3559,7 +3559,7 @@ ValueNum ValueNumStore::VNApplySelectors(ValueNumKind  vnk,
     {
         assert(fieldSeq != FieldSeqStore::NotAField());
 
-        // Skip any "FirstElem" pseudo-fields or any "ConstantIndex" pseudo-fields
+        // Skip any pseudo-fields
         if (fieldSeq->IsPseudoField())
         {
             return VNApplySelectors(vnk, map, fieldSeq->m_next, wbFinalStructSize);
@@ -3725,7 +3725,7 @@ ValueNum ValueNumStore::VNApplySelectorsAssign(
     {
         assert(fieldSeq != FieldSeqStore::NotAField());
 
-        // Skip any "FirstElem" pseudo-fields or any "ConstantIndex" pseudo-fields
+        // Skip any pseudo-fields.
         // These will occur, at least, in struct static expressions, for method table offsets.
         if (fieldSeq->IsPseudoField())
         {
@@ -5190,9 +5190,9 @@ void ValueNumStore::vnDumpFieldSeq(Compiler* comp, VNFuncApp* fieldSeq, bool isH
     }
 
     CORINFO_FIELD_HANDLE fldHnd = CORINFO_FIELD_HANDLE(fieldHndVal);
-    if (fldHnd == FieldSeqStore::FirstElemPseudoField)
+    if (fldHnd == FieldSeqStore::BoxedValuePseudoFieldHandle)
     {
-        printf("#FirstElem");
+        printf("#BoxedValue");
     }
     else
     {
@@ -7586,7 +7586,7 @@ void Compiler::fgValueNumberTree(GenTree* tree)
 
                                 // Get the first (instance or static) field from field seq.  GcHeap[field] will yield
                                 // the "field map".
-                                if (fldSeq->IsFirstElemFieldSeq())
+                                if (fldSeq->IsBoxedValueField())
                                 {
                                     fldSeq = fldSeq->m_next;
                                     assert(fldSeq != nullptr);

--- a/src/coreclr/src/jit/valuenum.cpp
+++ b/src/coreclr/src/jit/valuenum.cpp
@@ -7563,17 +7563,6 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                         }
                         else if (optIsFieldAddr(arg, &obj, &staticOffset, &fldSeq))
                         {
-#ifdef DEBUG
-                            if (obj != nullptr)
-                            {
-                                // Make sure that the class containing it is not a value class (as we are expecting
-                                // an instance field)
-                                CORINFO_CLASS_HANDLE fldCls = info.compCompHnd->getFieldClass(fldSeq->m_fieldHnd);
-                                assert((info.compCompHnd->getClassAttribs(fldCls) & CORINFO_FLG_VALUECLASS) == 0);
-                                assert(staticOffset == nullptr);
-                            }
-#endif // DEBUG
-
                             // Get the first (instance or static) field from field seq.  GcHeap[field] will yield
                             // the "field map".
                             if (fldSeq->IsBoxedValueField())
@@ -7981,18 +7970,6 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                 {
                     // Get the first (instance or static) field from field seq.  GcHeap[field] will yield the "field
                     // map".
-                    CLANG_FORMAT_COMMENT_ANCHOR;
-
-#ifdef DEBUG
-                    if (obj != nullptr)
-                    {
-                        // Make sure that the class containing it is not a value class (as we are expecting an
-                        // instance field)
-                        CORINFO_CLASS_HANDLE fldCls = info.compCompHnd->getFieldClass(fldSeq2->m_fieldHnd);
-                        assert((info.compCompHnd->getClassAttribs(fldCls) & CORINFO_FLG_VALUECLASS) == 0);
-                        assert(staticOffset == nullptr);
-                    }
-#endif // DEBUG
 
                     // Get a field sequence for just the first field in the sequence
                     //

--- a/src/coreclr/src/jit/valuenum.cpp
+++ b/src/coreclr/src/jit/valuenum.cpp
@@ -7574,11 +7574,11 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                             {
                                 assert(fldSeq != nullptr);
 #ifdef DEBUG
-                                CORINFO_CLASS_HANDLE fldCls = info.compCompHnd->getFieldClass(fldSeq->m_fieldHnd);
                                 if (obj != nullptr)
                                 {
                                     // Make sure that the class containing it is not a value class (as we are expecting
                                     // an instance field)
+                                    CORINFO_CLASS_HANDLE fldCls = info.compCompHnd->getFieldClass(fldSeq->m_fieldHnd);
                                     assert((info.compCompHnd->getClassAttribs(fldCls) & CORINFO_FLG_VALUECLASS) == 0);
                                     assert(staticOffset == nullptr);
                                 }
@@ -8005,11 +8005,11 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                         CLANG_FORMAT_COMMENT_ANCHOR;
 
 #ifdef DEBUG
-                        CORINFO_CLASS_HANDLE fldCls = info.compCompHnd->getFieldClass(fldSeq2->m_fieldHnd);
                         if (obj != nullptr)
                         {
                             // Make sure that the class containing it is not a value class (as we are expecting an
                             // instance field)
+                            CORINFO_CLASS_HANDLE fldCls = info.compCompHnd->getFieldClass(fldSeq2->m_fieldHnd);
                             assert((info.compCompHnd->getClassAttribs(fldCls) & CORINFO_FLG_VALUECLASS) == 0);
                             assert(staticOffset == nullptr);
                         }

--- a/src/coreclr/src/jit/valuenum.cpp
+++ b/src/coreclr/src/jit/valuenum.cpp
@@ -7542,8 +7542,7 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                             FieldSeqNode* fldSeq = nullptr;
                             GenTree*      arr    = nullptr;
 
-                            arg->ParseArrayAddress(this, &arrInfo, &arr, &inxVN, &fldSeq);
-                            if (arr == nullptr)
+                            if (!arg->ParseArrayAddress(this, &arrInfo, &arr, &inxVN, &fldSeq))
                             {
                                 fgMutateGcHeap(tree DEBUGARG("assignment to unparseable array expression"));
                                 return;
@@ -7879,8 +7878,7 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                 FieldSeqNode* fldSeq = nullptr;
                 GenTree*      arr    = nullptr;
 
-                addr->ParseArrayAddress(this, &arrInfo, &arr, &inxVN, &fldSeq);
-                if (arr == nullptr)
+                if (!addr->ParseArrayAddress(this, &arrInfo, &arr, &inxVN, &fldSeq))
                 {
                     tree->gtVNPair.SetBoth(vnStore->VNForExpr(compCurBB, tree->TypeGet()));
                     return;

--- a/src/coreclr/src/jit/valuenum.cpp
+++ b/src/coreclr/src/jit/valuenum.cpp
@@ -7563,16 +7563,7 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                         }
                         else if (optIsFieldAddr(arg, &obj, &staticOffset, &fldSeq))
                         {
-                            // Get the first (instance or static) field from field seq.  GcHeap[field] will yield
-                            // the "field map".
-                            if (fldSeq->IsBoxedValueField())
-                            {
-                                fldSeq = fldSeq->m_next;
-                                assert(fldSeq != nullptr);
-                            }
-
                             // Get a field sequence for just the first field in the sequence
-                            //
                             FieldSeqNode* firstFieldOnly = GetFieldSeqStore()->CreateSingleton(fldSeq->m_fieldHnd);
 
                             // The final field in the sequence will need to match the 'indType'
@@ -7968,11 +7959,7 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                 }
                 else if (optIsFieldAddr(addr, &obj, &staticOffset, &fldSeq2))
                 {
-                    // Get the first (instance or static) field from field seq.  GcHeap[field] will yield the "field
-                    // map".
-
                     // Get a field sequence for just the first field in the sequence
-                    //
                     FieldSeqNode* firstFieldOnly = GetFieldSeqStore()->CreateSingleton(fldSeq2->m_fieldHnd);
                     size_t        structSize     = 0;
                     ValueNum      fldMapVN =

--- a/src/coreclr/src/jit/valuenum.cpp
+++ b/src/coreclr/src/jit/valuenum.cpp
@@ -7099,11 +7099,8 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                     // If the static field handle is for a struct type field, then the value of the static
                     // is a "ref" to the boxed struct -- treat it as the address of the static (we assume that a
                     // first element offset will be added to get to the actual struct...)
-                    GenTreeClsVar* clsVar = tree->AsClsVar();
-                    FieldSeqNode*  fldSeq = clsVar->gtFieldSeq;
-                    assert(fldSeq != nullptr); // We need to have one.
-                    ValueNum selectedStaticVar = ValueNumStore::NoVN;
-                    if (gtIsStaticFieldPtrToBoxedStruct(clsVar->TypeGet(), fldSeq->m_fieldHnd))
+                    FieldSeqNode* fldSeq = tree->AsClsVar()->GetFieldSeq();
+                    if (gtIsStaticFieldPtrToBoxedStruct(tree->GetType(), fldSeq->m_fieldHnd))
                     {
                         clsVarVNPair.SetBoth(
                             vnStore->VNForFunc(TYP_BYREF, VNF_PtrToStatic, vnStore->VNForFieldSeq(fldSeq)));
@@ -7115,9 +7112,9 @@ void Compiler::fgValueNumberTree(GenTree* tree)
 
                         FieldSeqNode* fldSeqForStaticVar =
                             GetFieldSeqStore()->CreateSingleton(tree->AsClsVar()->gtClsVarHnd);
-                        size_t structSize = 0;
-                        selectedStaticVar = vnStore->VNApplySelectors(VNK_Liberal, fgCurMemoryVN[GcHeap],
-                                                                      fldSeqForStaticVar, &structSize);
+                        size_t   structSize        = 0;
+                        ValueNum selectedStaticVar = vnStore->VNApplySelectors(VNK_Liberal, fgCurMemoryVN[GcHeap],
+                                                                               fldSeqForStaticVar, &structSize);
                         selectedStaticVar =
                             vnStore->VNApplySelectorsTypeCheck(selectedStaticVar, tree->TypeGet(), structSize);
 

--- a/src/coreclr/src/jit/valuenum.cpp
+++ b/src/coreclr/src/jit/valuenum.cpp
@@ -7538,7 +7538,7 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                             FieldSeqNode* fldSeq = nullptr;
                             GenTree*      arr    = nullptr;
 
-                            if (!arg->ParseArrayAddress(this, &arrInfo, &arr, &inxVN, &fldSeq))
+                            if (!optParseArrayAddress(arg, &arrInfo, &arr, &inxVN, &fldSeq))
                             {
                                 fgMutateGcHeap(tree DEBUGARG("assignment to unparseable array expression"));
                                 return;
@@ -7564,7 +7564,7 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                                                                           rhsVNPair.GetLiberal(), lhs->TypeGet());
                             recordGcHeapStore(tree, heapVN DEBUGARG("ArrIndexAssign (case 2)"));
                         }
-                        else if (arg->IsFieldAddr(this, &obj, &staticOffset, &fldSeq))
+                        else if (optIsFieldAddr(arg, &obj, &staticOffset, &fldSeq))
                         {
                             if (fldSeq == FieldSeqStore::NotAField())
                             {
@@ -7874,7 +7874,7 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                 FieldSeqNode* fldSeq = nullptr;
                 GenTree*      arr    = nullptr;
 
-                if (!addr->ParseArrayAddress(this, &arrInfo, &arr, &inxVN, &fldSeq))
+                if (!optParseArrayAddress(addr, &arrInfo, &arr, &inxVN, &fldSeq))
                 {
                     tree->gtVNPair.SetBoth(vnStore->VNForExpr(compCurBB, tree->TypeGet()));
                     return;
@@ -7992,7 +7992,7 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                 {
                     fgValueNumberArrIndexVal(tree, &funcApp, addrXvnp.GetLiberal());
                 }
-                else if (addr->IsFieldAddr(this, &obj, &staticOffset, &fldSeq2))
+                else if (optIsFieldAddr(addr, &obj, &staticOffset, &fldSeq2))
                 {
                     if (fldSeq2 == FieldSeqStore::NotAField())
                     {

--- a/src/coreclr/src/jit/valuenum.cpp
+++ b/src/coreclr/src/jit/valuenum.cpp
@@ -5194,10 +5194,6 @@ void ValueNumStore::vnDumpFieldSeq(Compiler* comp, VNFuncApp* fieldSeq, bool isH
     {
         printf("#FirstElem");
     }
-    else if (fldHnd == FieldSeqStore::ConstantIndexPseudoField)
-    {
-        printf("#ConstantIndex");
-    }
     else
     {
         const char* modName;


### PR DESCRIPTION
x64 diff:
```
Total bytes of diff: -54 (-0.00% of base)
    diff is an improvement.
Top file improvements (bytes):
         -20 : Newtonsoft.Json.dasm (-0.00% of base)
         -15 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
         -13 : System.Private.Xml.dasm (-0.00% of base)
          -6 : System.Data.Common.dasm (-0.00% of base)
4 total files with Code Size differences (4 improved, 0 regressed), 263 unchanged.
Top method improvements (bytes):
         -13 (-3.05% of base) : System.Private.Xml.dasm - ItemType:Create(int,XmlQualifiedNameTest,XmlSchemaType,bool):XmlQueryType
         -11 (-3.82% of base) : Newtonsoft.Json.dasm - EnumUtils:InternalFlagsFormat(EnumInfo,long):String
          -9 (-2.00% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - TraceGC:GetUserAllocatedPerHeap(List`1,TraceGC,int,int):double
          -9 (-2.92% of base) : Newtonsoft.Json.dasm - StringUtils:ToCamelCase(String):String
          -6 (-1.87% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - TraceGC:GetUserAllocated(List`1,TraceGC,int):double
          -6 (-1.87% of base) : System.Data.Common.dasm - SqlDecimal:CalculatePrecision():ubyte:this
Top method improvements (percentages):
         -11 (-3.82% of base) : Newtonsoft.Json.dasm - EnumUtils:InternalFlagsFormat(EnumInfo,long):String
         -13 (-3.05% of base) : System.Private.Xml.dasm - ItemType:Create(int,XmlQualifiedNameTest,XmlSchemaType,bool):XmlQueryType
          -9 (-2.92% of base) : Newtonsoft.Json.dasm - StringUtils:ToCamelCase(String):String
          -9 (-2.00% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - TraceGC:GetUserAllocatedPerHeap(List`1,TraceGC,int,int):double
          -6 (-1.87% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - TraceGC:GetUserAllocated(List`1,TraceGC,int):double
          -6 (-1.87% of base) : System.Data.Common.dasm - SqlDecimal:CalculatePrecision():ubyte:this
6 total methods with Code Size differences (6 improved, 0 regressed), 196094 unchanged.
```
Diffs due to constant folding of some constant array indices.