### PR TITLE
Fix lousy box pattern matching

### DIFF
--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -9122,7 +9122,7 @@ void Compiler::gtChangeOperToNullCheck(GenTree* tree, BasicBlock* block)
 {
     assert(tree->OperIs(GT_FIELD, GT_IND, GT_OBJ, GT_BLK));
     tree->ChangeOper(GT_NULLCHECK);
-    tree->ChangeType(TYP_INT);
+    tree->SetType(TYP_INT);
     block->bbFlags |= BBF_HAS_NULLCHECK;
     optMethodFlags |= OMF_HAS_NULLCHECK;
 }

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -3640,6 +3640,8 @@ private:
     GenTree* impImportInitBlk(GenTree* dstAddr, GenTree* initValue, GenTree* size, bool isVolatile);
     GenTree* impImportCpBlk(GenTree* dstAddr, GenTree* srcAddr, GenTree* size, bool isVolatile);
 
+    GenTree* impImportPop(BasicBlock* block);
+
     /*
     XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX


### PR DESCRIPTION
win-x64 diff:
```
Total bytes of base: 50087331
Total bytes of diff: 50086080
Total bytes of delta: -1251 (-0.00% of base)
    diff is an improvement.

Top file regressions (bytes):
          75 : System.Text.Json.dasm (0.01% of base)

Top file improvements (bytes):
        -883 : System.Private.CoreLib.dasm (-0.02% of base)
        -351 : System.Composition.TypedParts.dasm (-0.83% of base)
         -75 : System.Linq.Queryable.dasm (-0.03% of base)
         -17 : System.Linq.Expressions.dasm (-0.00% of base)

5 total files with Code Size differences (4 improved, 1 regressed), 263 unchanged.

Top method regressions (bytes):
          75 ( 2.25% of base) : System.Text.Json.dasm - JsonConverter`1:TryWrite(Utf8JsonWriter,byref,JsonSerializerOptions,byref):bool:this (7 methods)
           2 ( 1.37% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:IndexOf(ref,Vector`1,int,int):int:this
           2 ( 1.35% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:LastIndexOf(ref,Vector`1,int,int):int:this

Top method improvements (bytes):
        -126 (-50.20% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:IndexOf(ref,short,int,int):int:this
        -125 (-50.20% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:IndexOf(ref,long,int,int):int:this
        -124 (-50.61% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:IndexOf(ref,int,int,int):int:this
        -117 (-9.95% of base) : System.Composition.TypedParts.dasm - <>f__AnonymousType0`2:ToString():String:this (7 methods)
        -117 (-9.95% of base) : System.Composition.TypedParts.dasm - <>f__AnonymousType1`2:ToString():String:this (7 methods)
        -117 (-9.95% of base) : System.Composition.TypedParts.dasm - <>f__AnonymousType2`2:ToString():String:this (7 methods)
        -116 (-52.49% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:IndexOf(ref,double,int,int):int:this
         -81 (-51.27% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:IndexOf(ref,short,int,int):int:this
         -75 (-6.64% of base) : System.Linq.Queryable.dasm - <>f__AnonymousType0`2:ToString():String:this (7 methods)
         -73 (-51.41% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:IndexOf(ref,int,int,int):int:this
         -73 (-51.41% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:IndexOf(ref,long,int,int):int:this
         -68 (-4.73% of base) : System.Private.CoreLib.dasm - GenericArraySortHelper`2:DownHeap(Span`1,Span`1,int,int,int) (5 methods)
         -41 (-4.66% of base) : System.Private.CoreLib.dasm - GenericArraySortHelper`1:DownHeap(Span`1,int,int,int) (5 methods)
         -30 (-1.63% of base) : System.Private.CoreLib.dasm - GenericArraySortHelper`1:IntroSort(Span`1,int) (5 methods)
         -17 (-1.50% of base) : System.Linq.Expressions.dasm - ContractUtils:RequiresNotNullItems(IList`1,String) (7 methods)
         -12 (-2.30% of base) : System.Private.CoreLib.dasm - GenericArraySortHelper`2:SwapIfGreaterWithValues(Span`1,Span`1,int,int) (5 methods)
         -10 (-9.17% of base) : System.Private.CoreLib.dasm - GenericArraySortHelper`1:SwapIfGreater(byref,byref) (5 methods)
          -5 (-0.17% of base) : System.Private.CoreLib.dasm - Dictionary`2:OnDeserialization(Object):this (7 methods)
          -2 (-0.18% of base) : System.Private.CoreLib.dasm - GenericArraySortHelper`1:PickPivotAndPartition(Span`1):int (5 methods)
          -1 (-0.93% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:LastIndexOf(ref,double,int,int):int:this

Top method regressions (percentages):
          75 ( 2.25% of base) : System.Text.Json.dasm - JsonConverter`1:TryWrite(Utf8JsonWriter,byref,JsonSerializerOptions,byref):bool:this (7 methods)
           2 ( 1.37% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:IndexOf(ref,Vector`1,int,int):int:this
           2 ( 1.35% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:LastIndexOf(ref,Vector`1,int,int):int:this

Top method improvements (percentages):
        -116 (-52.49% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:IndexOf(ref,double,int,int):int:this
         -73 (-51.41% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:IndexOf(ref,int,int,int):int:this
         -73 (-51.41% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:IndexOf(ref,long,int,int):int:this
         -81 (-51.27% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:IndexOf(ref,short,int,int):int:this
        -124 (-50.61% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:IndexOf(ref,int,int,int):int:this
        -125 (-50.20% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:IndexOf(ref,long,int,int):int:this
        -126 (-50.20% of base) : System.Private.CoreLib.dasm - ObjectEqualityComparer`1:IndexOf(ref,short,int,int):int:this
        -117 (-9.95% of base) : System.Composition.TypedParts.dasm - <>f__AnonymousType0`2:ToString():String:this (7 methods)
        -117 (-9.95% of base) : System.Composition.TypedParts.dasm - <>f__AnonymousType1`2:ToString():String:this (7 methods)
        -117 (-9.95% of base) : System.Composition.TypedParts.dasm - <>f__AnonymousType2`2:ToString():String:this (7 methods)
         -10 (-9.17% of base) : System.Private.CoreLib.dasm - GenericArraySortHelper`1:SwapIfGreater(byref,byref) (5 methods)
         -75 (-6.64% of base) : System.Linq.Queryable.dasm - <>f__AnonymousType0`2:ToString():String:this (7 methods)
         -68 (-4.73% of base) : System.Private.CoreLib.dasm - GenericArraySortHelper`2:DownHeap(Span`1,Span`1,int,int,int) (5 methods)
         -41 (-4.66% of base) : System.Private.CoreLib.dasm - GenericArraySortHelper`1:DownHeap(Span`1,int,int,int) (5 methods)
         -12 (-2.30% of base) : System.Private.CoreLib.dasm - GenericArraySortHelper`2:SwapIfGreaterWithValues(Span`1,Span`1,int,int) (5 methods)
         -30 (-1.63% of base) : System.Private.CoreLib.dasm - GenericArraySortHelper`1:IntroSort(Span`1,int) (5 methods)
         -17 (-1.50% of base) : System.Linq.Expressions.dasm - ContractUtils:RequiresNotNullItems(IList`1,String) (7 methods)
          -1 (-0.93% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:LastIndexOf(ref,double,int,int):int:this
          -2 (-0.18% of base) : System.Private.CoreLib.dasm - GenericArraySortHelper`1:PickPivotAndPartition(Span`1):int (5 methods)
          -5 (-0.17% of base) : System.Private.CoreLib.dasm - Dictionary`2:OnDeserialization(Object):this (7 methods)

23 total methods with Code Size differences (20 improved, 3 regressed), 258780 unchanged.
```
`JsonConverter'1:TryWrite` regression due to epilog duplication. Other small regressions due to useless CSEing of array lengths that block containment, previously hidden by incorrect side effect removal in importer.