### PR TITLE
Avoid creating const casts when widening to native int

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3422,7 +3422,7 @@ private:
     void impPushPendingBlock(BasicBlock* block);
     BasicBlock* impPopPendingBlock();
 
-    var_types impGetByRefResultType(genTreeOps oper, bool fUnsigned, GenTree** pOp1, GenTree** pOp2);
+    var_types impGetNumericBinaryOpType(genTreeOps oper, bool fUnsigned, GenTree** pOp1, GenTree** pOp2);
 
     void impImportBlock(BasicBlock* block);
     bool impSpillStackAtBlockEnd(BasicBlock* block);

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -3011,6 +3011,16 @@ struct GenTreeIntCon : public GenTreeIntConCommon
         return static_cast<uint8_t>(gtIconVal & 0xFF);
     }
 
+    uint32_t GetUInt32Value() const
+    {
+        return static_cast<uint32_t>(gtIconVal);
+    }
+
+    int32_t GetInt32Value() const
+    {
+        return static_cast<int32_t>(gtIconVal);
+    }
+
     void SetValue(ssize_t value)
     {
         gtIconVal  = value;

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -8987,7 +8987,10 @@ var_types Compiler::impGetNumericBinaryOpType(genTreeOps oper, bool fUnsigned, G
     if (op1->TypeIs(TYP_LONG) || op2->TypeIs(TYP_LONG))
     {
 #ifndef TARGET_64BIT
-        assert(op1->GetType() == op2->GetType());
+        // TODO-MIKE-Cleanup: Both operands should be LONG but
+        // JIT\Methodical\Boxing\morph\sin3double\sin3double.cmd
+        // contains invalid IL - it adds native int and int64.
+        assert(varTypeIsIntegral(op1->GetType()) && varTypeIsIntegral(op2->GetType()));
 #else
         // int32 + native int = native int
         // native int + int32 = native int

--- a/src/coreclr/jit/vartype.h
+++ b/src/coreclr/jit/vartype.h
@@ -246,9 +246,15 @@ inline bool varTypeIsIntOrI(T vt)
 }
 
 template <class T>
-inline bool genActualTypeIsIntOrI(T vt)
+inline bool varActualTypeIsIntOrI(T vt)
 {
     return ((TypeGet(vt) >= TYP_BOOL) && (TypeGet(vt) <= TYP_U_IMPL));
+}
+
+template <class T>
+inline bool genActualTypeIsIntOrI(T vt)
+{
+    return varActualTypeIsIntOrI(vt);
 }
 
 template <class T>


### PR DESCRIPTION
win-x64 diff:
```
Total bytes of base: 33183292
Total bytes of diff: 33182987
Total bytes of delta: -305 (-0.00% of base)
    diff is an improvement.


Top file regressions (bytes):
          30 : System.Security.Cryptography.Algorithms.dasm (0.01% of base)
          30 : System.Security.Cryptography.Cng.dasm (0.02% of base)

Top file improvements (bytes):
        -247 : System.Private.CoreLib.dasm (-0.01% of base)
         -32 : System.Net.HttpListener.dasm (-0.02% of base)
         -25 : System.Net.Mail.dasm (-0.01% of base)
         -22 : System.Net.Http.dasm (-0.00% of base)
         -18 : System.Net.Security.dasm (-0.01% of base)
          -9 : xunit.performance.execution.dasm (-0.06% of base)
          -7 : System.Net.Sockets.dasm (-0.00% of base)
          -3 : System.Threading.dasm (-0.02% of base)
          -2 : System.Private.DataContractSerialization.dasm (-0.00% of base)

11 total files with Code Size differences (9 improved, 2 regressed), 259 unchanged.

Top method regressions (bytes):
          37 (10.34% of base) : System.Security.Cryptography.Algorithms.dasm - NCrypt:DeriveKeyMaterialTls(SafeNCryptSecretHandle,ref,ref,int):ref
          37 (10.34% of base) : System.Security.Cryptography.Cng.dasm - NCrypt:DeriveKeyMaterialTls(SafeNCryptSecretHandle,ref,ref,int):ref
          18 ( 4.56% of base) : System.Net.Security.dasm - SSPIWrapper:QueryContextAttributes_SECPKG_ATTR_REMOTE_CERT_CONTEXT(ISSPIInterface,SafeDeleteContext):SafeFreeCertContext
           3 ( 1.30% of base) : System.Net.Http.dasm - HttpTelemetry:WriteEvent(int,ubyte,ubyte):this

Top method improvements (bytes):
         -25 (-0.70% of base) : System.Net.Security.dasm - SafeDeleteContext:AcceptSecurityContext(byref,byref,int,int,InputSecurityBuffers,byref,byref):int
         -25 (-0.70% of base) : System.Net.Http.dasm - SafeDeleteContext:AcceptSecurityContext(byref,byref,int,int,InputSecurityBuffers,byref,byref):int
         -25 (-0.70% of base) : System.Net.HttpListener.dasm - SafeDeleteContext:AcceptSecurityContext(byref,byref,int,int,InputSecurityBuffers,byref,byref):int
         -25 (-0.70% of base) : System.Net.Mail.dasm - SafeDeleteContext:AcceptSecurityContext(byref,byref,int,int,InputSecurityBuffers,byref,byref):int
         -22 (-6.57% of base) : System.Private.CoreLib.dasm - RuntimeTypeHandle:CreateInstanceForAnotherGenericParameter(RuntimeType,RuntimeType,RuntimeType):Object
         -19 (-9.45% of base) : System.Private.CoreLib.dasm - EventSource:WriteEvent(int,String,int):this
         -19 (-9.45% of base) : System.Private.CoreLib.dasm - EventSource:WriteEvent(int,String,long):this
         -19 (-9.45% of base) : System.Private.CoreLib.dasm - EventSource:WriteEvent(int,long,String):this
         -19 (-9.45% of base) : System.Private.CoreLib.dasm - EventSource:WriteEvent(int,int,String):this
         -17 (-11.18% of base) : System.Private.CoreLib.dasm - EventSource:WriteEvent(int,int,int):this
         -17 (-11.18% of base) : System.Private.CoreLib.dasm - EventSource:WriteEvent(int,long,long):this
         -15 (-7.98% of base) : System.Private.CoreLib.dasm - TplEventSource:TraceSynchronousWorkEnd(int):this
         -15 (-12.40% of base) : System.Private.CoreLib.dasm - EventSource:WriteEvent(int,int):this
         -15 (-12.40% of base) : System.Private.CoreLib.dasm - EventSource:WriteEvent(int,long):this
         -13 (-7.78% of base) : System.Private.CoreLib.dasm - EventSource:WriteEvent(int,String):this
         -13 (-5.28% of base) : System.Private.CoreLib.dasm - EventSource:WriteEvent(int,String,String):this
         -11 (-4.53% of base) : System.Private.CoreLib.dasm - PortableThreadPoolEventSource:ThreadPoolWorkerThreadAdjustmentSample(double,ushort):this
         -11 (-4.56% of base) : System.Private.CoreLib.dasm - PortableThreadPoolEventSource:ThreadPoolWorkingThreadCount(int,ushort):this
         -11 (-3.67% of base) : System.Private.CoreLib.dasm - EventSource:WriteEvent(int,ref):this (2 methods)
         -11 (-1.87% of base) : System.Private.CoreLib.dasm - EventSource:SendManifest(ref):this

Top method regressions (percentages):
          37 (10.34% of base) : System.Security.Cryptography.Algorithms.dasm - NCrypt:DeriveKeyMaterialTls(SafeNCryptSecretHandle,ref,ref,int):ref
          37 (10.34% of base) : System.Security.Cryptography.Cng.dasm - NCrypt:DeriveKeyMaterialTls(SafeNCryptSecretHandle,ref,ref,int):ref
          18 ( 4.56% of base) : System.Net.Security.dasm - SSPIWrapper:QueryContextAttributes_SECPKG_ATTR_REMOTE_CERT_CONTEXT(ISSPIInterface,SafeDeleteContext):SafeFreeCertContext
           3 ( 1.30% of base) : System.Net.Http.dasm - HttpTelemetry:WriteEvent(int,ubyte,ubyte):this

Top method improvements (percentages):
         -15 (-12.40% of base) : System.Private.CoreLib.dasm - EventSource:WriteEvent(int,int):this
         -15 (-12.40% of base) : System.Private.CoreLib.dasm - EventSource:WriteEvent(int,long):this
         -17 (-11.18% of base) : System.Private.CoreLib.dasm - EventSource:WriteEvent(int,int,int):this
         -17 (-11.18% of base) : System.Private.CoreLib.dasm - EventSource:WriteEvent(int,long,long):this
         -19 (-9.45% of base) : System.Private.CoreLib.dasm - EventSource:WriteEvent(int,String,int):this
         -19 (-9.45% of base) : System.Private.CoreLib.dasm - EventSource:WriteEvent(int,String,long):this
         -19 (-9.45% of base) : System.Private.CoreLib.dasm - EventSource:WriteEvent(int,long,String):this
         -19 (-9.45% of base) : System.Private.CoreLib.dasm - EventSource:WriteEvent(int,int,String):this
         -15 (-7.98% of base) : System.Private.CoreLib.dasm - TplEventSource:TraceSynchronousWorkEnd(int):this
         -13 (-7.78% of base) : System.Private.CoreLib.dasm - EventSource:WriteEvent(int,String):this
         -22 (-6.57% of base) : System.Private.CoreLib.dasm - RuntimeTypeHandle:CreateInstanceForAnotherGenericParameter(RuntimeType,RuntimeType,RuntimeType):Object
         -13 (-5.28% of base) : System.Private.CoreLib.dasm - EventSource:WriteEvent(int,String,String):this
         -11 (-4.56% of base) : System.Private.CoreLib.dasm - PortableThreadPoolEventSource:ThreadPoolWorkingThreadCount(int,ushort):this
         -11 (-4.53% of base) : System.Private.CoreLib.dasm - PortableThreadPoolEventSource:ThreadPoolWorkerThreadAdjustmentSample(double,ushort):this
         -11 (-3.67% of base) : System.Private.CoreLib.dasm - EventSource:WriteEvent(int,ref):this (2 methods)
          -9 (-2.48% of base) : xunit.performance.execution.dasm - BenchmarkEventSource:BenchmarkStart(String,String):this
         -11 (-1.87% of base) : System.Private.CoreLib.dasm - EventSource:SendManifest(ref):this
          -7 (-1.55% of base) : System.Net.Sockets.dasm - SocketPal:Poll(SafeSocketHandle,int,int,byref):int
          -7 (-1.40% of base) : System.Security.Cryptography.Cng.dasm - CngKey:ImportEncryptedPkcs8(ReadOnlySpan`1,ReadOnlySpan`1,CngProvider):CngKey
          -7 (-1.36% of base) : System.Net.Security.dasm - SSPIWrapper:QueryStringContextAttributes(ISSPIInterface,SafeDeleteContext,int):String

33 total methods with Code Size differences (29 improved, 4 regressed), 200656 unchanged.
```
Most diffs due to small `localloc` optimization kicking in. Regressions due to changes in frame offset that result in longer address mode displacements.