### PR TITLE
Always promote single field struct copies

### DIFF
--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -9300,8 +9300,9 @@ GenTree* Compiler::fgMorphCopyBlock(GenTreeOp* asg)
         return nop;
     }
 
-    if ((destLclVar != nullptr) && destLclVar->lvPromoted && (destLclOffs == 0) &&
-        (destLclVar->lvExactSize == destSize) && !destLclVar->lvDoNotEnregister)
+    if ((destLclVar != nullptr) && destLclVar->IsPromoted() && (destLclOffs == 0) &&
+        (destLclVar->lvExactSize == destSize) &&
+        (!destLclVar->lvDoNotEnregister || (destLclVar->GetPromotedFieldCount() == 1)))
     {
         assert(varTypeIsStruct(destLclVar->GetType()));
         assert(destHasSize);
@@ -9316,8 +9317,9 @@ GenTree* Compiler::fgMorphCopyBlock(GenTreeOp* asg)
         JITDUMP(" with mismatched dest offset/size");
     }
 
-    if ((srcLclVar != nullptr) && srcLclVar->lvPromoted && (srcLclOffs == 0) && (srcLclVar->lvExactSize == destSize) &&
-        !srcLclVar->lvDoNotEnregister)
+    if ((srcLclVar != nullptr) && srcLclVar->IsPromoted() && (srcLclOffs == 0) &&
+        (srcLclVar->lvExactSize == destSize) &&
+        (!srcLclVar->lvDoNotEnregister || (srcLclVar->GetPromotedFieldCount() == 1)))
     {
         assert(varTypeIsStruct(srcLclVar->GetType()));
         assert(destHasSize);

--- a/src/coreclr/src/jit/optimizer.cpp
+++ b/src/coreclr/src/jit/optimizer.cpp
@@ -9368,6 +9368,19 @@ void Compiler::optRemoveRedundantZeroInits()
                                 // the prolog and this explicit intialization. Therefore, it doesn't
                                 // require zero initialization in the prolog.
                                 lclDsc->lvHasExplicitInit = 1;
+
+                                // If the local is the only field of a promoted struct local then the
+                                // promoted struct local also doesn't require zero initialization in
+                                // the prolog.
+                                if (lclDsc->IsPromotedField())
+                                {
+                                    LclVarDsc* parentLcl = lvaGetDesc(lclDsc->GetPromotedFieldParentLclNum());
+
+                                    if (parentLcl->GetLayout()->GetSize() == varTypeSize(lclDsc->GetType()))
+                                    {
+                                        parentLcl->lvHasExplicitInit = 1;
+                                    }
+                                }
                             }
                         }
                         break;


### PR DESCRIPTION
x64 diff:
```
Total bytes of base: 32793066
Total bytes of diff: 32792351
Total bytes of delta: -715 (-0.00% of base)
    diff is an improvement.

Top file regressions (bytes):
          36 : xunit.execution.dotnet.dasm (0.02% of base)
          20 : System.Private.CoreLib.dasm (0.00% of base)
          20 : System.Security.Cryptography.X509Certificates.dasm (0.01% of base)
           6 : System.Security.Cryptography.Primitives.dasm (0.02% of base)
           3 : System.Drawing.Common.dasm (0.00% of base)
           1 : System.Net.Http.dasm (0.00% of base)
           1 : System.Net.Quic.dasm (0.00% of base)
           1 : System.Threading.Channels.dasm (0.00% of base)
           1 : System.Threading.Tasks.Dataflow.dasm (0.00% of base)
           1 : xunit.performance.execution.dasm (0.01% of base)

Top file improvements (bytes):
        -312 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.01% of base)
        -229 : Microsoft.CodeAnalysis.CSharp.dasm (-0.01% of base)
         -96 : System.Linq.Parallel.dasm (-0.02% of base)
         -46 : Microsoft.CodeAnalysis.dasm (-0.01% of base)
         -36 : Newtonsoft.Json.dasm (-0.01% of base)
         -36 : System.Data.Common.dasm (-0.00% of base)
         -15 : Newtonsoft.Json.Bson.dasm (-0.02% of base)
          -7 : Microsoft.Extensions.Configuration.Abstractions.dasm (-0.15% of base)
          -6 : xunit.core.dasm (-0.03% of base)
          -6 : xunit.performance.core.dasm (-0.18% of base)
          -5 : System.Private.Xml.dasm (-0.00% of base)
          -4 : System.Runtime.InteropServices.RuntimeInformation.dasm (-0.17% of base)
          -2 : System.Configuration.ConfigurationManager.dasm (-0.00% of base)
          -2 : xunit.assert.dasm (-0.00% of base)
          -1 : FSharp.Core.dasm (-0.00% of base)
          -1 : System.Security.Cryptography.Algorithms.dasm (-0.00% of base)
          -1 : System.Text.RegularExpressions.dasm (-0.00% of base)

27 total files with Code Size differences (17 improved, 10 regressed), 241 unchanged.

Top method regressions (bytes):
         136 (26.05% of base) : System.Private.CoreLib.dasm - RuntimeType:ValidateGenericArguments(MemberInfo,ref,Exception)
          30 ( 7.26% of base) : Microsoft.CodeAnalysis.dasm - AddedOrChangedMethodInfo:MapTypes(SymbolMatcher):AddedOrChangedMethodInfo:this
          24 ( 1.34% of base) : Microsoft.CodeAnalysis.CSharp.dasm - DocumentationCommentCompiler:DefaultVisit(Symbol):this
          21 ( 4.02% of base) : Microsoft.CodeAnalysis.CSharp.dasm - DirectiveParser:ParseElseDirective(SyntaxToken,SyntaxToken,bool,bool):DirectiveTriviaSyntax:this
          18 ( 3.02% of base) : System.Private.CoreLib.dasm - TimeZoneInfo:GetIsAmbiguousTime(DateTime,AdjustmentRule,DaylightTimeStruct):bool
          18 ( 3.02% of base) : System.Private.CoreLib.dasm - TimeZoneInfo:GetIsInvalidTime(DateTime,AdjustmentRule,DaylightTimeStruct):bool
          12 ( 1.61% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SourceConstructorSymbol:.ctor(SourceMemberContainerTypeSymbol,Location,ConstructorDeclarationSyntax,int,DiagnosticBag):this
          11 ( 1.72% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VisualBasicCompilation:StartSourceChecksumCalculation(PEModuleBuilder,DiagnosticBag):bool:this
          10 ( 1.01% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SourceUserDefinedOperatorSymbolBase:.ctor(int,String,SourceMemberContainerTypeSymbol,Location,SyntaxReference,SyntaxReference,SyntaxTokenList,DiagnosticBag,bool):this
          10 ( 1.45% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - TypeSubstitution:CreateAdditionalMethodTypeParameterSubstitution(MethodSymbol,ImmutableArray`1):TypeSubstitution
          10 ( 0.68% of base) : System.Data.Common.dasm - DataSetRelationCollection:AddCore(DataRelation):this
          10 ( 0.58% of base) : xunit.execution.dotnet.dasm - <<RunAsync>b__47_0>d:MoveNext():this
           9 ( 0.60% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SourceMemberMethodSymbol:.ctor(NamedTypeSymbol,TypeSymbol,String,Location,Binder,MethodDeclarationSyntax,int,DiagnosticBag):this
           7 ( 0.52% of base) : Microsoft.CodeAnalysis.CSharp.dasm - OverloadResolution:IsApplicable(Symbol,EffectiveParameters,AnalyzedArguments,ImmutableArray`1,bool,bool,bool,byref):MemberAnalysisResult:this
           6 ( 1.80% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Scanner:GetPreprocessorConstants(VisualBasicParseOptions):ImmutableDictionary`2
           6 ( 0.31% of base) : xunit.execution.dotnet.dasm - <RunAsync>d__41:MoveNext():this
           6 ( 0.36% of base) : xunit.execution.dotnet.dasm - <RunAsync>d__37:MoveNext():this
           6 ( 0.38% of base) : xunit.execution.dotnet.dasm - <RunAsync>d__27:MoveNext():this
           5 ( 0.82% of base) : Microsoft.CodeAnalysis.dasm - SourceFileResolver:.ctor(ImmutableArray`1,String,ImmutableArray`1):this
           5 ( 2.70% of base) : System.Data.Common.dasm - SqlBoolean:.cctor()

Top method improvements (bytes):
        -117 (-2.37% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:ReportOverloadResolutionFailureAndProduceBoundNode(VisualBasicSyntaxNode,int,ArrayBuilder`1,ImmutableArray`1,TypeSymbol,ImmutableArray`1,ImmutableArray`1,DiagnosticBag,VisualBasicSyntaxNode,BoundMethodOrPropertyGroup,Symbol,bool,BoundTypeExpression,Symbol,Location):BoundExpression:this
         -87 (-20.19% of base) : System.Private.CoreLib.dasm - TimeZoneInfo:CheckIsDst(DateTime,DateTime,DateTime,bool,AdjustmentRule):bool
         -71 (-4.28% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - LocalRewriter:VisitUsingStatement(BoundUsingStatement):BoundNode:this
         -69 (-3.85% of base) : System.Linq.Parallel.dasm - OrderedExceptQueryOperatorEnumerator`1:MoveNext(byref,byref):bool:this (2 methods)
         -39 (-2.35% of base) : Microsoft.CodeAnalysis.CSharp.dasm - AnonymousTypeGetHashCodeMethodSymbol:GenerateMethodBody(TypeCompilationState,DiagnosticBag):this
         -36 (-6.33% of base) : Microsoft.CodeAnalysis.dasm - EditAndContinueMethodDebugInformation:SerializeLambdaMap(BlobBuilder):this
         -35 (-3.47% of base) : Microsoft.CodeAnalysis.dasm - RuleSet:GetDiagnosticOptionsFromRulesetFile(Dictionary`2,String,IList`1,CommonMessageProvider):int
         -32 (-1.02% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LanguageParser:ParseNamespaceBody(byref,byref,byref,ushort):this
         -28 (-0.88% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:ReportOverloadResolutionFailureForASetOfCandidates(VisualBasicSyntaxNode,Location,int,int,ArrayBuilder`1,ImmutableArray`1,ImmutableArray`1,DiagnosticBag,Symbol,bool,VisualBasicSyntaxNode):this
         -20 (-9.13% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ExtendedErrorTypeSymbol:ExtractNonErrorType(TypeSymbol):TypeSymbol
         -20 (-7.30% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - MergedTypeDeclaration:MakeChildren():ref:this
         -19 (-4.35% of base) : System.Private.CoreLib.dasm - CurrentSystemTimeZone:GetUtcOffsetFromUniversalTime(DateTime,byref):long:this
         -18 (-6.14% of base) : Microsoft.CodeAnalysis.CSharp.dasm - MergedTypeDeclaration:get_NameLocations():ImmutableArray`1:this
         -18 (-6.57% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - MergedTypeDeclaration:get_NameLocations():ImmutableArray`1:this
         -17 (-5.38% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VisualBasicCommandLineParser:ParseGlobalImports(String,List`1,List`1)
         -16 (-3.96% of base) : System.Linq.Parallel.dasm - OrderedIntersectQueryOperatorEnumerator`1:.ctor(QueryOperatorEnumerator`2,QueryOperatorEnumerator`2,IEqualityComparer`1,IComparer`1,CancellationToken):this (2 methods)
         -15 (-6.25% of base) : Microsoft.CodeAnalysis.CSharp.dasm - TypeWithModifiers:Equals(TypeWithModifiers,bool):bool:this
         -15 (-1.43% of base) : System.Private.CoreLib.dasm - AdjustmentRule:ValidateAdjustmentRule(DateTime,DateTime,TimeSpan,TransitionTime,TransitionTime,bool)
         -14 (-3.02% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SyntaxParser:.ctor(Lexer,int,CSharpSyntaxNode,IEnumerable`1,bool,bool,CancellationToken):this
         -14 (-1.08% of base) : Microsoft.CodeAnalysis.CSharp.dasm - DeclarationTreeBuilder:AddNonTypeMemberNames(CSharpSyntaxNode,HashSet`1,byref)

Top method regressions (percentages):
         136 (26.05% of base) : System.Private.CoreLib.dasm - RuntimeType:ValidateGenericArguments(MemberInfo,ref,Exception)
          30 ( 7.26% of base) : Microsoft.CodeAnalysis.dasm - AddedOrChangedMethodInfo:MapTypes(SymbolMatcher):AddedOrChangedMethodInfo:this
          21 ( 4.02% of base) : Microsoft.CodeAnalysis.CSharp.dasm - DirectiveParser:ParseElseDirective(SyntaxToken,SyntaxToken,bool,bool):DirectiveTriviaSyntax:this
          18 ( 3.02% of base) : System.Private.CoreLib.dasm - TimeZoneInfo:GetIsAmbiguousTime(DateTime,AdjustmentRule,DaylightTimeStruct):bool
          18 ( 3.02% of base) : System.Private.CoreLib.dasm - TimeZoneInfo:GetIsInvalidTime(DateTime,AdjustmentRule,DaylightTimeStruct):bool
           3 ( 2.73% of base) : Microsoft.CodeAnalysis.dasm - AssemblyIdentity:InitializeKey(ImmutableArray`1,bool,byref,byref)
           5 ( 2.70% of base) : System.Data.Common.dasm - SqlBoolean:.cctor()
           3 ( 2.63% of base) : System.Drawing.Common.dasm - TriState:op_Explicit(TriState):bool
           1 ( 2.08% of base) : System.Configuration.ConfigurationManager.dasm - LocationUpdates:get_IsDefault():bool:this
           3 ( 1.84% of base) : Microsoft.CodeAnalysis.dasm - AssemblyIdentity:TryParsePublicKeyToken(String,byref):bool
           6 ( 1.80% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Scanner:GetPreprocessorConstants(VisualBasicParseOptions):ImmutableDictionary`2
          11 ( 1.72% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VisualBasicCompilation:StartSourceChecksumCalculation(PEModuleBuilder,DiagnosticBag):bool:this
          12 ( 1.61% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SourceConstructorSymbol:.ctor(SourceMemberContainerTypeSymbol,Location,ConstructorDeclarationSyntax,int,DiagnosticBag):this
           1 ( 1.52% of base) : Microsoft.CodeAnalysis.CSharp.dasm - PEMethodSymbol:get_CallingConvention():int:this
           1 ( 1.52% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - PEMethodSymbol:get_CallingConvention():int:this
          10 ( 1.45% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - TypeSubstitution:CreateAdditionalMethodTypeParameterSubstitution(MethodSymbol,ImmutableArray`1):TypeSubstitution
           1 ( 1.45% of base) : Microsoft.CodeAnalysis.CSharp.dasm - PlainUnboundLambdaState:get_ParameterCount():int:this
           1 ( 1.41% of base) : Microsoft.CodeAnalysis.CSharp.dasm - PEMethodSymbol:get_IsVararg():bool:this
           1 ( 1.41% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - PEMethodSymbol:get_IsVararg():bool:this
           4 ( 1.41% of base) : System.Threading.Tasks.Dataflow.dasm - SendAsyncSource`1:.ctor(ITargetBlock`1,__Canon,CancellationToken):this

Top method improvements (percentages):
          -6 (-21.43% of base) : System.Configuration.ConfigurationManager.dasm - OverrideModeSetting:CreateFromXmlReadValue(int):OverrideModeSetting
          -7 (-21.21% of base) : System.Private.CoreLib.dasm - RuntimeType:MakePointerType():Type:this
          -7 (-21.21% of base) : System.Private.CoreLib.dasm - RuntimeType:MakeByRefType():Type:this
          -7 (-21.21% of base) : System.Private.CoreLib.dasm - RuntimeType:MakeArrayType():Type:this
         -87 (-20.19% of base) : System.Private.CoreLib.dasm - TimeZoneInfo:CheckIsDst(DateTime,DateTime,DateTime,bool,AdjustmentRule):bool
         -20 (-9.13% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ExtendedErrorTypeSymbol:ExtractNonErrorType(TypeSymbol):TypeSymbol
          -7 (-8.86% of base) : Newtonsoft.Json.dasm - JsonTextWriter:DoWriteValueDelimiterAsync(CancellationToken):Task:this
          -7 (-8.86% of base) : Newtonsoft.Json.dasm - JsonTextWriter:DoWriteIndentSpaceAsync(CancellationToken):Task:this
          -7 (-8.54% of base) : Newtonsoft.Json.dasm - JsonTextWriter:DoWriteRawAsync(String,CancellationToken):Task:this
         -14 (-8.19% of base) : System.Data.Common.dasm - UniqueConstraint:Create(String,ref):this
          -8 (-7.34% of base) : Newtonsoft.Json.Bson.dasm - DateTimeUtils:ToUniversalTicks(DateTime):long
          -8 (-7.34% of base) : Newtonsoft.Json.dasm - DateTimeUtils:ToUniversalTicks(DateTime):long
         -20 (-7.30% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - MergedTypeDeclaration:MakeChildren():ref:this
          -7 (-7.14% of base) : Microsoft.CodeAnalysis.CSharp.dasm - BoundTreeRewriter:VisitStatementList(BoundStatementList):BoundNode:this
          -7 (-6.86% of base) : Microsoft.CodeAnalysis.CSharp.dasm - BoundTreeRewriter:VisitBlock(BoundBlock):BoundNode:this
          -7 (-6.80% of base) : Microsoft.Extensions.Configuration.Abstractions.dasm - ConfigurationRootExtensions:GetDebugView(IConfigurationRoot):String
          -7 (-6.80% of base) : Newtonsoft.Json.Bson.dasm - Base64Encoder:WriteCharsAsync(ref,int,int,CancellationToken):Task:this
          -7 (-6.80% of base) : Newtonsoft.Json.dasm - Base64Encoder:WriteCharsAsync(ref,int,int,CancellationToken):Task:this
         -18 (-6.57% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - MergedTypeDeclaration:get_NameLocations():ImmutableArray`1:this
         -36 (-6.33% of base) : Microsoft.CodeAnalysis.dasm - EditAndContinueMethodDebugInformation:SerializeLambdaMap(BlobBuilder):this

186 total methods with Code Size differences (107 improved, 79 regressed), 195979 unchanged.

41 files had text diffs but no metric diffs.
System.Collections.Immutable.dasm had 1468 diffs
System.Threading.Tasks.Parallel.dasm had 746 diffs
System.Net.Http.WinHttpHandler.dasm had 392 diffs
System.ComponentModel.Composition.dasm had 356 diffs
System.Reflection.MetadataLoadContext.dasm had 158 diffs
System.Runtime.Caching.dasm had 78 diffs
Microsoft.Diagnostics.Tracing.TraceEvent.dasm had 66 diffs
System.Private.DataContractSerialization.dasm had 64 diffs
System.DirectoryServices.dasm had 48 diffs
Microsoft.Extensions.Primitives.dasm had 42 diffs
System.Reflection.Metadata.dasm had 24 diffs
Microsoft.CSharp.dasm had 20 diffs
System.Management.dasm had 20 diffs
System.DirectoryServices.AccountManagement.dasm had 18 diffs
System.DirectoryServices.Protocols.dasm had 18 diffs
System.Resources.Extensions.dasm had 16 diffs
System.Text.Json.dasm had 16 diffs
System.Diagnostics.EventLog.dasm had 12 diffs
Microsoft.Extensions.Http.dasm had 10 diffs
Microsoft.VisualBasic.Core.dasm had 10 diffs
```
`RuntimeType:ValidateGenericArguments` regression caused by loop cloning. `AddedOrChangedMethodInfo:MapTypes` regression caused by cost changes that allow branch duplication. Other regressions due to CSE, address mode formation and extra register use that increase prolog/epilog sizes.