### PR TITLE
Remove some useless casts

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -968,14 +968,14 @@ public:
     bool lvNormalizeOnLoad() const
     {
         return varTypeIsSmall(TypeGet()) &&
-               // lvIsStructField is treated the same as the aliased local, see fgDoNormalizeOnStore.
+               // lvIsStructField is treated the same as the aliased local, see fgMorphNormalizeLclVarStore.
                (lvIsParam || lvAddrExposed || lvIsStructField);
     }
 
     bool lvNormalizeOnStore() const
     {
         return varTypeIsSmall(TypeGet()) &&
-               // lvIsStructField is treated the same as the aliased local, see fgDoNormalizeOnStore.
+               // lvIsStructField is treated the same as the aliased local, see fgMorphNormalizeLclVarStore.
                !(lvIsParam || lvAddrExposed || lvIsStructField);
     }
 
@@ -4477,7 +4477,7 @@ public:
     inline void fgConvertBBToThrowBB(BasicBlock* block);
 
     bool gtIsSmallIntCastNeeded(GenTree* tree, var_types toType);
-    GenTree* fgDoNormalizeOnStore(GenTree* tree);
+    GenTree* fgMorphNormalizeLclVarStore(GenTreeOp* asg);
 
     // The following check for loops that don't execute calls
     bool fgLoopCallMarked;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4476,7 +4476,7 @@ public:
     /* Helper code that has been factored out */
     inline void fgConvertBBToThrowBB(BasicBlock* block);
 
-    bool fgCastNeeded(GenTree* tree, var_types toType);
+    bool gtIsSmallIntCastNeeded(GenTree* tree, var_types toType);
     GenTree* fgDoNormalizeOnStore(GenTree* tree);
 
     // The following check for loops that don't execute calls

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -545,20 +545,7 @@ inline regNumber genRegNumFromMask(regMaskTP mask)
 
 inline bool genSmallTypeCanRepresentValue(var_types type, ssize_t value)
 {
-    switch (type)
-    {
-        case TYP_UBYTE:
-        case TYP_BOOL:
-            return FitsIn<UINT8>(value);
-        case TYP_BYTE:
-            return FitsIn<INT8>(value);
-        case TYP_USHORT:
-            return FitsIn<UINT16>(value);
-        case TYP_SHORT:
-            return FitsIn<INT16>(value);
-        default:
-            unreached();
-    }
+    return varTypeSmallIntCanRepresentValue(type, value);
 }
 
 /*****************************************************************************

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -1346,6 +1346,14 @@ bool Compiler::inlAnalyzeInlineeSignature(InlineInfo* inlineInfo)
 
         if (varTypeIsSmall(paramType) && varTypeIsIntegral(argNode->GetType()))
         {
+            if (GenTreeIntCon* con = argNode->IsIntCon())
+            {
+                if (varTypeSmallIntCanRepresentValue(paramType, con->GetValue()))
+                {
+                    continue;
+                }
+            }
+
             var_types argType = argNode->GetType();
 
             if (argNode->OperIs(GT_LCL_VAR))

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -1270,6 +1270,8 @@ GenTree* Compiler::fgOptimizeDelegateConstructor(GenTreeCall*            call,
 
 bool Compiler::fgCastNeeded(GenTree* tree, var_types toType)
 {
+    assert(varTypeIsSmall(toType));
+
     //
     // If tree is a relop and we need an 4-byte integer
     //  then we never need to insert a cast

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -1306,6 +1306,12 @@ bool Compiler::fgCastNeeded(GenTree* tree, var_types toType)
     {
         return false;
     }
+
+    if ((toType == TYP_SHORT) && ((fromType == TYP_BOOL) || (fromType == TYP_UBYTE)))
+    {
+        return false;
+    }
+
     //
     // If the sign-ness of the two types are different then a cast is necessary
     //

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -1268,48 +1268,6 @@ GenTree* Compiler::fgOptimizeDelegateConstructor(GenTreeCall*            call,
     return call;
 }
 
-// If assigning to a local var, add a cast if the target is
-// marked as NormalizedOnStore. Returns true if any change was made
-GenTree* Compiler::fgDoNormalizeOnStore(GenTree* tree)
-{
-    //
-    // Only normalize the stores in the global morph phase
-    //
-    if (fgGlobalMorph)
-    {
-        noway_assert(tree->OperGet() == GT_ASG);
-
-        GenTree* op1 = tree->AsOp()->gtOp1;
-        GenTree* op2 = tree->AsOp()->gtOp2;
-
-        if (op1->gtOper == GT_LCL_VAR && genActualType(op1->TypeGet()) == TYP_INT)
-        {
-            // Small-typed arguments and aliased locals are normalized on load.
-            // Other small-typed locals are normalized on store.
-            // If it is an assignment to one of the latter, insert the cast on RHS
-            unsigned   varNum = op1->AsLclVarCommon()->GetLclNum();
-            LclVarDsc* varDsc = &lvaTable[varNum];
-
-            if (varDsc->lvNormalizeOnStore())
-            {
-                noway_assert(op1->gtType <= TYP_INT);
-                op1->gtType = TYP_INT;
-
-                if (gtIsSmallIntCastNeeded(op2, varDsc->TypeGet()))
-                {
-                    op2                 = gtNewCastNode(TYP_INT, op2, false, varDsc->TypeGet());
-                    tree->AsOp()->gtOp2 = op2;
-
-                    // Propagate GTF_COLON_COND
-                    op2->gtFlags |= (tree->gtFlags & GTF_COLON_COND);
-                }
-            }
-        }
-    }
-
-    return tree;
-}
-
 /*****************************************************************************
  *
  *  Mark whether the edge "srcBB -> dstBB" forms a loop that will always

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -17432,6 +17432,10 @@ bool Compiler::gtIsSmallIntCastNeeded(GenTree* tree, var_types toType)
     {
         fromType = call->GetRetSigType();
     }
+    else if (tree->OperIs(GT_LCL_VAR))
+    {
+        fromType = lvaGetDesc(tree->AsLclVar())->GetType();
+    }
     else
     {
         fromType = tree->GetType();

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -17417,6 +17417,11 @@ bool Compiler::gtIsSmallIntCastNeeded(GenTree* tree, var_types toType)
         return false;
     }
 
+    if (GenTreeIntCon* con = tree->IsIntCon())
+    {
+        return !varTypeSmallIntCanRepresentValue(toType, con->GetValue());
+    }
+
     var_types fromType;
 
     if (GenTreeCast* cast = tree->IsCast())

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -875,7 +875,7 @@ public:
 #define GTF_VAR_CONTEXT     0x00200000 // GT_LCL_VAR -- this node is part of a runtime lookup
 #define GTF_VAR_FOLDED_IND  0x00100000 // GT_LCL_VAR -- this node was folded from *(typ*)&lclVar expression tree in fgMorphSmpOp()
 // where 'typ' is a small type and 'lclVar' corresponds to a normalized-on-store local variable.
-// This flag identifies such nodes in order to make sure that fgDoNormalizeOnStore() is called on their parents in post-order morph.
+// This flag identifies such nodes in order to make sure that fgMorphNormalizeLclVarStore() is called on their parents in post-order morph.
 
                                        // Relevant for inlining optimizations (see inlPrependStatements)
 

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -88,7 +88,7 @@ private:
 
     void ContainCheckCallOperands(GenTreeCall* call);
     void ContainCheckIndir(GenTreeIndir* indirNode);
-    void ContainCheckStoreIndir(GenTreeIndir* indirNode);
+    void ContainCheckStoreIndir(GenTreeStoreInd* store);
     void ContainCheckMul(GenTreeOp* node);
     void ContainCheckShiftRotate(GenTreeOp* node);
     void ContainCheckStoreLcl(GenTreeLclVarCommon* store);
@@ -168,14 +168,14 @@ private:
     void InsertPInvokeCallEpilog(GenTreeCall* call);
     void InsertPInvokeMethodProlog();
     void InsertPInvokeMethodEpilog(BasicBlock* returnBB DEBUGARG(GenTree* lastExpr));
-    GenTree* SetGCState(int cns);
+    GenTreeStoreInd* SetGCState(int cns);
     GenTree* CreateReturnTrapSeq();
     enum FrameLinkAction
     {
         PushFrame,
         PopFrame
     };
-    GenTree* CreateFrameLinkUpdate(FrameLinkAction);
+    GenTreeStoreInd* CreateFrameLinkUpdate(FrameLinkAction);
     GenTree* AddrGen(ssize_t addr);
     GenTree* AddrGen(void* addr);
 
@@ -287,7 +287,7 @@ private:
     // Per tree node member functions
     void LowerStoreIndirCommon(GenTreeStoreInd* ind);
     void LowerIndir(GenTreeIndir* ind);
-    void LowerStoreIndir(GenTreeIndir* node);
+    void LowerStoreIndir(GenTreeStoreInd* store);
     GenTree* LowerAdd(GenTreeOp* node);
     bool LowerUnsignedDivOrMod(GenTreeOp* divMod);
     GenTree* LowerConstIntDivOrMod(GenTree* node);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -10827,23 +10827,8 @@ DONE_MORPHING_CHILDREN:
                         tree->AsOp()->gtOp2 = op2 = op2->AsCast()->CastOp();
                     }
                 }
-                else if (op2->OperIsCompare() && varTypeIsByte(effectiveOp1->TypeGet()))
-                {
-                    /* We don't need to zero extend the setcc instruction */
-                    op2->gtType = TYP_BYTE;
-                }
             }
-            // If we introduced a CSE we may need to undo the optimization above
-            // (i.e. " op2->gtType = TYP_BYTE;" which depends upon op1 being a GT_IND of a byte type)
-            // When we introduce the CSE we remove the GT_IND and subsitute a GT_LCL_VAR in it place.
-            else if (op2->OperIsCompare() && (op2->gtType == TYP_BYTE) && (op1->gtOper == GT_LCL_VAR))
-            {
-                unsigned   varNum = op1->AsLclVarCommon()->GetLclNum();
-                LclVarDsc* varDsc = &lvaTable[varNum];
 
-                /* We again need to zero extend the setcc instruction */
-                op2->gtType = varDsc->TypeGet();
-            }
             fgAssignSetVarDef(tree);
 
             /* We can't CSE the LHS of an assignment */

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -10786,7 +10786,7 @@ DONE_MORPHING_CHILDREN:
             }
 
             /* If we are storing a small type, we might be able to omit a cast */
-            if ((effectiveOp1->gtOper == GT_IND) && varTypeIsSmall(effectiveOp1->TypeGet()))
+            if (effectiveOp1->OperIs(GT_IND, GT_LCL_FLD) && varTypeIsSmall(effectiveOp1->TypeGet()))
             {
                 if (!gtIsActiveCSE_Candidate(op2) && (op2->gtOper == GT_CAST) && !op2->gtOverflow())
                 {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -10192,7 +10192,7 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac)
             return fgMorphIntoHelperCall(tree, helper, gtNewCallArgs(op1, op2));
 
         case GT_RETURN:
-            if (fgGlobalMorph && varTypeIsSmall(info.compRetType) && fgCastNeeded(op1, info.compRetType))
+            if (fgGlobalMorph && varTypeIsSmall(info.compRetType) && gtIsSmallIntCastNeeded(op1, info.compRetType))
             {
                 // Small-typed return values are extended by the callee.
 

--- a/src/coreclr/jit/vartype.h
+++ b/src/coreclr/jit/vartype.h
@@ -414,6 +414,22 @@ inline var_types varTypePointerAdd(var_types type)
     return (type == TYP_REF) ? TYP_BYREF : type;
 }
 
-/*****************************************************************************/
+inline bool varTypeSmallIntCanRepresentValue(var_types type, ssize_t value)
+{
+    switch (type)
+    {
+        case TYP_UBYTE:
+        case TYP_BOOL:
+            return FitsIn<uint8_t>(value);
+        case TYP_BYTE:
+            return FitsIn<int8_t>(value);
+        case TYP_USHORT:
+            return FitsIn<uint16_t>(value);
+        case TYP_SHORT:
+            return FitsIn<int16_t>(value);
+        default:
+            unreached();
+    }
+}
+
 #endif // _VARTYPE_H_
-/*****************************************************************************/


### PR DESCRIPTION
win-x64 diff:
```
Total bytes of base: 33182789
Total bytes of diff: 33181659
Total bytes of delta: -1130 (-0.00% of base)
    diff is an improvement.


Top file regressions (bytes):
           1 : System.Security.Cryptography.Pkcs.dasm (0.00% of base)

Top file improvements (bytes):
        -305 : System.Private.Xml.dasm (-0.01% of base)
        -151 : System.Private.CoreLib.dasm (-0.00% of base)
        -116 : System.Net.Http.dasm (-0.02% of base)
         -85 : System.Reflection.Metadata.dasm (-0.03% of base)
         -61 : Microsoft.CodeAnalysis.dasm (-0.01% of base)
         -49 : System.Text.Encoding.CodePages.dasm (-0.07% of base)
         -42 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
         -39 : Microsoft.VisualBasic.Core.dasm (-0.01% of base)
         -39 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.00% of base)
         -37 : Newtonsoft.Json.dasm (-0.01% of base)
         -24 : System.Speech.dasm (-0.01% of base)
         -24 : System.DirectoryServices.dasm (-0.01% of base)
         -23 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00% of base)
         -22 : System.Private.DataContractSerialization.dasm (-0.00% of base)
         -16 : System.Data.Common.dasm (-0.00% of base)
         -15 : System.Net.Security.dasm (-0.01% of base)
         -13 : System.Net.HttpListener.dasm (-0.01% of base)
         -12 : System.Net.Quic.dasm (-0.02% of base)
          -9 : ILCompiler.Reflection.ReadyToRun.dasm (-0.01% of base)
          -9 : System.Threading.Tasks.Parallel.dasm (-0.02% of base)

32 total files with Code Size differences (31 improved, 1 regressed), 238 unchanged.

Top method regressions (bytes):
          12 ( 0.93% of base) : System.Private.Xml.dasm - XmlTextReaderImpl:ParseTextAsync(int,ref,int,int,int,int,ushort):Task`1:this
           1 ( 0.07% of base) : Microsoft.CodeAnalysis.CSharp.dasm - OverloadResolution:IsApplicable(Symbol,EffectiveParameters,AnalyzedArguments,ImmutableArray`1,bool,bool,bool,byref):MemberAnalysisResult:this
           1 ( 0.35% of base) : System.Reflection.Metadata.dasm - MetadataBuilder:AddAssembly(StringHandle,Version,StringHandle,BlobHandle,int,int):AssemblyDefinitionHandle:this
           1 ( 0.08% of base) : System.Security.Cryptography.Pkcs.dasm - Rfc3161TimestampRequest:CreateFromHash(ReadOnlyMemory`1,Oid,Oid,Nullable`1,bool,X509ExtensionCollection):Rfc3161TimestampRequest

Top method improvements (bytes):
         -72 (-0.61% of base) : System.Reflection.Metadata.dasm - MetadataReader:InitializeTableReaders(MemoryBlock,ubyte,ref,ref):this
         -24 (-0.97% of base) : System.Text.Encoding.CodePages.dasm - GB18030Encoding:GetChars(long,int,long,int,DecoderNLS):int:this
         -24 (-1.77% of base) : System.DirectoryServices.dasm - AdsValueHelper:GetValue():Object:this
         -20 (-7.33% of base) : System.Speech.dasm - WAVEFORMATEX:ToWaveHeader(ref):WAVEFORMATEX
         -18 (-0.94% of base) : System.Private.Xml.dasm - XmlTextReaderImpl:ParseAttributes():this
         -16 (-0.44% of base) : Microsoft.VisualBasic.Core.dasm - Operators:ModObject(Object,Object):Object
         -15 (-3.16% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - ReloggerEventListener:OnEventWritten(EventWrittenEventArgs):this
         -12 (-0.40% of base) : System.Private.Xml.dasm - XmlTextReaderImpl:IncrementalRead():int:this
         -12 (-0.31% of base) : System.Private.Xml.dasm - <ParseAttributesAsync>d__531:MoveNext():this
         -12 (-9.84% of base) : System.Private.CoreLib.dasm - TplEventSource:CreateGuidForTaskID(int):Guid
         -10 (-0.68% of base) : System.Private.DataContractSerialization.dasm - XmlUTF8TextReader:ReadAttributes():this
          -9 (-0.85% of base) : System.Data.Common.dasm - SqlDecimal:Parse(String):SqlDecimal
          -9 (-7.32% of base) : System.Net.Http.dasm - HttpConnection:WriteTwoBytesSlowAsync(ubyte,ubyte,bool):Task:this
          -8 (-0.67% of base) : System.Text.Encoding.CodePages.dasm - ISO2022Encoding:GetCharsCP52936(long,int,long,int,ISO2022Decoder):int:this
          -8 (-6.20% of base) : Microsoft.CodeAnalysis.dasm - MetadataTypeName:FromFullName(String,bool,int):MetadataTypeName
          -8 (-4.47% of base) : Microsoft.CodeAnalysis.dasm - CompilationWithAnalyzers:GetAnalyzerDiagnosticsCoreAsync(ImmutableArray`1,bool,bool,bool,bool,CancellationToken):Task`1:this
          -8 (-0.53% of base) : System.Private.Xml.dasm - XmlTextEncoder:Write(String):this
          -7 (-4.61% of base) : Newtonsoft.Json.dasm - JsonWriter:WriteTokenAsync(JsonReader,bool,bool,bool,CancellationToken):Task:this
          -6 (-0.40% of base) : ILCompiler.Reflection.ReadyToRun.dasm - InfoHdrDecoder:DecodeHeader(ref,byref,int):InfoHdrSmall
          -6 (-0.98% of base) : Microsoft.CodeAnalysis.dasm - MetadataWriter:PopulateMethodTableRows(ref):this

Top method regressions (percentages):
          12 ( 0.93% of base) : System.Private.Xml.dasm - XmlTextReaderImpl:ParseTextAsync(int,ref,int,int,int,int,ushort):Task`1:this
           1 ( 0.35% of base) : System.Reflection.Metadata.dasm - MetadataBuilder:AddAssembly(StringHandle,Version,StringHandle,BlobHandle,int,int):AssemblyDefinitionHandle:this
           1 ( 0.08% of base) : System.Security.Cryptography.Pkcs.dasm - Rfc3161TimestampRequest:CreateFromHash(ReadOnlyMemory`1,Oid,Oid,Nullable`1,bool,X509ExtensionCollection):Rfc3161TimestampRequest
           1 ( 0.07% of base) : Microsoft.CodeAnalysis.CSharp.dasm - OverloadResolution:IsApplicable(Symbol,EffectiveParameters,AnalyzedArguments,ImmutableArray`1,bool,bool,bool,byref):MemberAnalysisResult:this

Top method improvements (percentages):
          -4 (-50.00% of base) : System.Private.CoreLib.dasm - Byte:System.IConvertible.ToInt16(IFormatProvider):short:this
          -4 (-50.00% of base) : System.Private.CoreLib.dasm - Convert:ToInt16(ubyte):short
          -4 (-44.44% of base) : System.Private.CoreLib.dasm - SByte:System.IConvertible.ToInt16(IFormatProvider):short:this
          -3 (-42.86% of base) : System.Private.CoreLib.dasm - Byte:System.IConvertible.ToChar(IFormatProvider):ushort:this
          -3 (-42.86% of base) : System.Private.CoreLib.dasm - Byte:System.IConvertible.ToUInt16(IFormatProvider):ushort:this
          -4 (-12.12% of base) : System.Private.CoreLib.dasm - Vector128:<CreateScalar>g__SoftwareFallback|55_0(byte):Vector128`1
          -4 (-11.76% of base) : System.Private.CoreLib.dasm - Vector128:<CreateScalar>g__SoftwareFallback|52_0(short):Vector128`1
          -4 (-10.53% of base) : System.Private.CoreLib.dasm - Vector64:CreateScalar(short):Vector64`1
          -4 (-10.53% of base) : System.Private.CoreLib.dasm - Vector64:<CreateScalar>g__SoftwareFallback|31_0(short):Vector64`1
         -12 (-9.84% of base) : System.Private.CoreLib.dasm - TplEventSource:CreateGuidForTaskID(int):Guid
          -3 (-9.38% of base) : System.Private.CoreLib.dasm - Vector128:<CreateScalar>g__SoftwareFallback|50_0(ubyte):Vector128`1
          -3 (-9.09% of base) : System.Private.CoreLib.dasm - Vector128:<CreateScalar>g__SoftwareFallback|57_0(ushort):Vector128`1
          -4 (-8.70% of base) : System.Private.CoreLib.dasm - PropertyValue:.ctor(byte):this
          -4 (-8.51% of base) : System.Private.CoreLib.dasm - PropertyValue:.ctor(short):this
          -3 (-8.11% of base) : System.Private.CoreLib.dasm - Vector64:CreateScalar(ubyte):Vector64`1
          -3 (-8.11% of base) : System.Private.CoreLib.dasm - Vector64:CreateScalar(byte):Vector64`1
          -3 (-8.11% of base) : System.Private.CoreLib.dasm - Vector64:CreateScalar(ushort):Vector64`1
          -3 (-8.11% of base) : System.Private.CoreLib.dasm - Vector64:<CreateScalar>g__SoftwareFallback|29_0(ubyte):Vector64`1
          -3 (-8.11% of base) : System.Private.CoreLib.dasm - Vector64:<CreateScalar>g__SoftwareFallback|34_0(byte):Vector64`1
          -3 (-8.11% of base) : System.Private.CoreLib.dasm - Vector64:<CreateScalar>g__SoftwareFallback|36_0(ushort):Vector64`1

302 total methods with Code Size differences (298 improved, 4 regressed), 200387 unchanged.
```
Regressions caused by changes in register allocation leading to extra REX prefixes.

alt-win-arm64 diff:
```
Total bytes of base: 52417208
Total bytes of diff: 52415724
Total bytes of delta: -1484 (-0.00% of base)
    diff is an improvement.


Top file improvements (bytes):
        -380 : System.Private.Xml.dasm (-0.01% of base)
        -208 : System.Net.Http.dasm (-0.03% of base)
        -192 : System.Private.CoreLib.dasm (-0.00% of base)
        -168 : Microsoft.CodeAnalysis.dasm (-0.01% of base)
         -56 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.00% of base)
         -52 : Newtonsoft.Json.dasm (-0.01% of base)
         -48 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
         -40 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00% of base)
         -40 : Microsoft.VisualBasic.Core.dasm (-0.01% of base)
         -32 : System.DirectoryServices.dasm (-0.01% of base)
         -28 : System.Text.Encoding.CodePages.dasm (-0.03% of base)
         -24 : System.Net.Security.dasm (-0.01% of base)
         -24 : System.Private.DataContractSerialization.dasm (-0.00% of base)
         -20 : System.Reflection.Metadata.dasm (-0.00% of base)
         -20 : System.Speech.dasm (-0.00% of base)
         -20 : System.Data.Common.dasm (-0.00% of base)
         -16 : System.Net.WebSockets.dasm (-0.03% of base)
         -16 : System.Net.HttpListener.dasm (-0.01% of base)
         -16 : System.Net.Quic.dasm (-0.02% of base)
         -12 : ILCompiler.Reflection.ReadyToRun.dasm (-0.01% of base)

33 total files with Code Size differences (33 improved, 0 regressed), 237 unchanged.

Top method improvements (bytes):
         -32 (-8.00% of base) : Microsoft.CodeAnalysis.dasm - CompilationWithAnalyzers:GetAnalyzerDiagnosticsCoreAsync(ImmutableArray`1,bool,bool,bool,bool,CancellationToken):Task`1:this (2 methods)
         -32 (-1.59% of base) : System.DirectoryServices.dasm - AdsValueHelper:GetValue():Object:this
         -24 (-0.83% of base) : System.Text.Encoding.CodePages.dasm - GB18030Encoding:GetChars(long,int,long,int,DecoderNLS):int:this
         -20 (-3.21% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - ReloggerEventListener:OnEventWritten(EventWrittenEventArgs):this
         -20 (-5.15% of base) : System.Speech.dasm - WAVEFORMATEX:ToWaveHeader(ref):WAVEFORMATEX
         -16 (-2.58% of base) : Microsoft.CodeAnalysis.CSharp.dasm - DynamicTypeDecoder:TransformTypeInternal(TypeSymbol,AssemblySymbol,int,ubyte,ImmutableArray`1,bool,bool):TypeSymbol (2 methods)
         -16 (-0.68% of base) : System.Private.Xml.dasm - XmlTextReaderImpl:ParseAttributes():this
         -16 (-0.34% of base) : System.Private.Xml.dasm - <ParseAttributesAsync>d__531:MoveNext():this
         -16 (-1.07% of base) : Microsoft.CodeAnalysis.dasm - MetadataWriter:PopulateMethodTableRows(ref):this (2 methods)
         -16 (-1.08% of base) : Microsoft.CodeAnalysis.dasm - MetadataWriter:PopulateGenericParamTableRows():this (2 methods)
         -16 (-7.14% of base) : Microsoft.CodeAnalysis.dasm - MetadataTypeName:FromNamespaceAndTypeName(String,String,bool,int):MetadataTypeName (2 methods)
         -16 (-5.00% of base) : Microsoft.CodeAnalysis.dasm - MetadataTypeName:FromTypeName(String,bool,int):MetadataTypeName (2 methods)
         -16 (-7.14% of base) : Microsoft.CodeAnalysis.dasm - MetadataTypeName:FromFullName(String,bool,int):MetadataTypeName (2 methods)
         -16 (-0.29% of base) : Microsoft.VisualBasic.Core.dasm - Operators:ModObject(Object,Object):Object
         -16 (-5.41% of base) : System.Net.Http.dasm - AuthenticationHelper:SendWithAuthAsync(HttpRequestMessage,Uri,bool,ICredentials,bool,bool,bool,HttpConnectionPool,CancellationToken):ValueTask`1
         -16 (-3.70% of base) : System.Net.Security.dasm - SslStream:ForceAuthenticationAsync(__Canon,bool,ref,bool):Task:this (2 methods)
         -16 (-10.81% of base) : System.Private.CoreLib.dasm - TplEventSource:CreateGuidForTaskID(int):Guid
         -12 (-6.67% of base) : System.Private.Xml.dasm - DtdParser:HandleEntityReferenceAsync(XmlQualifiedName,bool,bool,bool):Task`1:this
         -12 (-7.69% of base) : Newtonsoft.Json.dasm - JsonWriter:WriteTokenAsync(JsonReader,bool,bool,bool,CancellationToken):Task:this
         -12 (-0.85% of base) : System.Data.Common.dasm - SqlDecimal:Parse(String):SqlDecimal

Top method improvements (percentages):
          -4 (-16.67% of base) : System.Private.CoreLib.dasm - Byte:System.IConvertible.ToChar(IFormatProvider):ushort:this
          -4 (-16.67% of base) : System.Private.CoreLib.dasm - Byte:System.IConvertible.ToInt16(IFormatProvider):short:this
          -4 (-16.67% of base) : System.Private.CoreLib.dasm - Byte:System.IConvertible.ToUInt16(IFormatProvider):ushort:this
          -4 (-16.67% of base) : System.Private.CoreLib.dasm - Convert:ToInt16(ubyte):short
          -4 (-16.67% of base) : System.Private.CoreLib.dasm - SByte:System.IConvertible.ToInt16(IFormatProvider):short:this
          -4 (-12.50% of base) : System.Private.CoreLib.dasm - Vector128:CreateScalar(ubyte):Vector128`1
          -4 (-12.50% of base) : System.Private.CoreLib.dasm - Vector128:CreateScalar(short):Vector128`1
          -4 (-12.50% of base) : System.Private.CoreLib.dasm - Vector128:CreateScalar(byte):Vector128`1
          -4 (-12.50% of base) : System.Private.CoreLib.dasm - Vector128:CreateScalar(ushort):Vector128`1
          -4 (-12.50% of base) : System.Private.CoreLib.dasm - Vector128:<CreateScalar>g__SoftwareFallback|50_0(ubyte):Vector128`1
          -4 (-12.50% of base) : System.Private.CoreLib.dasm - Vector128:<CreateScalar>g__SoftwareFallback|52_0(short):Vector128`1
          -4 (-12.50% of base) : System.Private.CoreLib.dasm - Vector128:<CreateScalar>g__SoftwareFallback|55_0(byte):Vector128`1
          -4 (-12.50% of base) : System.Private.CoreLib.dasm - Vector128:<CreateScalar>g__SoftwareFallback|57_0(ushort):Vector128`1
         -16 (-10.81% of base) : System.Private.CoreLib.dasm - TplEventSource:CreateGuidForTaskID(int):Guid
          -4 (-8.33% of base) : System.Private.CoreLib.dasm - PropertyValue:.ctor(bool):this
          -4 (-8.33% of base) : System.Private.CoreLib.dasm - PropertyValue:.ctor(ubyte):this
          -4 (-8.33% of base) : System.Private.CoreLib.dasm - PropertyValue:.ctor(byte):this
          -4 (-8.33% of base) : System.Private.CoreLib.dasm - PropertyValue:.ctor(short):this
          -8 (-8.33% of base) : System.Private.CoreLib.dasm - PropertyValue:.ctor(ushort):this (2 methods)
         -32 (-8.00% of base) : Microsoft.CodeAnalysis.dasm - CompilationWithAnalyzers:GetAnalyzerDiagnosticsCoreAsync(ImmutableArray`1,bool,bool,bool,bool,CancellationToken):Task`1:this (2 methods)

257 total methods with Code Size differences (257 improved, 0 regressed), 199920 unchanged.
```