### PR TITLE
Remove some bogus GLOB_REFs

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6791,7 +6791,7 @@ GenTree* Compiler::gtCloneExpr(
 
         case GT_FIELD:
 
-            copy = gtNewFieldRef(tree->TypeGet(), tree->AsField()->gtFldHnd, nullptr, tree->AsField()->gtFldOffset);
+            copy = gtNewFieldRef(tree->TypeGet(), tree->AsField()->gtFldHnd, tree->AsField()->gtFldObj, tree->AsField()->gtFldOffset);
 
             copy->AsField()->gtFldObj = tree->AsField()->gtFldObj != nullptr
                                             ? gtCloneExpr(tree->AsField()->gtFldObj, addFlags, deepVarNum, deepVarVal)

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6371,27 +6371,22 @@ GenTree* Compiler::gtClone(GenTree* tree, bool complexOK)
                 return nullptr;
             }
 
-            if (tree->gtOper == GT_FIELD)
+            if (GenTreeField* field = tree->IsField())
             {
-                GenTree* objp;
+                GenTree* addr = field->GetAddr();
 
-                // copied from line 9850
-
-                objp = nullptr;
-                if (tree->AsField()->gtFldObj != nullptr)
+                if (addr != nullptr)
                 {
-                    objp = gtClone(tree->AsField()->gtFldObj, false);
-                    if (objp == nullptr)
+                    addr = gtClone(addr, false);
+
+                    if (addr == nullptr)
                     {
                         return nullptr;
                     }
                 }
 
-                copy = gtNewFieldRef(tree->TypeGet(), tree->AsField()->gtFldHnd, objp, tree->AsField()->gtFldOffset);
-                copy->AsField()->gtFldMayOverlap = tree->AsField()->gtFldMayOverlap;
-#ifdef FEATURE_READYTORUN_COMPILER
-                copy->AsField()->SetR2RFieldLookupAddr(tree->AsField()->GetR2RFieldLookupAddr());
-#endif
+                copy = new (this, GT_FIELD) GenTreeField(field);
+                copy->AsField()->SetAddr(addr);
             }
             else if (tree->OperIs(GT_ADD, GT_SUB))
             {
@@ -6790,16 +6785,11 @@ GenTree* Compiler::gtCloneExpr(
             break;
 
         case GT_FIELD:
-
-            copy = gtNewFieldRef(tree->TypeGet(), tree->AsField()->gtFldHnd, tree->AsField()->gtFldObj, tree->AsField()->gtFldOffset);
-
-            copy->AsField()->gtFldObj = tree->AsField()->gtFldObj != nullptr
-                                            ? gtCloneExpr(tree->AsField()->gtFldObj, addFlags, deepVarNum, deepVarVal)
-                                            : nullptr;
-            copy->AsField()->gtFldMayOverlap = tree->AsField()->gtFldMayOverlap;
-#ifdef FEATURE_READYTORUN_COMPILER
-            copy->AsField()->SetR2RFieldLookupAddr(tree->AsField()->GetR2RFieldLookupAddr());
-#endif
+            copy = new (this, GT_FIELD) GenTreeField(tree->AsField());
+            if (GenTree* addr = tree->AsField()->GetAddr())
+            {
+                copy->AsField()->SetAddr(gtCloneExpr(addr, addFlags, deepVarNum, deepVarVal));
+            }
             break;
 
         case GT_ARR_ELEM:

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -3647,9 +3647,27 @@ public:
         }
     }
 
+    GenTreeField(const GenTreeField* copyFrom)
+        : GenTree(GT_FIELD, copyFrom->GetType())
+        , gtFldObj(copyFrom->gtFldObj)
+        , gtFldHnd(copyFrom->gtFldHnd)
+        , gtFldOffset(copyFrom->gtFldOffset)
+        , gtFldMayOverlap(copyFrom->gtFldMayOverlap)
+#ifdef FEATURE_READYTORUN_COMPILER
+        , m_r2rFieldLookupAddr(copyFrom->m_r2rFieldLookupAddr)
+#endif
+    {
+    }
+
     GenTree* GetAddr() const
     {
         return gtFldObj;
+    }
+
+    void SetAddr(GenTree* addr)
+    {
+        assert((addr == nullptr) || addr->TypeIs(TYP_I_IMPL, TYP_BYREF, TYP_REF));
+        gtFldObj = addr;
     }
 
     CORINFO_FIELD_HANDLE GetFieldHandle() const


### PR DESCRIPTION
win-x64 diff:
```
Total bytes of base: 33188809
Total bytes of diff: 33188663
Total bytes of delta: -146 (-0.00% of base)
    diff is an improvement.


Top file improvements (bytes):
        -146 : System.Reflection.Metadata.dasm (-0.05% of base)

1 total files with Code Size differences (1 improved, 0 regressed), 270 unchanged.

Top method improvements (bytes):
         -57 (-12.05% of base) : System.Reflection.Metadata.dasm - LocalScope:GetLocalVariables():LocalVariableHandleCollection:this
         -57 (-12.05% of base) : System.Reflection.Metadata.dasm - LocalScope:GetLocalConstants():LocalConstantHandleCollection:this
         -16 (-24.62% of base) : System.Reflection.Metadata.dasm - MetadataReader:get_LocalVariables():LocalVariableHandleCollection:this
         -16 (-24.62% of base) : System.Reflection.Metadata.dasm - MetadataReader:get_LocalConstants():LocalConstantHandleCollection:this

Top method improvements (percentages):
         -16 (-24.62% of base) : System.Reflection.Metadata.dasm - MetadataReader:get_LocalVariables():LocalVariableHandleCollection:this
         -16 (-24.62% of base) : System.Reflection.Metadata.dasm - MetadataReader:get_LocalConstants():LocalConstantHandleCollection:this
         -57 (-12.05% of base) : System.Reflection.Metadata.dasm - LocalScope:GetLocalVariables():LocalVariableHandleCollection:this
         -57 (-12.05% of base) : System.Reflection.Metadata.dasm - LocalScope:GetLocalConstants():LocalConstantHandleCollection:this

4 total methods with Code Size differences (4 improved, 0 regressed), 201005 unchanged.
```
win-x64 pmi diff:
```
Total bytes of base: 47935099
Total bytes of diff: 47934473
Total bytes of delta: -626 (-0.00% of base)
    diff is an improvement.


Top file improvements (bytes):
        -306 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.01% of base)
        -166 : System.Reflection.Metadata.dasm (-0.04% of base)
         -57 : System.Net.Quic.dasm (-0.08% of base)
         -48 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00% of base)
         -36 : System.Memory.dasm (-0.01% of base)
         -13 : System.Text.Json.dasm (-0.00% of base)

6 total files with Code Size differences (6 improved, 0 regressed), 265 unchanged.

Top method improvements (bytes):
         -72 (-6.35% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AsyncMethodToClassRewriter:SpillArgumentListInner(ImmutableArray`1,ArrayBuilder`1,bool,byref):ImmutableArray`1:this
         -62 (-13.16% of base) : System.Reflection.Metadata.dasm - LocalScope:GetLocalVariables():LocalVariableHandleCollection:this
         -62 (-13.16% of base) : System.Reflection.Metadata.dasm - LocalScope:GetLocalConstants():LocalConstantHandleCollection:this
         -57 (-2.64% of base) : System.Net.Quic.dasm - MsQuicStream:SendReadOnlySequenceAsync(ReadOnlySequence`1,int):ValueTask:this
         -55 (-3.15% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AsyncMethodToClassRewriter:VisitAwaitOperator(BoundAwaitOperator):BoundNode:this
         -41 (-1.87% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AsyncMethodToClassRewriter:VisitLoweredConditionalAccess(BoundLoweredConditionalAccess):BoundNode:this
         -36 (-0.39% of base) : System.Memory.dasm - ReadOnlySequenceDebugView`1:.ctor(ReadOnlySequence`1):this (7 methods)
         -33 (-4.13% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AsyncMethodToClassRewriter:VisitTernaryConditionalExpression(BoundTernaryConditionalExpression):BoundNode:this
         -33 (-4.71% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AsyncMethodToClassRewriter:VisitBinaryConditionalExpression(BoundBinaryConditionalExpression):BoundNode:this
         -22 (-3.85% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AsyncMethodToClassRewriter:VisitSequence(BoundSequence):BoundNode:this
         -21 (-30.43% of base) : System.Reflection.Metadata.dasm - MetadataReader:get_LocalVariables():LocalVariableHandleCollection:this
         -21 (-30.43% of base) : System.Reflection.Metadata.dasm - MetadataReader:get_LocalConstants():LocalConstantHandleCollection:this
         -13 (-1.43% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CSharpCompilation:GetWellKnownType(int):NamedTypeSymbol:this
         -13 (-2.53% of base) : Microsoft.CodeAnalysis.CSharp.dasm - MetadataOrSourceAssemblySymbol:GetDeclaredSpecialType(byte):NamedTypeSymbol:this
         -13 (-2.78% of base) : Microsoft.CodeAnalysis.CSharp.dasm - MissingCorLibrarySymbol:GetDeclaredSpecialType(byte):NamedTypeSymbol:this
         -13 (-2.49% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - MetadataOrSourceAssemblySymbol:GetDeclaredSpecialType(byte):NamedTypeSymbol:this
         -13 (-2.76% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - MissingCorLibrarySymbol:GetDeclaredSpecialType(byte):NamedTypeSymbol:this
         -13 (-1.85% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VisualBasicCompilation:GetWellKnownType(int):NamedTypeSymbol:this
         -11 (-1.16% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AsyncMethodToClassRewriter:VisitBinaryOperator(BoundBinaryOperator):BoundNode:this
         -10 (-0.45% of base) : System.Text.Json.dasm - Utf8JsonReader:UnescapeSequenceAndCompare(ReadOnlySpan`1):bool:this

Top method improvements (percentages):
         -21 (-30.43% of base) : System.Reflection.Metadata.dasm - MetadataReader:get_LocalVariables():LocalVariableHandleCollection:this
         -21 (-30.43% of base) : System.Reflection.Metadata.dasm - MetadataReader:get_LocalConstants():LocalConstantHandleCollection:this
         -62 (-13.16% of base) : System.Reflection.Metadata.dasm - LocalScope:GetLocalVariables():LocalVariableHandleCollection:this
         -62 (-13.16% of base) : System.Reflection.Metadata.dasm - LocalScope:GetLocalConstants():LocalConstantHandleCollection:this
         -72 (-6.35% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AsyncMethodToClassRewriter:SpillArgumentListInner(ImmutableArray`1,ArrayBuilder`1,bool,byref):ImmutableArray`1:this
         -33 (-4.71% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AsyncMethodToClassRewriter:VisitBinaryConditionalExpression(BoundBinaryConditionalExpression):BoundNode:this
         -33 (-4.13% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AsyncMethodToClassRewriter:VisitTernaryConditionalExpression(BoundTernaryConditionalExpression):BoundNode:this
         -22 (-3.85% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AsyncMethodToClassRewriter:VisitSequence(BoundSequence):BoundNode:this
         -55 (-3.15% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AsyncMethodToClassRewriter:VisitAwaitOperator(BoundAwaitOperator):BoundNode:this
         -13 (-2.78% of base) : Microsoft.CodeAnalysis.CSharp.dasm - MissingCorLibrarySymbol:GetDeclaredSpecialType(byte):NamedTypeSymbol:this
         -13 (-2.76% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - MissingCorLibrarySymbol:GetDeclaredSpecialType(byte):NamedTypeSymbol:this
         -57 (-2.64% of base) : System.Net.Quic.dasm - MsQuicStream:SendReadOnlySequenceAsync(ReadOnlySequence`1,int):ValueTask:this
         -13 (-2.53% of base) : Microsoft.CodeAnalysis.CSharp.dasm - MetadataOrSourceAssemblySymbol:GetDeclaredSpecialType(byte):NamedTypeSymbol:this
         -13 (-2.49% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - MetadataOrSourceAssemblySymbol:GetDeclaredSpecialType(byte):NamedTypeSymbol:this
         -41 (-1.87% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AsyncMethodToClassRewriter:VisitLoweredConditionalAccess(BoundLoweredConditionalAccess):BoundNode:this
         -13 (-1.85% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VisualBasicCompilation:GetWellKnownType(int):NamedTypeSymbol:this
         -13 (-1.43% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CSharpCompilation:GetWellKnownType(int):NamedTypeSymbol:this
         -11 (-1.16% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AsyncMethodToClassRewriter:VisitBinaryOperator(BoundBinaryOperator):BoundNode:this
          -9 (-1.15% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CSharpCompilation:GetHostObjectTypeSymbol():TypeSymbol:this
         -10 (-0.45% of base) : System.Text.Json.dasm - Utf8JsonReader:UnescapeSequenceAndCompare(ReadOnlySpan`1):bool:this

22 total methods with Code Size differences (22 improved, 0 regressed), 239421 unchanged.
```