### PR TITLE
Don't add temps for local address call args

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -1926,7 +1926,8 @@ public:
     Statement* gtNewStmt(GenTree* expr = nullptr, IL_OFFSETX offset = BAD_IL_OFFSET);
 
     // For unary opers.
-    GenTree* gtNewOperNode(genTreeOps oper, var_types type, GenTree* op1, bool doSimplifications = TRUE);
+    GenTree* gtNewOperNode(genTreeOps oper, var_types type, GenTree* op1, bool doSimplifications = true);
+    GenTree* gtNewAddrNode(GenTree* location, var_types type = TYP_BYREF);
 
     // For binary opers.
     GenTreeOp* gtNewOperNode(genTreeOps oper, var_types type, GenTree* op1, GenTree* op2);

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -899,6 +899,18 @@ inline GenTree* Compiler::gtNewOperNode(genTreeOps oper, var_types type, GenTree
     return node;
 }
 
+inline GenTree* Compiler::gtNewAddrNode(GenTree* location, var_types type)
+{
+    if (location->OperIs(GT_IND) && ((location->gtFlags & GTF_IND_ARR_INDEX) == 0))
+    {
+        return location->AsIndir()->GetAddr();
+    }
+
+    location->SetDoNotCSE();
+
+    return new (this, GT_ADDR) GenTreeOp(GT_ADDR, type, location, nullptr);
+}
+
 // Returns an opcode that is of the largest node size in use.
 inline genTreeOps LargeOpOpcode()
 {

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -1378,7 +1378,7 @@ bool Compiler::inlAnalyzeInlineeSignature(InlineInfo* inlineInfo)
             // But this is done only if the arg represents a local address which is BYREF
             // in spec but in reality is just a native pointer.
 
-            if (argNode->IsLocalAddrExpr() == nullptr)
+            if (!impIsAddressInLocal(argNode))
             {
                 inlineInfo->inlineResult->NoteFatal(InlineObservation::CALLSITE_ARG_NO_BASH_TO_INT);
                 return false;

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -369,7 +369,7 @@ private:
             case GT_HWINTRINSIC:
 #endif
                 // TODO-MIKE-Cleanup: Bleah, more ADDR(SIMD|HWINTRINSIC) nonsense...
-                return m_compiler->gtNewOperNode(GT_ADDR, TYP_BYREF, tree);
+                return m_compiler->gtNewAddrNode(tree);
 
             default:
                 unreached();
@@ -389,7 +389,7 @@ private:
                 return dst;
             }
 
-            return m_compiler->gtNewObjNode(layout, m_compiler->gtNewOperNode(GT_ADDR, TYP_I_IMPL, dst));
+            return m_compiler->gtNewObjNode(layout, m_compiler->gtNewAddrNode(dst, TYP_I_IMPL));
         }
 
         GenTree* dstAddr = GetStructAddress(dst);
@@ -1061,7 +1061,7 @@ bool Compiler::inlImportReturn(InlineInfo* inlineInfo, GenTree* retExpr, CORINFO
 
         if (varTypeIsStruct(retExpr->GetType()))
         {
-            GenTree* lclAddr = gtNewOperNode(GT_ADDR, TYP_I_IMPL, lclVar);
+            GenTree* lclAddr = gtNewAddrNode(lclVar, TYP_I_IMPL);
 
             asg = impAssignStructPtr(lclAddr, retExpr, retExprClass, CHECK_SPILL_NONE);
         }
@@ -2308,7 +2308,7 @@ Statement* Compiler::inlInitInlineeArgs(const InlineInfo* inlineInfo, Statement*
                 assert(!argNode->OperIs(GT_COMMA));
 
                 GenTree* dst     = gtNewLclvNode(argInfo.paramLclNum, argInfo.paramType);
-                GenTree* dstAddr = gtNewOperNode(GT_ADDR, TYP_BYREF, dst);
+                GenTree* dstAddr = gtNewAddrNode(dst, TYP_BYREF);
                 asg              = impAssignStructPtr(dstAddr, argNode, argClass, CHECK_SPILL_NONE);
 
                 if (restoreLayout)

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -1784,10 +1784,8 @@ GenTree* Compiler::fgCreateMonitorTree(unsigned lvaMonAcquired, unsigned lvaThis
 {
     // Insert the expression "enter/exitCrit(this, &acquired)" or "enter/exitCrit(handle, &acquired)"
 
-    var_types typeMonAcquired = TYP_UBYTE;
-    GenTree*  varNode         = gtNewLclvNode(lvaMonAcquired, typeMonAcquired);
-    GenTree*  varAddrNode     = gtNewAddrNode(varNode);
-    GenTree*  tree;
+    GenTree* varAddrNode = gtNewLclVarAddrNode(lvaMonAcquired);
+    GenTree* tree;
 
     if (info.compIsStatic)
     {
@@ -1917,10 +1915,7 @@ void Compiler::fgAddReversePInvokeEnterExit()
 
     // Add enter pinvoke exit callout at the start of prolog
 
-    GenTree* pInvokeFrameVar = gtNewAddrNode(gtNewLclvNode(lvaReversePInvokeFrameVar, TYP_BLK), TYP_I_IMPL);
-
-    GenTree* tree;
-
+    GenTree*        pInvokeFrameVar = gtNewLclVarAddrNode(lvaReversePInvokeFrameVar);
     CorInfoHelpFunc reversePInvokeEnterHelper;
 
     GenTreeCall::Use* args;
@@ -1950,7 +1945,7 @@ void Compiler::fgAddReversePInvokeEnterExit()
         args                      = gtNewCallArgs(pInvokeFrameVar);
     }
 
-    tree = gtNewHelperCallNode(reversePInvokeEnterHelper, TYP_VOID, args);
+    GenTree* tree = gtNewHelperCallNode(reversePInvokeEnterHelper, TYP_VOID, args);
 
     fgEnsureFirstBBisScratch();
 
@@ -1968,7 +1963,7 @@ void Compiler::fgAddReversePInvokeEnterExit()
 
     // Add reverse pinvoke exit callout at the end of epilog
 
-    tree = gtNewAddrNode(gtNewLclvNode(lvaReversePInvokeFrameVar, TYP_BLK), TYP_I_IMPL);
+    tree = gtNewLclVarAddrNode(lvaReversePInvokeFrameVar);
 
     CorInfoHelpFunc reversePInvokeExitHelper = opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TRACK_TRANSITIONS)
                                                    ? CORINFO_HELP_JIT_REVERSE_PINVOKE_EXIT_TRACK_TRANSITIONS

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -1786,7 +1786,7 @@ GenTree* Compiler::fgCreateMonitorTree(unsigned lvaMonAcquired, unsigned lvaThis
 
     var_types typeMonAcquired = TYP_UBYTE;
     GenTree*  varNode         = gtNewLclvNode(lvaMonAcquired, typeMonAcquired);
-    GenTree*  varAddrNode     = gtNewOperNode(GT_ADDR, TYP_BYREF, varNode);
+    GenTree*  varAddrNode     = gtNewAddrNode(varNode);
     GenTree*  tree;
 
     if (info.compIsStatic)
@@ -1917,7 +1917,7 @@ void Compiler::fgAddReversePInvokeEnterExit()
 
     // Add enter pinvoke exit callout at the start of prolog
 
-    GenTree* pInvokeFrameVar = gtNewOperNode(GT_ADDR, TYP_I_IMPL, gtNewLclvNode(lvaReversePInvokeFrameVar, TYP_BLK));
+    GenTree* pInvokeFrameVar = gtNewAddrNode(gtNewLclvNode(lvaReversePInvokeFrameVar, TYP_BLK), TYP_I_IMPL);
 
     GenTree* tree;
 
@@ -1968,7 +1968,7 @@ void Compiler::fgAddReversePInvokeEnterExit()
 
     // Add reverse pinvoke exit callout at the end of epilog
 
-    tree = gtNewOperNode(GT_ADDR, TYP_I_IMPL, gtNewLclvNode(lvaReversePInvokeFrameVar, TYP_BLK));
+    tree = gtNewAddrNode(gtNewLclvNode(lvaReversePInvokeFrameVar, TYP_BLK), TYP_I_IMPL);
 
     CorInfoHelpFunc reversePInvokeExitHelper = opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TRACK_TRANSITIONS)
                                                    ? CORINFO_HELP_JIT_REVERSE_PINVOKE_EXIT_TRACK_TRANSITIONS

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6420,7 +6420,7 @@ GenTree* Compiler::gtClone(GenTree* tree, bool complexOK)
                 {
                     return nullptr;
                 }
-                copy = gtNewOperNode(GT_ADDR, tree->TypeGet(), op1);
+                copy = gtNewAddrNode(op1, tree->GetType());
             }
             else
             {
@@ -12095,7 +12095,7 @@ GenTree* Compiler::gtTryRemoveBoxUpstreamEffects(GenTree* op, BoxRemovalOptions 
         DISPSTMT(copyStmt);
 
         // Return the address of the now-struct typed box temp
-        return gtNewOperNode(GT_ADDR, TYP_BYREF, gtNewLclvNode(boxTempLclNum, boxTempLclDsc->TypeGet()));
+        return gtNewAddrNode(gtNewLclvNode(boxTempLclNum, boxTempLclDsc->GetType()));
     }
 
     // If the copy is a struct copy, make sure we know how to isolate
@@ -13946,7 +13946,7 @@ GenTree* Compiler::gtNewTempAssign(unsigned tmp, GenTree* val)
         dest->gtFlags |= GTF_DONT_CSE;
         valx->gtFlags |= GTF_DONT_CSE;
 
-        GenTree* destAddr = gtNewOperNode(GT_ADDR, TYP_BYREF, dest);
+        GenTree* destAddr = gtNewAddrNode(dest);
         asg               = impAssignStructPtr(destAddr, val, valStructHnd, CHECK_SPILL_NONE);
     }
     else

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2671,7 +2671,7 @@ bool Compiler::gtCanSwapOrder(GenTree* firstNode, GenTree* secondNode)
             if (firstNode->gtFlags & strictEffects & GTF_PERSISTENT_SIDE_EFFECTS)
             {
                 // We have to be conservative - can swap iff op2 is constant.
-                if (!secondNode->IsInvariant())
+                if (!secondNode->OperIsConst())
                 {
                     canSwap = false;
                 }
@@ -17497,9 +17497,4 @@ bool Compiler::gtIsSmallIntCastNeeded(GenTree* tree, var_types toType)
     }
 
     return varTypeIsUnsigned(fromType) != varTypeIsUnsigned(toType);
-}
-
-bool GenTree::IsInvariant()
-{
-    return OperIsConst() || (Compiler::impIsAddressInLocal(this) != nullptr);
 }

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -2084,11 +2084,9 @@ private:
 public:
     bool Precedes(GenTree* other);
 
-    bool IsInvariant();
-
     bool IsReuseRegValCandidate()
     {
-        return IsInvariant() || IsHWIntrinsicZero();
+        return OperIsConst() || IsHWIntrinsicZero();
     }
 
     bool IsReuseRegVal()

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -6678,7 +6678,7 @@ GenTree* Compiler::fgCreateCallDispatcherAndGetResult(GenTreeCall*          orig
 
         var_types tmpRetBufType = lvaGetDesc(tmpRetBufNum)->TypeGet();
 
-        retValArg = gtNewOperNode(GT_ADDR, TYP_I_IMPL, gtNewLclvNode(tmpRetBufNum, tmpRetBufType));
+        retValArg = gtNewAddrNode(gtNewLclvNode(tmpRetBufNum, tmpRetBufType), TYP_I_IMPL);
 
         var_types callerRetBufType = lvaGetDesc(info.compRetBuffArg)->TypeGet();
 
@@ -8661,7 +8661,7 @@ GenTree* Compiler::fgMorphBlkNode(GenTree* tree, bool isDest)
         // and nothing updates the value numbers of the COMMA chain, they'll still have the
         // VN of the original effective value instead of its address.
 
-        GenTree* effectiveValAddr = gtNewOperNode(GT_ADDR, TYP_BYREF, effectiveVal);
+        GenTree* effectiveValAddr = gtNewAddrNode(effectiveVal);
         INDEBUG(effectiveValAddr->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;)
         commas.Top()->SetOp(1, effectiveValAddr);
 
@@ -9282,7 +9282,7 @@ GenTree* Compiler::fgMorphCopyBlock(GenTreeOp* asg)
         {
             if (src->GetType() != dest->GetType())
             {
-                src = gtNewIndir(dest->GetType(), gtNewOperNode(GT_ADDR, TYP_I_IMPL, srcLclNode));
+                src = gtNewIndir(dest->GetType(), gtNewAddrNode(srcLclNode, TYP_I_IMPL));
                 src->gtFlags |= srcLclVar->lvAddrExposed ? GTF_GLOB_REF : 0;
             }
         }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -969,7 +969,7 @@ void CallInfo::ArgsComplete(Compiler* compiler, GenTreeCall* call)
                 needsTemps = true;
             }
 
-            // For all previous arguments, unless they are a simple constant
+            // For all previous arguments, unless they are constants or local addresses
             // we require that they be evaluated into temps
 
             for (unsigned prevArgIndex = 0; prevArgIndex < argIndex; prevArgIndex++)
@@ -978,7 +978,7 @@ void CallInfo::ArgsComplete(Compiler* compiler, GenTreeCall* call)
 
                 assert(prevArgInfo->GetArgNum() < argInfo->GetArgNum());
 
-                if (!prevArgInfo->GetNode()->IsInvariant())
+                if (!prevArgInfo->GetNode()->OperIsConst() && !prevArgInfo->GetNode()->OperIsLocalAddr())
                 {
                     prevArgInfo->SetTempNeeded();
                     needsTemps = true;

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -6678,7 +6678,7 @@ GenTree* Compiler::fgCreateCallDispatcherAndGetResult(GenTreeCall*          orig
 
         var_types tmpRetBufType = lvaGetDesc(tmpRetBufNum)->TypeGet();
 
-        retValArg = gtNewAddrNode(gtNewLclvNode(tmpRetBufNum, tmpRetBufType), TYP_I_IMPL);
+        retValArg = gtNewLclVarAddrNode(tmpRetBufNum);
 
         var_types callerRetBufType = lvaGetDesc(info.compRetBuffArg)->TypeGet();
 

--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -855,9 +855,8 @@ void ObjectAllocator::RewriteUses()
                 if (m_allocator->m_HeapLocalToStackLocalMap.TryGetValue(lclNum, &newLclNum))
                 {
                     newType = TYP_I_IMPL;
-                    tree =
-                        m_compiler->gtNewOperNode(GT_ADDR, newType, m_compiler->gtNewLclvNode(newLclNum, TYP_STRUCT));
-                    *use = tree;
+                    tree    = m_compiler->gtNewAddrNode(m_compiler->gtNewLclvNode(newLclNum, TYP_STRUCT), newType);
+                    *use    = tree;
                 }
                 else
                 {

--- a/src/coreclr/jit/patchpoint.cpp
+++ b/src/coreclr/jit/patchpoint.cpp
@@ -163,8 +163,7 @@ private:
         //
         // call PPHelper(&ppCounter, ilOffset)
         GenTree*          ilOffsetNode  = compiler->gtNewIconNode(ilOffset, TYP_INT);
-        GenTree*          ppCounterRef  = compiler->gtNewLclvNode(ppCounterLclNum, TYP_INT);
-        GenTree*          ppCounterAddr = compiler->gtNewAddrNode(ppCounterRef, TYP_I_IMPL);
+        GenTree*          ppCounterAddr = compiler->gtNewLclVarAddrNode(ppCounterLclNum);
         GenTreeCall::Use* helperArgs    = compiler->gtNewCallArgs(ppCounterAddr, ilOffsetNode);
         GenTreeCall*      helperCall    = compiler->gtNewHelperCallNode(CORINFO_HELP_PATCHPOINT, TYP_VOID, helperArgs);
 

--- a/src/coreclr/jit/patchpoint.cpp
+++ b/src/coreclr/jit/patchpoint.cpp
@@ -164,7 +164,7 @@ private:
         // call PPHelper(&ppCounter, ilOffset)
         GenTree*          ilOffsetNode  = compiler->gtNewIconNode(ilOffset, TYP_INT);
         GenTree*          ppCounterRef  = compiler->gtNewLclvNode(ppCounterLclNum, TYP_INT);
-        GenTree*          ppCounterAddr = compiler->gtNewOperNode(GT_ADDR, TYP_I_IMPL, ppCounterRef);
+        GenTree*          ppCounterAddr = compiler->gtNewAddrNode(ppCounterRef, TYP_I_IMPL);
         GenTreeCall::Use* helperArgs    = compiler->gtNewCallArgs(ppCounterAddr, ilOffsetNode);
         GenTreeCall*      helperCall    = compiler->gtNewHelperCallNode(CORINFO_HELP_PATCHPOINT, TYP_VOID, helperArgs);
 


### PR DESCRIPTION
win-x64 diff:
```
Total bytes of base: 33188663
Total bytes of diff: 33182416
Total bytes of delta: -6247 (-0.02% of base)
    diff is an improvement.


Top file regressions (bytes):
          61 : System.Security.Cryptography.Pkcs.dasm (0.02% of base)
           5 : System.Private.Uri.dasm (0.01% of base)
           5 : System.Text.Json.dasm (0.00% of base)
           2 : System.Security.Cryptography.Primitives.dasm (0.01% of base)

Top file improvements (bytes):
       -3481 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.11% of base)
        -579 : System.Net.Http.dasm (-0.11% of base)
        -339 : System.Private.CoreLib.dasm (-0.01% of base)
        -224 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.01% of base)
        -168 : System.Net.Security.dasm (-0.08% of base)
        -162 : System.Data.Common.dasm (-0.01% of base)
        -157 : System.Collections.Immutable.dasm (-0.07% of base)
        -123 : Microsoft.CodeAnalysis.CSharp.dasm (-0.01% of base)
        -117 : System.Reflection.Metadata.dasm (-0.04% of base)
         -92 : System.Formats.Asn1.dasm (-0.15% of base)
         -89 : System.Private.Xml.dasm (-0.00% of base)
         -77 : System.Net.HttpListener.dasm (-0.04% of base)
         -75 : System.Threading.Tasks.Dataflow.dasm (-0.05% of base)
         -70 : Microsoft.CodeAnalysis.dasm (-0.01% of base)
         -57 : System.Security.Cryptography.Algorithms.dasm (-0.02% of base)
         -46 : System.Memory.dasm (-0.06% of base)
         -37 : System.Net.Mail.dasm (-0.02% of base)
         -30 : System.IO.Pipes.dasm (-0.09% of base)
         -30 : System.Net.Quic.dasm (-0.05% of base)
         -30 : System.Runtime.Numerics.dasm (-0.04% of base)

56 total files with Code Size differences (52 improved, 4 regressed), 215 unchanged.

Top method regressions (bytes):
          36 ( 2.42% of base) : System.Security.Cryptography.Pkcs.dasm - ManagedPkcsPal:Encrypt(CmsRecipientCollection,ContentInfo,AlgorithmIdentifier,X509Certificate2Collection,CryptographicAttributeObjectCollection,ref,ref,ref):ref:this
          29 ( 3.65% of base) : System.Data.Common.dasm - DataTable:ParseSortString(String):ref:this
          20 ( 2.31% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceMemberFieldSymbol:ComputeWithEventsFieldType(PropertySymbol,ModifiedIdentifierSyntax,Binder,bool,DiagnosticBag):TypeSymbol
          18 ( 5.19% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - OverloadResolutionResult:GetBestResult(ImmutableArray`1):Nullable`1
          18 ( 2.30% of base) : System.Security.Cryptography.Algorithms.dasm - EccKeyFormatHelper:FromECPublicKey(ReadOnlyMemory`1,byref,byref)
          15 ( 2.03% of base) : System.Security.Cryptography.Algorithms.dasm - SpecifiedECDomain:Encode(AsnWriter,Asn1Tag):this
          15 ( 2.03% of base) : System.Security.Cryptography.Cng.dasm - SpecifiedECDomain:Encode(AsnWriter,Asn1Tag):this
          13 ( 0.70% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - ArgumentNode:InferTypeAndPropagateHints():bool:this
          10 ( 0.73% of base) : System.Security.Cryptography.Pkcs.dasm - SignedCms:ComputeSignature(CmsSigner,bool):this
           9 ( 0.97% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VisualBasicSyntaxRewriter:VisitLambdaHeader(LambdaHeaderSyntax):SyntaxNode:this
           8 ( 1.44% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VisualBasicSyntaxRewriter:VisitVariableDeclarator(VariableDeclaratorSyntax):SyntaxNode:this
           8 ( 3.14% of base) : System.Collections.Immutable.dasm - Builder:set_Item(__Canon,__Canon):this (2 methods)
           8 ( 3.33% of base) : System.Collections.Immutable.dasm - Builder:Add(__Canon,__Canon):this (2 methods)
           5 ( 0.32% of base) : System.Private.Uri.dasm - IPv6AddressHelper:ParseCanonicalName(String,int,byref,byref):String
           5 ( 2.26% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:Add(__Canon):ImmutableHashSet`1:this
           5 ( 2.26% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:Remove(__Canon):ImmutableHashSet`1:this
           5 ( 2.02% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:Intersect(IEnumerable`1):ImmutableHashSet`1:this
           5 ( 2.02% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:SymmetricExcept(IEnumerable`1):ImmutableHashSet`1:this
           4 ( 0.60% of base) : System.Text.Json.dasm - JsonDocument:TextEquals(int,ReadOnlySpan`1,bool,bool):bool:this
           4 ( 0.49% of base) : System.Private.CoreLib.dasm - CustomAttributeData:get_NamedArguments():IList`1:this

Top method improvements (bytes):
       -3478 (-5.83% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - CtfTraceEventSource:InitEventMap():Dictionary`2
        -297 (-3.27% of base) : System.Net.Http.dasm - QPackStaticTable:.cctor()
        -138 (-3.09% of base) : System.Net.Http.dasm - Http2Stream:.cctor()
        -106 (-0.90% of base) : System.Reflection.Metadata.dasm - MetadataReader:InitializeTableReaders(MemoryBlock,ubyte,ref,ref):this
         -99 (-7.72% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - OverloadResolution:InferTypeArguments(byref,ImmutableArray`1,ImmutableArray`1,TypeSymbol,BoundNode,byref,Binder,byref):bool
         -56 (-2.74% of base) : System.Formats.Asn1.dasm - AsnDecoder:ProcessConstructedBitString(ReadOnlySpan`1,int,Span`1,BitStringCopyAction,bool,byref,byref):int
         -51 (-2.56% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - ReducedExtensionMethodSymbol:Create(TypeSymbol,MethodSymbol,int):MethodSymbol
         -51 (-2.82% of base) : System.Private.CoreLib.dasm - ArraySegment`1:GetEnumerator():Enumerator:this (17 methods)
         -49 (-4.22% of base) : Microsoft.CodeAnalysis.dasm - CommonReferenceManager`2:GetInitialReferenceBindingsToProcess(ImmutableArray`1,ImmutableArray`1,ImmutableArray`1,ArrayBuilder`1,int,ArrayBuilder`1):this
         -45 (-2.36% of base) : System.Data.Common.dasm - TimeSpanStorage:Aggregate(ref,int):Object:this
         -39 (-1.92% of base) : System.Private.Xml.dasm - XmlDocument:.cctor()
         -37 (-1.24% of base) : System.Net.Security.dasm - <WriteAsyncInternal>d__183`1:MoveNext():this (3 methods)
         -34 (-10.93% of base) : System.Private.CoreLib.dasm - CustomAttribute:GetCustomAttributes(RuntimeModule,int,int,RuntimeType):ref
         -30 (-8.31% of base) : System.IO.Pipes.dasm - PipeStream:WriteAsync(ReadOnlyMemory`1,CancellationToken):ValueTask:this
         -29 (-1.18% of base) : System.Diagnostics.Process.dasm - NtProcessManager:GetProcessInfos(PerformanceCounterLib,int,int,ReadOnlySpan`1):ref
         -25 (-3.89% of base) : System.Net.HttpListener.dasm - SSPIWrapper:QueryBlittableContextAttributes(ISSPIInterface,SafeDeleteContext,int,Type,byref,byref):bool (2 methods)
         -25 (-3.92% of base) : System.Net.Security.dasm - SSPIWrapper:QueryBlittableContextAttributes(ISSPIInterface,SafeDeleteContext,int,Type,byref,byref):bool (2 methods)
         -24 (-2.82% of base) : System.Drawing.Common.dasm - PageSettings:get_PrintableArea():RectangleF:this
         -23 (-1.10% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:ResolveMethodForDelegateInvokeFullOrRelaxed(BoundAddressOfOperator,MethodSymbol,bool,DiagnosticBag,bool,byref):KeyValuePair`2
         -23 (-2.63% of base) : System.Security.Cryptography.Pkcs.dasm - Pkcs12SafeContents:Decrypt(ReadOnlySpan`1,ReadOnlySpan`1):this

Top method regressions (percentages):
          18 ( 5.19% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - OverloadResolutionResult:GetBestResult(ImmutableArray`1):Nullable`1
          29 ( 3.65% of base) : System.Data.Common.dasm - DataTable:ParseSortString(String):ref:this
           8 ( 3.33% of base) : System.Collections.Immutable.dasm - Builder:Add(__Canon,__Canon):this (2 methods)
           8 ( 3.14% of base) : System.Collections.Immutable.dasm - Builder:set_Item(__Canon,__Canon):this (2 methods)
          36 ( 2.42% of base) : System.Security.Cryptography.Pkcs.dasm - ManagedPkcsPal:Encrypt(CmsRecipientCollection,ContentInfo,AlgorithmIdentifier,X509Certificate2Collection,CryptographicAttributeObjectCollection,ref,ref,ref):ref:this
          20 ( 2.31% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceMemberFieldSymbol:ComputeWithEventsFieldType(PropertySymbol,ModifiedIdentifierSyntax,Binder,bool,DiagnosticBag):TypeSymbol
          18 ( 2.30% of base) : System.Security.Cryptography.Algorithms.dasm - EccKeyFormatHelper:FromECPublicKey(ReadOnlyMemory`1,byref,byref)
           5 ( 2.26% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:Add(__Canon):ImmutableHashSet`1:this
           5 ( 2.26% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:Remove(__Canon):ImmutableHashSet`1:this
          15 ( 2.03% of base) : System.Security.Cryptography.Algorithms.dasm - SpecifiedECDomain:Encode(AsnWriter,Asn1Tag):this
          15 ( 2.03% of base) : System.Security.Cryptography.Cng.dasm - SpecifiedECDomain:Encode(AsnWriter,Asn1Tag):this
           5 ( 2.02% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:Intersect(IEnumerable`1):ImmutableHashSet`1:this
           5 ( 2.02% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:SymmetricExcept(IEnumerable`1):ImmutableHashSet`1:this
           2 ( 1.80% of base) : System.Reflection.MetadataLoadContext.dasm - EcmaToStringHelpers:ToTypeString(TypeSpecificationHandle,MetadataReader,byref):String
           2 ( 1.67% of base) : Microsoft.CodeAnalysis.dasm - RealParser:MultiplyByPowerOfTen(byref,int)
           2 ( 1.67% of base) : Microsoft.CodeAnalysis.dasm - RealParser:ShiftLeft(byref,int)
           4 ( 1.53% of base) : System.Linq.Parallel.dasm - HashLookup`2:get_Item(int):KeyValuePair`2:this (2 methods)
           8 ( 1.44% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VisualBasicSyntaxRewriter:VisitVariableDeclarator(VariableDeclaratorSyntax):SyntaxNode:this
           4 ( 1.29% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:Union(IEnumerable`1,bool):ImmutableHashSet`1:this
           2 ( 1.26% of base) : System.Collections.Immutable.dasm - ImmutableDictionary`2:SetItems(IEnumerable`1):ImmutableDictionary`2:this

Top method improvements (percentages):
          -7 (-14.89% of base) : System.Net.HttpListener.dasm - HttpListenerRequest:get_RequestTraceIdentifier():Guid:this
         -34 (-10.93% of base) : System.Private.CoreLib.dasm - CustomAttribute:GetCustomAttributes(RuntimeModule,int,int,RuntimeType):ref
         -15 (-9.49% of base) : System.Speech.dasm - AudioDeviceOut:GetDeviceName(int,byref):int
         -30 (-8.31% of base) : System.IO.Pipes.dasm - PipeStream:WriteAsync(ReadOnlyMemory`1,CancellationToken):ValueTask:this
         -14 (-7.73% of base) : System.Collections.Immutable.dasm - ImmutableDictionary`2:SetItem(__Canon,__Canon):ImmutableDictionary`2:this
         -99 (-7.72% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - OverloadResolution:InferTypeArguments(byref,ImmutableArray`1,ImmutableArray`1,TypeSymbol,BoundNode,byref,Binder,byref):bool
         -14 (-7.65% of base) : System.Collections.Immutable.dasm - ImmutableDictionary`2:Add(__Canon,__Canon):ImmutableDictionary`2:this
         -22 (-7.53% of base) : System.Private.CoreLib.dasm - MemoryExtensions:TrimStart(Span`1,ReadOnlySpan`1):Span`1
         -15 (-6.58% of base) : Microsoft.CodeAnalysis.CSharp.dasm - PEModuleSymbol:GetCustomAttributesFilterExtensions(EntityHandle,byref):ImmutableArray`1:this
          -4 (-6.35% of base) : System.Net.HttpListener.dasm - HttpListenerTimeoutManager:get_EntityBody():TimeSpan:this
          -4 (-6.35% of base) : System.Net.HttpListener.dasm - HttpListenerTimeoutManager:get_DrainEntityBody():TimeSpan:this
          -4 (-6.35% of base) : System.Net.HttpListener.dasm - HttpListenerTimeoutManager:get_RequestQueue():TimeSpan:this
          -4 (-6.35% of base) : System.Net.HttpListener.dasm - HttpListenerTimeoutManager:get_IdleConnection():TimeSpan:this
          -4 (-6.35% of base) : System.Net.HttpListener.dasm - HttpListenerTimeoutManager:get_HeaderWait():TimeSpan:this
          -4 (-6.06% of base) : System.Net.HttpListener.dasm - HttpListenerTimeoutManager:GetTimeout(int):TimeSpan:this
         -18 (-6.02% of base) : System.Private.CoreLib.dasm - MemoryExtensions:TrimEnd(Span`1,ReadOnlySpan`1):Span`1
       -3478 (-5.83% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - CtfTraceEventSource:InitEventMap():Dictionary`2
         -12 (-4.92% of base) : System.Security.Cryptography.Pkcs.dasm - Pkcs12CertBag:.ctor(X509Certificate2):this
          -7 (-4.90% of base) : System.Collections.Immutable.dasm - ImmutableArray`1:Contains(KeyValuePair`2):bool:this
          -6 (-4.84% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Conversion:ToArrayIndexConversion():Conversion:this

530 total methods with Code Size differences (392 improved, 138 regressed), 200479 unchanged.
```
linux-x64 diff:
```
Total bytes of delta: -345 (-0.00% of base)
    diff is an improvement.


Top file regressions (bytes):
           7 : System.Security.Cryptography.Pkcs.dasm (0.00% of base)
           2 : System.Private.CoreLib.dasm (0.00% of base)
           1 : ILCompiler.Reflection.ReadyToRun.dasm (0.00% of base)

Top file improvements (bytes):
        -106 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.00% of base)
         -50 : System.Private.Xml.dasm (-0.00% of base)
         -46 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00% of base)
         -37 : System.Net.HttpListener.dasm (-0.02% of base)
         -27 : System.Reflection.MetadataLoadContext.dasm (-0.01% of base)
         -24 : System.Data.Common.dasm (-0.00% of base)
         -18 : System.Collections.Concurrent.dasm (-0.02% of base)
         -10 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
          -8 : System.Diagnostics.DiagnosticSource.dasm (-0.01% of base)
          -8 : System.Security.Cryptography.X509Certificates.dasm (-0.00% of base)
          -6 : System.Net.Http.dasm (-0.00% of base)
          -5 : Microsoft.VisualBasic.Core.dasm (-0.00% of base)
          -4 : System.Linq.Parallel.dasm (-0.00% of base)
          -3 : System.Collections.NonGeneric.dasm (-0.01% of base)
          -3 : System.Net.Quic.dasm (-0.00% of base)

18 total files with Code Size differences (15 improved, 3 regressed), 253 unchanged.

Top method regressions (bytes):
          31 ( 1.70% of base) : System.Security.Cryptography.Pkcs.dasm - ManagedPkcsPal:Encrypt(CmsRecipientCollection,ContentInfo,AlgorithmIdentifier,X509Certificate2Collection,CryptographicAttributeObjectCollection,ref,ref,ref):ref:this
           1 ( 0.75% of base) : ILCompiler.Reflection.ReadyToRun.dasm - PgoSchemaMergeComparer:Compare(PgoSchemaElem,PgoSchemaElem):int:this
           1 ( 0.11% of base) : System.Private.CoreLib.dasm - CustomAttributeTypedArgument:.ctor(RuntimeModule,CustomAttributeEncodedArgument):this
           1 ( 0.05% of base) : System.Private.CoreLib.dasm - EventSource:WriteEventVarargs(int,long,ref):this

Top method improvements (bytes):
         -32 (-3.83% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxTokenListBuilder:ToList():SyntaxTokenList:this (2 methods)
         -28 (-2.80% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SyntaxTokenListBuilder:ToList():SyntaxTokenList:this (2 methods)
         -28 (-4.29% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - MergedTypeDeclaration:GetLexicalSortKey(VisualBasicCompilation):LexicalSortKey:this (2 methods)
         -28 (-0.71% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - TypeParameterNode:InferTypeAndPropagateHints():bool:this (2 methods)
         -24 (-1.42% of base) : System.Reflection.MetadataLoadContext.dasm - <>c__DisplayClass5_0:<TryComputeMarshalAsCustomAttributeData>b__0():CustomAttributeArguments:this
         -20 (-0.74% of base) : System.Private.Xml.dasm - BigNumber:DblToRgbFast(double,ref,byref,byref):bool
         -18 (-0.76% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SyntaxTriviaListBuilder:ToList():SyntaxTriviaList:this (2 methods)
         -18 (-0.87% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxTriviaListBuilder:ToList():SyntaxTriviaList:this (2 methods)
         -15 (-2.30% of base) : System.Data.Common.dasm - SqlDecimal:Round(SqlDecimal,int,bool):SqlDecimal
         -15 (-0.80% of base) : System.Private.Xml.dasm - XmlSqlBinaryReader:ValueAsString(int):String:this
         -15 (-0.72% of base) : System.Private.Xml.dasm - XmlSqlBinaryReader:ValueAsObject(int,bool):Object:this
         -14 (-1.20% of base) : System.Security.Cryptography.Pkcs.dasm - Pkcs12SafeContents:Decrypt(ReadOnlySpan`1,ReadOnlySpan`1):this
         -12 (-0.95% of base) : System.Collections.Concurrent.dasm - InternalPartitionEnumerator:get_Current():KeyValuePair`2:this (6 methods)
         -10 (-0.72% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - <Stackify>d__3:MoveNext():bool:this
         -10 (-0.66% of base) : System.Security.Cryptography.Pkcs.dasm - Rfc3161TimestampTokenInfo:Encode(Oid,Oid,ReadOnlyMemory`1,ReadOnlyMemory`1,DateTimeOffset,bool,Nullable`1,Nullable`1,Nullable`1,X509ExtensionCollection):ref
          -8 (-1.49% of base) : System.Diagnostics.DiagnosticSource.dasm - <EnumerateStringValues>d__13:MoveNext():bool:this
          -8 (-0.70% of base) : System.Security.Cryptography.X509Certificates.dasm - ChainPal:BuildChain(bool,ICertificatePal,X509Certificate2Collection,OidCollection,OidCollection,int,int,X509Certificate2Collection,int,DateTime,TimeSpan,bool):ChainPal
          -7 (-15.22% of base) : System.Net.HttpListener.dasm - HttpListenerRequest:get_RequestTraceIdentifier():Guid:this
          -6 (-1.55% of base) : System.Collections.Concurrent.dasm - StaticIndexRangePartitionForArray`1:get_Current():KeyValuePair`2:this (2 methods)
          -6 (-0.16% of base) : System.Data.Common.dasm - SqlDecimalStorage:Aggregate(ref,int):Object:this

Top method regressions (percentages):
          31 ( 1.70% of base) : System.Security.Cryptography.Pkcs.dasm - ManagedPkcsPal:Encrypt(CmsRecipientCollection,ContentInfo,AlgorithmIdentifier,X509Certificate2Collection,CryptographicAttributeObjectCollection,ref,ref,ref):ref:this
           1 ( 0.75% of base) : ILCompiler.Reflection.ReadyToRun.dasm - PgoSchemaMergeComparer:Compare(PgoSchemaElem,PgoSchemaElem):int:this
           1 ( 0.11% of base) : System.Private.CoreLib.dasm - CustomAttributeTypedArgument:.ctor(RuntimeModule,CustomAttributeEncodedArgument):this
           1 ( 0.05% of base) : System.Private.CoreLib.dasm - EventSource:WriteEventVarargs(int,long,ref):this

Top method improvements (percentages):
          -7 (-15.22% of base) : System.Net.HttpListener.dasm - HttpListenerRequest:get_RequestTraceIdentifier():Guid:this
          -5 (-8.33% of base) : System.Net.HttpListener.dasm - HttpListenerTimeoutManager:get_EntityBody():TimeSpan:this
          -5 (-8.33% of base) : System.Net.HttpListener.dasm - HttpListenerTimeoutManager:get_DrainEntityBody():TimeSpan:this
          -5 (-8.33% of base) : System.Net.HttpListener.dasm - HttpListenerTimeoutManager:get_RequestQueue():TimeSpan:this
          -5 (-8.33% of base) : System.Net.HttpListener.dasm - HttpListenerTimeoutManager:get_IdleConnection():TimeSpan:this
          -5 (-8.33% of base) : System.Net.HttpListener.dasm - HttpListenerTimeoutManager:get_HeaderWait():TimeSpan:this
          -5 (-7.94% of base) : System.Net.HttpListener.dasm - HttpListenerTimeoutManager:GetTimeout(int):TimeSpan:this
         -28 (-4.29% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - MergedTypeDeclaration:GetLexicalSortKey(VisualBasicCompilation):LexicalSortKey:this (2 methods)
         -32 (-3.83% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxTokenListBuilder:ToList():SyntaxTokenList:this (2 methods)
          -5 (-3.79% of base) : Microsoft.VisualBasic.Core.dasm - DateAndTime:TimeValue(String):DateTime
          -4 (-3.12% of base) : System.Linq.Parallel.dasm - HashLookup`2:get_Item(int):KeyValuePair`2:this
         -28 (-2.80% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SyntaxTokenListBuilder:ToList():SyntaxTokenList:this (2 methods)
         -15 (-2.30% of base) : System.Data.Common.dasm - SqlDecimal:Round(SqlDecimal,int,bool):SqlDecimal
          -6 (-1.55% of base) : System.Collections.Concurrent.dasm - StaticIndexRangePartitionForArray`1:get_Current():KeyValuePair`2:this (2 methods)
          -8 (-1.49% of base) : System.Diagnostics.DiagnosticSource.dasm - <EnumerateStringValues>d__13:MoveNext():bool:this
         -24 (-1.42% of base) : System.Reflection.MetadataLoadContext.dasm - <>c__DisplayClass5_0:<TryComputeMarshalAsCustomAttributeData>b__0():CustomAttributeArguments:this
          -3 (-1.40% of base) : System.Net.Http.dasm - MultiMemory:GetBlock(int):Memory`1:this
          -3 (-1.40% of base) : System.Net.Quic.dasm - MultiMemory:GetBlock(int):Memory`1:this
         -14 (-1.20% of base) : System.Security.Cryptography.Pkcs.dasm - Pkcs12SafeContents:Decrypt(ReadOnlySpan`1,ReadOnlySpan`1):this
         -12 (-0.95% of base) : System.Collections.Concurrent.dasm - InternalPartitionEnumerator:get_Current():KeyValuePair`2:this (6 methods)

38 total methods with Code Size differences (34 improved, 4 regressed), 200463 unchanged.
```
Regression in `ManagedPkcsPal:Encrypt` is a local struct init that surprisingly is no longer eliminated, even if the local is no longer address exposed.  In `DataTable:ParseSortString` CSE has the funny idea of CSEing a local address live across a call. Other regressions tend to be caused by changes in prolog local init code size or due to register allocation changes.

linux-x64 is less affected due to the lack of implict-byref params.