### PR TITLE
Fix 2 INDEX morph CQ issues

### DIFF
--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -4724,7 +4724,8 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
                                                              asIndex->GetArray()->AsStrCon()->gtSconCPX, &length);
             if ((cnsIndex < length) && (str != nullptr))
             {
-                GenTree* cnsCharNode = gtNewIconNode(str[cnsIndex], elemTyp);
+                assert(tree->TypeIs(TYP_USHORT));
+                GenTree* cnsCharNode = gtNewIconNode(str[cnsIndex], TYP_INT);
                 INDEBUG(cnsCharNode->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED);
                 return cnsCharNode;
             }

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -4860,10 +4860,12 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
         if ((index->gtFlags & (GTF_ASG | GTF_CALL | GTF_GLOB_REF)) || gtComplexityExceeds(&index, MAX_ARR_COMPLEXITY) ||
             index->OperIs(GT_FIELD, GT_LCL_FLD))
         {
-            unsigned indexTmpNum = lvaGrabTemp(true DEBUGARG("index expr"));
-            indexDefn            = gtNewTempAssign(indexTmpNum, index);
-            index                = gtNewLclvNode(indexTmpNum, index->TypeGet());
-            index2               = gtNewLclvNode(indexTmpNum, index->TypeGet());
+            var_types indexTmpType = varActualType(index->GetType());
+            unsigned  indexTmpNum  = lvaNewTemp(indexTmpType, true DEBUGARG("index expr"));
+
+            indexDefn = gtNewAssignNode(gtNewLclvNode(indexTmpNum, indexTmpType), index);
+            index     = gtNewLclvNode(indexTmpNum, indexTmpType);
+            index2    = gtNewLclvNode(indexTmpNum, indexTmpType);
         }
         else
         {


### PR DESCRIPTION
win-x64 diff:
```
Total bytes of base: 32792192
Total bytes of diff: 32792100
Total bytes of delta: -92 (-0.00% of base)
    diff is an improvement.

Top file improvements (bytes):
         -22 : System.Net.Mail.dasm (-0.01% of base)
         -17 : System.Private.DataContractSerialization.dasm (-0.00% of base)
         -12 : System.Private.CoreLib.dasm (-0.00% of base)
          -9 : System.Net.HttpListener.dasm (-0.00% of base)
          -7 : System.Net.Http.dasm (-0.00% of base)
          -6 : ILCompiler.Reflection.ReadyToRun.dasm (-0.01% of base)
          -6 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
          -6 : System.IO.Compression.dasm (-0.01% of base)
          -4 : System.Private.Uri.dasm (-0.00% of base)
          -3 : System.Text.Encoding.CodePages.dasm (-0.00% of base)

10 total files with Code Size differences (10 improved, 0 regressed), 258 unchanged.

Top method improvements (bytes):
          -9 (-0.40% of base) : System.Net.HttpListener.dasm - HttpListenerResponse:SerializeHeaders(byref,bool):List`1:this
          -9 (-2.37% of base) : System.Private.CoreLib.dasm - UTF7Encoding:MakeTables():this
          -6 (-0.41% of base) : ILCompiler.Reflection.ReadyToRun.dasm - PEExportTable:.ctor(PEReader):this
          -6 (-0.07% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - RegisteredTraceEventParser:GetManifestForRegisteredProvider(Guid):String
          -6 (-0.36% of base) : System.IO.Compression.dasm - InflaterManaged:DecodeDynamicBlockHeader():bool:this
          -4 (-2.04% of base) : System.Net.Mail.dasm - MailBnfHelper:ValidateHeaderName(String)
          -4 (-0.49% of base) : System.Net.Mail.dasm - MailBnfHelper:ReadQuotedString(String,byref,StringBuilder,bool,bool):String
          -4 (-0.90% of base) : System.Net.Mail.dasm - MailBnfHelper:GetTokenOrQuotedString(String,StringBuilder,bool)
          -4 (-4.49% of base) : System.Private.DataContractSerialization.dasm - XmlUTF8TextReader:ReadAttributeText(ref,int,int):int:this
          -4 (-4.49% of base) : System.Private.DataContractSerialization.dasm - XmlUTF8TextReader:ReadWhitespace(ref,int,int):int:this
          -4 (-4.49% of base) : System.Private.DataContractSerialization.dasm - XmlUTF8TextReader:ReadText(ref,int,int):int:this
          -3 (-0.45% of base) : System.Net.Http.dasm - WhitespaceReader:TryReadCfwsReverse(String,int,byref,bool):bool
          -3 (-0.45% of base) : System.Net.Mail.dasm - WhitespaceReader:TryReadCfwsReverse(String,int,byref,bool):bool
          -3 (-0.85% of base) : System.Net.Mail.dasm - MailBnfHelper:ReadToken(String,byref,StringBuilder):String
          -3 (-0.20% of base) : System.Private.CoreLib.dasm - DateTimeFormatInfo:Tokenize(int,byref,byref,byref):bool:this
          -3 (-1.04% of base) : System.Private.DataContractSerialization.dasm - XmlUTF8TextReader:ReadTextAndWatchForInvalidCharacters(ref,int,int):int:this
          -3 (-0.28% of base) : System.Text.Encoding.CodePages.dasm - SBCSCodePageEncoding:GetChars(long,int,long,int,DecoderNLS):int:this
          -2 (-0.43% of base) : System.Net.Http.dasm - DomainLiteralReader:TryReadReverse(String,int,byref,bool):bool
          -2 (-0.50% of base) : System.Net.Http.dasm - DotAtomReader:TryReadReverse(String,int,byref,bool):bool
          -2 (-0.50% of base) : System.Net.Mail.dasm - DotAtomReader:TryReadReverse(String,int,byref,bool):bool

Top method improvements (percentages):
          -4 (-4.49% of base) : System.Private.DataContractSerialization.dasm - XmlUTF8TextReader:ReadAttributeText(ref,int,int):int:this
          -4 (-4.49% of base) : System.Private.DataContractSerialization.dasm - XmlUTF8TextReader:ReadWhitespace(ref,int,int):int:this
          -4 (-4.49% of base) : System.Private.DataContractSerialization.dasm - XmlUTF8TextReader:ReadText(ref,int,int):int:this
          -9 (-2.37% of base) : System.Private.CoreLib.dasm - UTF7Encoding:MakeTables():this
          -2 (-2.13% of base) : System.Private.Uri.dasm - Uri:get_SecuredPathIndex():int:this
          -4 (-2.04% of base) : System.Net.Mail.dasm - MailBnfHelper:ValidateHeaderName(String)
          -3 (-1.04% of base) : System.Private.DataContractSerialization.dasm - XmlUTF8TextReader:ReadTextAndWatchForInvalidCharacters(ref,int,int):int:this
          -4 (-0.90% of base) : System.Net.Mail.dasm - MailBnfHelper:GetTokenOrQuotedString(String,StringBuilder,bool)
          -3 (-0.85% of base) : System.Net.Mail.dasm - MailBnfHelper:ReadToken(String,byref,StringBuilder):String
          -2 (-0.50% of base) : System.Net.Http.dasm - DotAtomReader:TryReadReverse(String,int,byref,bool):bool
          -2 (-0.50% of base) : System.Net.Mail.dasm - DotAtomReader:TryReadReverse(String,int,byref,bool):bool
          -4 (-0.49% of base) : System.Net.Mail.dasm - MailBnfHelper:ReadQuotedString(String,byref,StringBuilder,bool,bool):String
          -3 (-0.45% of base) : System.Net.Http.dasm - WhitespaceReader:TryReadCfwsReverse(String,int,byref,bool):bool
          -3 (-0.45% of base) : System.Net.Mail.dasm - WhitespaceReader:TryReadCfwsReverse(String,int,byref,bool):bool
          -2 (-0.43% of base) : System.Net.Http.dasm - DomainLiteralReader:TryReadReverse(String,int,byref,bool):bool
          -2 (-0.42% of base) : System.Net.Mail.dasm - DomainLiteralReader:TryReadReverse(String,int,byref,bool):bool
          -6 (-0.41% of base) : ILCompiler.Reflection.ReadyToRun.dasm - PEExportTable:.ctor(PEReader):this
          -9 (-0.40% of base) : System.Net.HttpListener.dasm - HttpListenerResponse:SerializeHeaders(byref,bool):List`1:this
          -6 (-0.36% of base) : System.IO.Compression.dasm - InflaterManaged:DecodeDynamicBlockHeader():bool:this
          -3 (-0.28% of base) : System.Text.Encoding.CodePages.dasm - SBCSCodePageEncoding:GetChars(long,int,long,int,DecoderNLS):int:this

24 total methods with Code Size differences (24 improved, 0 regressed), 196141 unchanged.
```