### PR TITLE
Don't add a temp when merging byref returns

### DIFF
--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -8596,8 +8596,7 @@ public:
     // Returns true if the method being compiled returns a value
     bool compMethodHasRetVal()
     {
-        return compMethodReturnsNativeScalarType() || compMethodReturnsRetBufAddr() ||
-               compMethodReturnsMultiRegRetType();
+        return compMethodReturnsNativeScalarType() || compMethodReturnsMultiRegRetType();
     }
 
     // Returns true if the method requires a PInvoke prolog and epilog

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -15118,15 +15118,12 @@ void Compiler::fgMergeBlockReturn(BasicBlock* block)
             asg = fgMorphCopyBlock(asg->AsOp());
         }
 
-        if (newLastStmt == lastStmt)
-        {
-            lastStmt->SetRootNode(asg);
-        }
-        else
+        lastStmt->SetRootNode(asg);
+
+        if (newLastStmt != lastStmt)
         {
             fgRemoveStmt(block, lastStmt);
-            Statement* newStmt = gtNewStmt(asg, ilOffset);
-            fgInsertStmtAfter(block, newLastStmt, newStmt);
+            fgInsertStmtAfter(block, newLastStmt, lastStmt);
         }
     }
     else if ((ret != nullptr) && ret->OperIs(GT_RETURN))

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -15136,10 +15136,14 @@ void Compiler::fgMergeBlockReturn(BasicBlock* block)
             noway_assert(lastStmt != nullptr);
             noway_assert(lastStmt->GetNextStmt() == nullptr);
 
-            // Must be a void GT_RETURN with null operand; delete it as this block branches to oneReturn
-            // block
-            noway_assert(ret->TypeGet() == TYP_VOID);
-            noway_assert(ret->gtGetOp1() == nullptr);
+            // If the return buffer address is being returned then we don't have a merged return
+            // temp because the address is just a LCL_VAR. Otherwise this has to be a VOID RETURN.
+
+            if (!compMethodReturnsRetBufAddr())
+            {
+                noway_assert(ret->TypeGet() == TYP_VOID);
+                noway_assert(ret->gtGetOp1() == nullptr);
+            }
 
             fgRemoveStmt(block, lastStmt);
         }

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -15070,91 +15070,89 @@ void Compiler::fgMergeBlockReturn(BasicBlock* block)
     Statement* lastStmt = block->lastStmt();
     GenTree*   ret      = (lastStmt != nullptr) ? lastStmt->GetRootNode() : nullptr;
 
-    if ((ret != nullptr) && (ret->OperGet() == GT_RETURN) && ((ret->gtFlags & GTF_RET_MERGED) != 0))
+    if ((ret != nullptr) && ret->OperIs(GT_RETURN) && ((ret->gtFlags & GTF_RET_MERGED) != 0))
     {
         // This return was generated during epilog merging, so leave it alone
+
+        return;
+    }
+
+#ifndef TARGET_X86
+    if ((info.compFlags & CORINFO_FLG_SYNCH) != 0)
+    {
+        fgConvertSyncReturnToLeave(block);
     }
     else
+#endif
     {
-        // We'll jump to the genReturnBB.
-        CLANG_FORMAT_COMMENT_ANCHOR;
+        block->bbJumpKind = BBJ_ALWAYS;
+        block->bbJumpDest = genReturnBB;
 
-#if !defined(TARGET_X86)
-        if (info.compFlags & CORINFO_FLG_SYNCH)
+        fgAddRefPred(genReturnBB, block);
+        fgReturnCount--;
+    }
+
+    if (genReturnLocal != BAD_VAR_NUM)
+    {
+        noway_assert(compMethodHasRetVal());
+
+        noway_assert(ret != nullptr);
+        noway_assert(ret->OperIs(GT_RETURN));
+        noway_assert(ret->AsUnOp()->gtOp1 != nullptr);
+
+        noway_assert(lastStmt->GetNextStmt() == nullptr);
+
+        // Replace the RETURN with an assignment to the merged return temp.
+        //
+        // The return tree may be a COMMA and then gtNewTempAssign will extract it
+        // to a separate statement, AFTER the assignment statment because we don't
+        // always have a previous statement to pass to gtNewTempAssign. Then we'll
+        // need to move the assignment statement at the end of the block.
+
+        Statement* newLastStmt = lastStmt;
+        IL_OFFSETX ilOffset    = lastStmt->GetILOffsetX();
+        GenTree*   asg = gtNewTempAssign(genReturnLocal, ret->AsUnOp()->GetOp(0), &newLastStmt, ilOffset, block);
+
+        if (asg->OperIsCopyBlkOp())
         {
-            fgConvertSyncReturnToLeave(block);
+            asg = fgMorphCopyBlock(asg->AsOp());
+        }
+
+        if (newLastStmt == lastStmt)
+        {
+            lastStmt->SetRootNode(asg);
         }
         else
-#endif // !TARGET_X86
         {
-            block->bbJumpKind = BBJ_ALWAYS;
-            block->bbJumpDest = genReturnBB;
-            fgAddRefPred(genReturnBB, block);
-            fgReturnCount--;
-        }
-        if (genReturnLocal != BAD_VAR_NUM)
-        {
-            // replace the GT_RETURN node to be a GT_ASG that stores the return value into genReturnLocal.
-
-            // Method must be returning a value other than TYP_VOID.
-            noway_assert(compMethodHasRetVal());
-
-            // This block must be ending with a GT_RETURN
-            noway_assert(lastStmt != nullptr);
-            noway_assert(lastStmt->GetNextStmt() == nullptr);
-            noway_assert(ret != nullptr);
-
-            // GT_RETURN must have non-null operand as the method is returning the value assigned to
-            // genReturnLocal
-            noway_assert(ret->OperGet() == GT_RETURN);
-            noway_assert(ret->gtGetOp1() != nullptr);
-
-            Statement* pAfterStatement = lastStmt;
-            IL_OFFSETX offset          = lastStmt->GetILOffsetX();
-            GenTree*   tree = gtNewTempAssign(genReturnLocal, ret->gtGetOp1(), &pAfterStatement, offset, block);
-            if (tree->OperIsCopyBlkOp())
-            {
-                tree = fgMorphCopyBlock(tree->AsOp());
-            }
-
-            if (pAfterStatement == lastStmt)
-            {
-                lastStmt->SetRootNode(tree);
-            }
-            else
-            {
-                // gtNewTempAssign inserted additional statements after last
-                fgRemoveStmt(block, lastStmt);
-                Statement* newStmt = gtNewStmt(tree, offset);
-                fgInsertStmtAfter(block, pAfterStatement, newStmt);
-                lastStmt = newStmt;
-            }
-        }
-        else if (ret != nullptr && ret->OperGet() == GT_RETURN)
-        {
-            // This block ends with a GT_RETURN
-            noway_assert(lastStmt != nullptr);
-            noway_assert(lastStmt->GetNextStmt() == nullptr);
-
-            // If the return buffer address is being returned then we don't have a merged return
-            // temp because the address is just a LCL_VAR. Otherwise this has to be a VOID RETURN.
-
-            if (!compMethodReturnsRetBufAddr())
-            {
-                noway_assert(ret->TypeGet() == TYP_VOID);
-                noway_assert(ret->gtGetOp1() == nullptr);
-            }
-
             fgRemoveStmt(block, lastStmt);
+            Statement* newStmt = gtNewStmt(asg, ilOffset);
+            fgInsertStmtAfter(block, newLastStmt, newStmt);
         }
-#ifdef DEBUG
-        if (verbose)
-        {
-            printf("morph " FMT_BB " to point at onereturn.  New block is\n", block->bbNum);
-            fgTableDispBasicBlock(block);
-        }
-#endif
     }
+    else if ((ret != nullptr) && ret->OperIs(GT_RETURN))
+    {
+        // If the return buffer address is being returned then we don't have a merged return
+        // temp because the address is just a LCL_VAR. Otherwise this has to be a VOID RETURN.
+
+        if (!compMethodReturnsRetBufAddr())
+        {
+            noway_assert(ret->TypeIs(TYP_VOID));
+            noway_assert(ret->AsUnOp()->gtOp1 == nullptr);
+        }
+
+        noway_assert(lastStmt->GetNextStmt() == nullptr);
+
+        fgRemoveStmt(block, lastStmt);
+    }
+
+#ifdef DEBUG
+    if (verbose)
+    {
+        printf("Return block " FMT_BB " now jumps to merged return block " FMT_BB "\n", block->bbNum,
+               genReturnBB->bbNum);
+        fgTableDispBasicBlock(block);
+    }
+#endif
 }
 
 /*****************************************************************************


### PR DESCRIPTION
win-x64 diff:
```
Total bytes of diff: -1520 (-0.00% of base)
    diff is an improvement.

Top file improvements (bytes):
        -546 : Microsoft.CodeAnalysis.CSharp.dasm (-0.03% of base)
        -138 : System.Runtime.Numerics.dasm (-0.20% of base)
        -135 : System.Private.CoreLib.dasm (-0.00% of base)
        -121 : System.Net.Http.dasm (-0.02% of base)
        -105 : System.Drawing.Primitives.dasm (-0.29% of base)
         -81 : Microsoft.CodeAnalysis.dasm (-0.01% of base)
         -63 : Microsoft.Extensions.Logging.Abstractions.dasm (-0.25% of base)
         -46 : System.Collections.Immutable.dasm (-0.02% of base)
         -45 : System.Private.Xml.dasm (-0.00% of base)
         -42 : System.Data.Common.dasm (-0.00% of base)
         -39 : Newtonsoft.Json.dasm (-0.01% of base)
         -36 : FSharp.Core.dasm (-0.00% of base)
         -24 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
         -24 : System.Threading.Tasks.Parallel.dasm (-0.08% of base)
         -18 : System.Formats.Cbor.dasm (-0.04% of base)
         -18 : System.Private.DataContractSerialization.dasm (-0.00% of base)
         -15 : System.Text.RegularExpressions.dasm (-0.01% of base)
         -12 : System.ComponentModel.TypeConverter.dasm (-0.01% of base)
         -12 : System.Reflection.MetadataLoadContext.dasm (-0.01% of base)

19 total files with Code Size differences (19 improved, 0 regressed), 248 unchanged.

Top method improvements (bytes):
         -93 (-4.12% of base) : System.Drawing.Primitives.dasm - ColorTranslator:FromOle(int):Color
         -75 (-7.31% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LookupPosition:GetFirstIncludedToken(StatementSyntax,bool):SyntaxToken
         -72 (-4.67% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LookupPosition:GetFirstExcludedToken(StatementSyntax):SyntaxToken
         -39 (-2.88% of base) : Microsoft.CodeAnalysis.dasm - MetadataDecoder`5:DecodeCustomAttributePrimitiveElementOrThrow(byref,ubyte,__Canon):TypedConstant:this
         -37 (-4.32% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ConversionsBase:ClassifyExplicitBuiltInOnlyConversion(TypeSymbol,TypeSymbol,byref):Conversion:this
         -37 (-3.28% of base) : System.Net.Http.dasm - HttpConnectionPool:GetConnectionAsync(HttpRequestMessage,bool,CancellationToken):ValueTask`1:this
         -36 (-3.44% of base) : System.Private.CoreLib.dasm - Memory`1:Pin():MemoryHandle:this (4 methods)
         -36 (-3.44% of base) : System.Private.CoreLib.dasm - ReadOnlyMemory`1:Pin():MemoryHandle:this (4 methods)
         -33 (-1.68% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:CheckViability(Symbol,int,int,TypeSymbol,bool,byref,ConsList`1):SingleLookupResult:this
         -30 (-5.60% of base) : System.Data.Common.dasm - BigIntegerStorage:ConvertToBigInteger(Object,IFormatProvider):BigInteger
         -28 (-3.51% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ConversionsBase:ClassifyImplicitBuiltInConversionFromExpression(BoundExpression,TypeSymbol,TypeSymbol,byref):Conversion:this
         -27 (-5.38% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LanguageParser:GetOriginalModifiers(CSharpSyntaxNode):SyntaxTokenList
         -27 (-2.79% of base) : Newtonsoft.Json.dasm - ConvertUtils:ToBigInteger(Object):BigInteger
         -25 (-3.53% of base) : Microsoft.Extensions.Logging.Abstractions.dasm - LogValues`6:get_Item(int):KeyValuePair`2:this
         -24 (-5.76% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - EventPipeEventMetaDataHeader:GetProviderGuidFromProviderName(String):Guid
         -24 (-2.35% of base) : System.Collections.Immutable.dasm - HashBucket:Remove(__Canon,IEqualityComparer`1,byref):HashBucket:this (2 methods)
         -23 (-3.45% of base) : System.Private.CoreLib.dasm - TimeSpanTokenizer:GetNextToken():TimeSpanToken:this
         -22 (-1.54% of base) : System.Collections.Immutable.dasm - HashBucket:Add(__Canon,__Canon,IEqualityComparer`1,IEqualityComparer`1,int,byref):HashBucket:this
         -21 (-4.05% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ConversionsBase:ClassifyStandardConversion(BoundExpression,TypeSymbol,TypeSymbol,byref):Conversion:this
         -21 (-1.72% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CSharpSyntaxRewriter:VisitToken(SyntaxToken):SyntaxToken:this

Top method improvements (percentages):
         -13 (-8.23% of base) : System.Private.CoreLib.dasm - SyncTextWriter:DisposeAsync():ValueTask:this
         -75 (-7.31% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LookupPosition:GetFirstIncludedToken(StatementSyntax,bool):SyntaxToken
         -18 (-6.95% of base) : System.Private.DataContractSerialization.dasm - ValueHandle:ToDecimal():Decimal:this
         -24 (-5.76% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - EventPipeEventMetaDataHeader:GetProviderGuidFromProviderName(String):Guid
         -30 (-5.60% of base) : System.Data.Common.dasm - BigIntegerStorage:ConvertToBigInteger(Object,IFormatProvider):BigInteger
         -27 (-5.38% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LanguageParser:GetOriginalModifiers(CSharpSyntaxNode):SyntaxTokenList
         -12 (-4.92% of base) : System.Runtime.Numerics.dasm - Complex:op_Division(Complex,double):Complex
         -12 (-4.80% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CSharpSemanticModel:GetSpeculativeSymbolInfoCore(int,SyntaxNode,int):SymbolInfo:this
         -18 (-4.72% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CSharpSemanticModel:GetSymbolInfoFromNode(SyntaxNode,CancellationToken):SymbolInfo:this
         -72 (-4.67% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LookupPosition:GetFirstExcludedToken(StatementSyntax):SyntaxToken
         -21 (-4.35% of base) : System.Runtime.Numerics.dasm - BigInteger:Pow(BigInteger,int):BigInteger
         -37 (-4.32% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ConversionsBase:ClassifyExplicitBuiltInOnlyConversion(TypeSymbol,TypeSymbol,byref):Conversion:this
         -93 (-4.12% of base) : System.Drawing.Primitives.dasm - ColorTranslator:FromOle(int):Color
         -21 (-4.05% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ConversionsBase:ClassifyStandardConversion(BoundExpression,TypeSymbol,TypeSymbol,byref):Conversion:this
         -18 (-3.87% of base) : FSharp.Core.dasm - OperatorIntrinsics:loop@5442-13(Decimal,Decimal,int):Decimal
         -18 (-3.86% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ConversionsBase:ClassifyStandardImplicitConversion(TypeSymbol,TypeSymbol,byref):Conversion:this
         -25 (-3.53% of base) : Microsoft.Extensions.Logging.Abstractions.dasm - LogValues`6:get_Item(int):KeyValuePair`2:this
         -28 (-3.51% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ConversionsBase:ClassifyImplicitBuiltInConversionFromExpression(BoundExpression,TypeSymbol,TypeSymbol,byref):Conversion:this
         -21 (-3.46% of base) : Microsoft.Extensions.Logging.Abstractions.dasm - LogValues`5:get_Item(int):KeyValuePair`2:this
         -23 (-3.45% of base) : System.Private.CoreLib.dasm - TimeSpanTokenizer:GetNextToken():TimeSpanToken:this

76 total methods with Code Size differences (76 improved, 0 regressed), 196024 unchanged.
```