### PR TITLE
Eliminate some struct COMMAs

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -2656,7 +2656,7 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
         {
             // Replace as COMMA(side_effects, const value tree);
             assert((sideEffList->gtFlags & GTF_SIDE_EFFECT) != 0);
-            return gtNewOperNode(GT_COMMA, conValTree->TypeGet(), sideEffList, conValTree);
+            return gtNewCommaNode(sideEffList, conValTree);
         }
         else
         {
@@ -3942,7 +3942,7 @@ GenTree* Compiler::optAssertionProp_Call(ASSERT_VALARG_TP assertions, GenTreeCal
                 gtExtractSideEffList(call, &list, GTF_SIDE_EFFECT, true);
                 if (list != nullptr)
                 {
-                    arg1 = gtNewOperNode(GT_COMMA, call->TypeGet(), list, arg1);
+                    arg1 = gtNewCommaNode(list, arg1, call->TypeGet());
                     fgSetTreeSeq(arg1);
                 }
 

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -468,14 +468,12 @@ void Compiler::optAddCopies()
 
             /* Change the tree to a GT_COMMA with the two assignments as child nodes */
 
-            tree->gtBashToNOP();
             tree->ChangeOper(GT_COMMA);
-
-            tree->AsOp()->gtOp1 = newAsgn;
-            tree->AsOp()->gtOp2 = copyAsgn;
-
-            tree->gtFlags |= (newAsgn->gtFlags & GTF_ALL_EFFECT);
-            tree->gtFlags |= (copyAsgn->gtFlags & GTF_ALL_EFFECT);
+            tree->AsOp()->SetOp(0, newAsgn);
+            tree->AsOp()->SetOp(1, copyAsgn);
+            tree->SetType(TYP_VOID);
+            tree->SetSideEffects(newAsgn->GetSideEffects() | copyAsgn->GetSideEffects());
+            tree->gtFlags &= ~GTF_REVERSE_OPS;
         }
 
         JITDUMPTREE(stmt->GetRootNode(), "\nIntroduced a copy for V%02u\n", lclNum);

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3942,7 +3942,7 @@ GenTree* Compiler::optAssertionProp_Call(ASSERT_VALARG_TP assertions, GenTreeCal
                 gtExtractSideEffList(call, &list, GTF_SIDE_EFFECT, true);
                 if (list != nullptr)
                 {
-                    arg1 = gtNewCommaNode(list, arg1, call->TypeGet());
+                    arg1 = gtNewCommaNode(list, arg1);
                     fgSetTreeSeq(arg1);
                 }
 

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1019,11 +1019,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
         }
         else // !helperCallArgs
         {
-            /* Skip over a GT_COMMA node(s), if necessary */
-            while (op2->gtOper == GT_COMMA)
-            {
-                op2 = op2->AsOp()->gtOp2;
-            }
+            op2 = op2->SkipComma();
 
             // printf("create assertion\n");
 
@@ -3601,15 +3597,9 @@ GenTree* Compiler::optAssertionProp_Cast(ASSERT_VALARG_TP assertions, GenTree* t
         return nullptr;
     }
 
-    // Skip over a GT_COMMA node(s), if necessary to get to the lcl.
-    GenTree* lcl = op1;
-    while (lcl->gtOper == GT_COMMA)
-    {
-        lcl = lcl->AsOp()->gtOp2;
-    }
+    GenTree* lcl = op1->SkipComma();
 
-    // If we don't have a cast of a LCL_VAR then bail.
-    if (lcl->gtOper != GT_LCL_VAR)
+    if (!lcl->OperIs(GT_LCL_VAR))
     {
         return nullptr;
     }

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -1942,8 +1942,6 @@ public:
                                                ClassLayout**     argLayout);
 #endif // FEATURE_HW_INTRINSICS
 
-    GenTree* gtNewMustThrowException(unsigned helper, var_types type, CORINFO_CLASS_HANDLE clsHnd);
-
     GenTreeLclFld* gtNewLclFldNode(unsigned lnum, var_types type, unsigned offset);
     GenTreeRetExpr* gtNewRetExpr(GenTreeCall* call, var_types type);
 
@@ -2969,6 +2967,7 @@ protected:
                                           CORINFO_METHOD_HANDLE method,
                                           CORINFO_SIG_INFO*     sig,
                                           bool                  mustExpand);
+    GenTree* impNewMustThrowException(unsigned helper, var_types type, CORINFO_CLASS_HANDLE clsHnd);
 
 #ifdef FEATURE_HW_INTRINSICS
     GenTree* impHWIntrinsic(NamedIntrinsic        intrinsic,

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -1795,6 +1795,7 @@ public:
 
     // For binary opers.
     GenTreeOp* gtNewOperNode(genTreeOps oper, var_types type, GenTree* op1, GenTree* op2);
+    GenTreeOp* gtNewCommaNode(GenTree* op1, GenTree* op2, var_types type = TYP_UNDEF);
 
     GenTreeQmark* gtNewQmarkNode(var_types type, GenTree* cond, GenTree* op1, GenTree* op2);
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3087,7 +3087,6 @@ public:
         impMakeMultiUse(tree, useCount, uses, layout, spillCheckLevel DEBUGARG(reason));
     }
 
-    GenTree* impAssignStruct(GenTree* dest, GenTree* src, ClassLayout* layout, unsigned curLevel);
     GenTree* impAssignStructAddr(GenTree* dest, GenTree* src, ClassLayout* layout, unsigned curLevel);
 
     GenTree* impGetStructAddr(GenTree* structVal, CORINFO_CLASS_HANDLE structHnd, unsigned curLevel, bool willDeref);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3087,7 +3087,6 @@ public:
         impMakeMultiUse(tree, useCount, uses, layout, spillCheckLevel DEBUGARG(reason));
     }
 
-    GenTree* impAssignStruct(GenTree* dest, GenTree* src, CORINFO_CLASS_HANDLE structHnd, unsigned curLevel);
     GenTree* impAssignStruct(GenTree* dest, GenTree* src, ClassLayout* layout, unsigned curLevel);
     GenTree* impAssignStructAddr(GenTree* dest, GenTree* src, ClassLayout* layout, unsigned curLevel);
 

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1226,35 +1226,25 @@ inline GenTree* Compiler::gtNewNullCheck(GenTree* addr, BasicBlock* basicBlock)
     return nullCheck;
 }
 
-/*****************************************************************************
- *
- *  Create (and check for) a "nothing" node, i.e. a node that doesn't produce
- *  any code. We currently use a "nop" node of type void for this purpose.
- */
-
+// Create (and check for) a "nothing" node, i.e. a node that doesn't produce
+// any code. We currently use a "nop" node of type void for this purpose.
 inline GenTree* Compiler::gtNewNothingNode()
 {
     return new (this, GT_NOP) GenTreeOp(GT_NOP, TYP_VOID);
 }
-/*****************************************************************************/
 
 inline bool GenTree::IsNothingNode() const
 {
-    return (gtOper == GT_NOP && gtType == TYP_VOID);
+    return (gtOper == GT_NOP) && (gtType == TYP_VOID);
 }
 
-/*****************************************************************************
- *
- *  Change the given node to a NOP - May be later changed to a GT_COMMA
- *
- *****************************************************************************/
-
-inline void GenTree::gtBashToNOP()
+inline void GenTree::ChangeToNothingNode()
 {
     ChangeOper(GT_NOP);
 
     gtType        = TYP_VOID;
-    AsOp()->gtOp1 = AsOp()->gtOp2 = nullptr;
+    AsOp()->gtOp1 = nullptr;
+    AsOp()->gtOp2 = nullptr;
 
     gtFlags &= ~(GTF_ALL_EFFECT | GTF_REVERSE_OPS);
 }

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1261,7 +1261,7 @@ inline void GenTree::gtBashToNOP()
 
 inline GenTree* Compiler::gtUnusedValNode(GenTree* expr)
 {
-    return gtNewOperNode(GT_COMMA, TYP_VOID, expr, gtNewNothingNode());
+    return gtNewCommaNode(expr, gtNewNothingNode());
 }
 
 /*****************************************************************************

--- a/src/coreclr/jit/earlyprop.cpp
+++ b/src/coreclr/jit/earlyprop.cpp
@@ -693,8 +693,7 @@ GenTree* Compiler::optFindNullCheckToFold(GenTree* tree, LocalNumberToNullCheckT
             return nullptr;
         }
 
-        const bool commaOnly              = true;
-        GenTree*   commaOp1EffectiveValue = defRHS->gtGetOp1()->gtEffectiveVal(commaOnly);
+        GenTree* commaOp1EffectiveValue = defRHS->gtGetOp1()->SkipComma();
 
         if (commaOp1EffectiveValue->OperGet() != GT_NULLCHECK)
         {

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -493,8 +493,7 @@ private:
             m_compiler->gtInitStructCopyAsg(newAsg->AsOp());
         }
 
-        return m_compiler->gtNewOperNode(GT_COMMA, dst->GetType(), newAsg,
-                                         m_compiler->gtNewLclvNode(tempLclNum, dst->GetType()));
+        return m_compiler->gtNewCommaNode(newAsg, m_compiler->gtNewLclvNode(tempLclNum, dst->GetType()));
     }
 
     void AttachStructInlineeToAsg(GenTreeOp* asg, GenTree* src, ClassLayout* layout)

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -1259,10 +1259,10 @@ public:
         GenTreeCall::Use* const args             = compiler->gtNewCallArgs(tmpNode, classProfileNode);
         GenTree* const helperCallNode = compiler->gtNewHelperCallNode(CORINFO_HELP_CLASSPROFILE, TYP_VOID, args);
         GenTree* const tmpNode2       = compiler->gtNewLclvNode(tmpNum, TYP_REF);
-        GenTree* const callCommaNode  = compiler->gtNewOperNode(GT_COMMA, TYP_REF, helperCallNode, tmpNode2);
+        GenTree* const callCommaNode  = compiler->gtNewCommaNode(helperCallNode, tmpNode2);
         GenTree* const tmpNode3       = compiler->gtNewLclvNode(tmpNum, TYP_REF);
         GenTree* const asgNode = compiler->gtNewOperNode(GT_ASG, TYP_REF, tmpNode3, call->gtCallThisArg->GetNode());
-        GenTree* const asgCommaNode = compiler->gtNewOperNode(GT_COMMA, TYP_REF, asgNode, callCommaNode);
+        GenTree* const asgCommaNode = compiler->gtNewCommaNode(asgNode, callCommaNode);
 
         // Update the call
         //

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6149,7 +6149,7 @@ void Compiler::gtInitStructCopyAsg(GenTreeOp* asg)
     {
         // Make this a NOP
         // TODO-Cleanup: probably doesn't matter, but could do this earlier and avoid creating a GT_ASG
-        asg->gtBashToNOP();
+        asg->ChangeToNothingNode();
         return;
     }
 
@@ -11975,7 +11975,7 @@ GenTree* Compiler::gtTryRemoveBoxUpstreamEffects(GenTree* op, BoxRemovalOptions 
 
         // Remove the newobj and assigment to box temp
         JITDUMP("Bashing NEWOBJ [%06u] to NOP\n", dspTreeID(asg));
-        asg->gtBashToNOP();
+        asg->ChangeToNothingNode();
 
         if (varTypeIsStruct(copyDst->GetType()))
         {
@@ -12047,7 +12047,7 @@ GenTree* Compiler::gtTryRemoveBoxUpstreamEffects(GenTree* op, BoxRemovalOptions 
     //
     // Change the assignment expression to a NOP.
     JITDUMP("\nBashing NEWOBJ [%06u] to NOP\n", dspTreeID(asg));
-    asg->gtBashToNOP();
+    asg->ChangeToNothingNode();
 
     // Change the copy expression so it preserves key
     // source side effects.
@@ -12057,7 +12057,7 @@ GenTree* Compiler::gtTryRemoveBoxUpstreamEffects(GenTree* op, BoxRemovalOptions 
     {
         // If there were no copy source side effects just bash
         // the copy to a NOP.
-        copy->gtBashToNOP();
+        copy->ChangeToNothingNode();
         JITDUMP(" to NOP; no source side effects.\n");
     }
     else if (!isStructCopy)

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -5282,7 +5282,9 @@ GenTreeOp* Compiler::gtNewCommaNode(GenTree* op1, GenTree* op2, var_types type)
 
     if (type == TYP_UNDEF)
     {
-        type = op2->GetType();
+        // ASG and NULLCHECK have non VOID types but they don't actually
+        // produce a value. Don't propagate the type through COMMAs.
+        type = op2->OperIs(GT_ASG, GT_NULLCHECK) ? TYP_VOID : op2->GetType();
     }
 
     assert(!op2->OperIs(GT_NULLCHECK, GT_ASG) || (type == TYP_VOID));

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -16585,40 +16585,6 @@ bool GenTreeHWIntrinsic::OperIsMemoryLoadOrStore() const
 
 #endif // FEATURE_HW_INTRINSICS
 
-//---------------------------------------------------------------------------------------
-// gtNewMustThrowException:
-//    create a throw node (calling into JIT helper) that must be thrown.
-//    The result would be a comma node: COMMA(jithelperthrow(void), x) where x's type should be specified.
-//
-// Arguments
-//    helper      -  JIT helper ID
-//    type        -  return type of the node
-//
-// Return Value
-//    pointer to the throw node
-//
-GenTree* Compiler::gtNewMustThrowException(unsigned helper, var_types type, CORINFO_CLASS_HANDLE clsHnd)
-{
-    GenTreeCall* node = gtNewHelperCallNode(helper, TYP_VOID);
-    node->gtCallMoreFlags |= GTF_CALL_M_DOES_NOT_RETURN;
-    if (type != TYP_VOID)
-    {
-        unsigned dummyTemp = lvaGrabTemp(true DEBUGARG("dummy temp of must thrown exception"));
-        if (type == TYP_STRUCT)
-        {
-            lvaSetStruct(dummyTemp, clsHnd, false);
-            type = lvaTable[dummyTemp].GetType();
-        }
-        else
-        {
-            lvaTable[dummyTemp].SetType(type);
-        }
-
-        return gtNewCommaNode(node, gtNewLclvNode(dummyTemp, type));
-    }
-    return node;
-}
-
 void ReturnTypeDesc::InitializeStruct(Compiler* comp, ClassLayout* retLayout, StructPassing retKind)
 {
     switch (retKind.kind)

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1690,7 +1690,7 @@ public:
 
     void ReplaceOperand(GenTree** useEdge, GenTree* replacement);
 
-    inline GenTree* gtEffectiveVal(bool commaOnly = false);
+    inline GenTree* gtEffectiveVal();
     inline GenTree* gtCommaAssignVal();
 
     GenTree* SkipComma();
@@ -8098,18 +8098,17 @@ inline GenTree* GenTree::gtGetOp2IfPresent() const
     return op2;
 }
 
-inline GenTree* GenTree::gtEffectiveVal(bool commaOnly /* = false */)
+inline GenTree* GenTree::gtEffectiveVal()
 {
-    GenTree* effectiveVal = this;
-    for (;;)
+    for (GenTree* effectiveVal = this;;)
     {
-        if (effectiveVal->gtOper == GT_COMMA)
+        if (effectiveVal->OperIs(GT_COMMA))
         {
-            effectiveVal = effectiveVal->AsOp()->gtGetOp2();
+            effectiveVal = effectiveVal->AsOp()->GetOp(1);
         }
-        else if (!commaOnly && (effectiveVal->gtOper == GT_NOP) && (effectiveVal->AsOp()->gtOp1 != nullptr))
+        else if (effectiveVal->OperIs(GT_NOP) && (effectiveVal->AsUnOp()->GetOp(0) != nullptr))
         {
-            effectiveVal = effectiveVal->AsOp()->gtOp1;
+            effectiveVal = effectiveVal->AsUnOp()->GetOp(0);
         }
         else
         {

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1786,7 +1786,7 @@ public:
     //---------------------------------------------------------------------
 
     bool IsNothingNode() const;
-    void gtBashToNOP();
+    void ChangeToNothingNode();
 
     // Value number update action enumeration
     enum ValueNumberUpdate

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -786,6 +786,12 @@ public:
         gtFlags = (gtFlags & ~GTF_ALL_EFFECT) | sideEffects;
     }
 
+    void AddSideEffects(unsigned sideEffects)
+    {
+        assert((sideEffects & ~GTF_ALL_EFFECT) == 0);
+        gtFlags |= sideEffects;
+    }
+
 // The extra flag GTF_IS_IN_CSE is used to tell the consumer of these flags
 // that we are calling in the context of performing a CSE, thus we
 // should allow the run-once side effects of running a class constructor.

--- a/src/coreclr/jit/hwintrinsic.cpp
+++ b/src/coreclr/jit/hwintrinsic.cpp
@@ -329,7 +329,7 @@ GenTree* Compiler::addRangeCheckIfNeeded(
     GenTreeBoundsChk* hwIntrinsicChk = new (this, GT_HW_INTRINSIC_CHK)
         GenTreeBoundsChk(GT_HW_INTRINSIC_CHK, immOpUses[1], adjustedUpperBoundNode, SCK_ARG_RNG_EXCPN);
 
-    return gtNewOperNode(GT_COMMA, immOpUses[0]->GetType(), hwIntrinsicChk, immOpUses[0]);
+    return gtNewCommaNode(hwIntrinsicChk, immOpUses[0]);
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -15731,7 +15731,7 @@ void Compiler::impDevirtualizeCall(GenTreeCall*            call,
     }
 
     // See what we know about the type of 'this' in the call.
-    GenTree*             thisObj       = call->gtCallThisArg->GetNode()->gtEffectiveVal(false);
+    GenTree*             thisObj       = call->gtCallThisArg->GetNode()->gtEffectiveVal();
     GenTree*             actualThisObj = nullptr;
     bool                 isExact       = false;
     bool                 objIsNonNull  = false;

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -9976,7 +9976,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
                 if (varTypeIsStruct(lclTyp))
                 {
-                    op1 = impAssignStruct(op2, op1, typGetObjLayout(clsHnd), CHECK_SPILL_ALL);
+                    op1 = impAssignStructAddr(gtNewAddrNode(op2), op1, typGetObjLayout(clsHnd), CHECK_SPILL_ALL);
                 }
                 else
                 {

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -8030,8 +8030,8 @@ void Compiler::impImportLeave(BasicBlock* block)
 
     BasicBlock* step         = DUMMY_INIT(NULL);
     unsigned    encFinallies = 0; // Number of enclosing finallies.
-    GenTree*    endCatches   = NULL;
-    Statement*  endLFinStmt  = NULL; // The statement tree to indicate the end of locally-invoked finally.
+    GenTree*    endCatches   = nullptr;
+    Statement*  endLFinStmt  = nullptr; // The statement tree to indicate the end of locally-invoked finally.
 
     unsigned  XTnum;
     EHblkDsc* HBtab;
@@ -8059,9 +8059,9 @@ void Compiler::impImportLeave(BasicBlock* block)
             GenTree* endCatch = gtNewHelperCallNode(CORINFO_HELP_ENDCATCH, TYP_VOID);
 
             // Make a list of all the currently pending endCatches
-            if (endCatches)
+            if (endCatches != nullptr)
             {
-                endCatches = gtNewCommaNode(endCatches, endCatch, TYP_VOID);
+                endCatches = gtNewCommaNode(endCatches, endCatch);
             }
             else
             {
@@ -12510,7 +12510,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     }
                     if (helperNode != nullptr)
                     {
-                        op1 = gtNewCommaNode(helperNode, op1, op1->OperIs(GT_ASG) ? TYP_VOID : op1->GetType());
+                        op1 = gtNewCommaNode(helperNode, op1);
                     }
                 }
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -12501,9 +12501,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     op1 = gtNewAssignNode(op1, op2);
                 }
 
-                /* Check if the class needs explicit initialization */
-
-                if (fieldInfo.fieldFlags & CORINFO_FLG_FIELD_INITCLASS)
+                if ((fieldInfo.fieldFlags & CORINFO_FLG_FIELD_INITCLASS) != 0)
                 {
                     GenTree* helperNode = impInitClass(&resolvedToken);
                     if (compDonotInline())
@@ -12512,7 +12510,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     }
                     if (helperNode != nullptr)
                     {
-                        op1 = gtNewCommaNode(helperNode, op1);
+                        op1 = gtNewCommaNode(helperNode, op1, op1->OperIs(GT_ASG) ? TYP_VOID : op1->GetType());
                     }
                 }
 
@@ -12540,7 +12538,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                    statics) and calls. But don't need to spill other statics
                    as we have explicitly spilled this particular static field. */
 
-                impSpillSideEffects(false, (unsigned)CHECK_SPILL_ALL DEBUGARG("spill side effects before STFLD"));
+                impSpillSideEffects(false, CHECK_SPILL_ALL DEBUGARG("spill side effects before STFLD"));
 
                 if (deferStructAssign)
                 {

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -1892,7 +1892,7 @@ void Compiler::fgComputeLifeLIR(VARSET_TP& life, BasicBlock* block, VARSET_VALAR
                         if (operand->OperIs(GT_PUTARG_STK))
                         {
                             operand->AsPutArgStk()->gtOp1->SetUnusedValue();
-                            operand->gtBashToNOP();
+                            operand->ChangeToNothingNode();
                         }
 
                         return GenTree::VisitResult::Continue;
@@ -2184,7 +2184,7 @@ void Compiler::fgRemoveDeadStoreLIR(GenTree* store, BasicBlock* block)
     if ((store->gtFlags & GTF_LATE_ARG) != 0)
     {
         JITDUMP("node is a late arg; replacing with NOP\n");
-        store->gtBashToNOP();
+        store->ChangeToNothingNode();
 
         // NOTE: this is a bit of a hack. We need to keep these nodes around as they are
         // referenced by the call, but they're considered side-effect-free non-value-producing
@@ -2464,7 +2464,7 @@ bool Compiler::fgRemoveDeadStore(GenTree**        pTree,
                 JITDUMPTREE(asgNode, "Removing tree in " FMT_BB " as useless", compCurBB->bbNum);
 
                 // No side effects - Change the assignment to a GT_NOP node
-                asgNode->gtBashToNOP();
+                asgNode->ChangeToNothingNode();
 
                 INDEBUG(*treeModf = true;)
             }

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -265,7 +265,7 @@ void Compiler::fgPerNodeLocalVarLiveness(GenTree* tree)
             {
                 GenTreeLclVarCommon* dummyLclVarTree = nullptr;
                 bool                 dummyIsEntire   = false;
-                GenTree*             addrArg         = tree->AsOp()->gtOp1->gtEffectiveVal(/*commaOnly*/ true);
+                GenTree*             addrArg         = tree->AsIndir()->GetAddr()->SkipComma();
                 if (!addrArg->DefinesLocalAddr(this, /*width doesn't matter*/ 0, &dummyLclVarTree, &dummyIsEntire))
                 {
                     fgCurMemoryUse |= memoryKindSet(GcHeap, ByrefExposed);

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -2426,64 +2426,47 @@ bool Compiler::fgRemoveDeadStore(GenTree**        pTree,
             if (sideEffList != nullptr)
             {
                 noway_assert(sideEffList->gtFlags & GTF_SIDE_EFFECT);
-#ifdef DEBUG
-                if (verbose)
-                {
-                    printf("Extracted side effects list from condition...\n");
-                    gtDispTree(sideEffList);
-                    printf("\n");
-                }
-#endif // DEBUG
+
+                JITDUMPTREE(sideEffList, "Extracted side effects list from condition...\n");
+
                 if (sideEffList->gtOper == asgNode->gtOper)
                 {
-#ifdef DEBUG
-                    *treeModf = true;
-#endif // DEBUG
+                    INDEBUG(*treeModf = true;)
+
                     asgNode->AsOp()->gtOp1 = sideEffList->AsOp()->gtOp1;
                     asgNode->AsOp()->gtOp2 = sideEffList->AsOp()->gtOp2;
                     asgNode->gtType        = sideEffList->gtType;
                 }
                 else
                 {
-#ifdef DEBUG
-                    *treeModf = true;
-#endif // DEBUG
-                    // Change the node to a GT_COMMA holding the side effect list
-                    asgNode->gtBashToNOP();
+                    INDEBUG(*treeModf = true;)
 
                     asgNode->ChangeOper(GT_COMMA);
-                    asgNode->gtFlags |= sideEffList->gtFlags & GTF_ALL_EFFECT;
+                    asgNode->SetType(TYP_VOID);
 
-                    if (sideEffList->gtOper == GT_COMMA)
+                    if (sideEffList->OperIs(GT_COMMA))
                     {
-                        asgNode->AsOp()->gtOp1 = sideEffList->AsOp()->gtOp1;
-                        asgNode->AsOp()->gtOp2 = sideEffList->AsOp()->gtOp2;
+                        asgNode->AsOp()->SetOp(0, sideEffList->AsOp()->GetOp(0));
+                        asgNode->AsOp()->SetOp(1, sideEffList->AsOp()->GetOp(1));
                     }
                     else
                     {
-                        asgNode->AsOp()->gtOp1 = sideEffList;
-                        asgNode->AsOp()->gtOp2 = gtNewNothingNode();
+                        asgNode->AsOp()->SetOp(0, sideEffList);
+                        asgNode->AsOp()->SetOp(1, gtNewNothingNode());
                     }
+
+                    asgNode->SetSideEffects(sideEffList->GetSideEffects());
+                    asgNode->gtFlags &= ~GTF_REVERSE_OPS;
                 }
             }
             else
             {
-#ifdef DEBUG
-                if (verbose)
-                {
-                    printf("\nRemoving tree ");
-                    printTreeID(asgNode);
-                    printf(" in " FMT_BB " as useless\n", compCurBB->bbNum);
-                    gtDispTree(asgNode);
-                    printf("\n");
-                }
-#endif // DEBUG
+                JITDUMPTREE(asgNode, "Removing tree in " FMT_BB " as useless", compCurBB->bbNum);
+
                 // No side effects - Change the assignment to a GT_NOP node
                 asgNode->gtBashToNOP();
 
-#ifdef DEBUG
-                *treeModf = true;
-#endif // DEBUG
+                INDEBUG(*treeModf = true;)
             }
 
             // Re-link the nodes for this statement - Do not update ordering!

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -3332,7 +3332,7 @@ GenTree* Compiler::abiMorphMkRefAnyToStore(unsigned tempLclNum, GenTreeOp* mkref
     destTypeField->SetFieldSeq(GetFieldSeqStore()->CreateSingleton(GetRefanyTypeField()));
     GenTree* asgTypeField = gtNewAssignNode(destTypeField, mkrefany->GetOp(1));
 
-    return gtNewCommaNode(asgPtrField, asgTypeField, TYP_VOID);
+    return gtNewCommaNode(asgPtrField, asgTypeField);
 }
 
 #if FEATURE_MULTIREG_ARGS
@@ -5061,7 +5061,7 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
 
         if (asg != nullptr)
         {
-            comma = gtNewCommaNode(asg, nullchk, TYP_VOID);
+            comma = gtNewCommaNode(asg, nullchk);
         }
         else
         {
@@ -6260,7 +6260,7 @@ GenTree* Compiler::fgMorphTailCallViaHelpers(GenTreeCall* call, CORINFO_TAILCALL
                     // COMMA(tmp = "this", deref(tmp))
                     GenTree* tmp          = gtNewLclvNode(lclNum, objp->TypeGet());
                     GenTree* nullcheck    = gtNewNullCheck(tmp, compCurBB);
-                    doBeforeStoreArgsStub = gtNewCommaNode(doBeforeStoreArgsStub, nullcheck, TYP_VOID);
+                    doBeforeStoreArgsStub = gtNewCommaNode(doBeforeStoreArgsStub, nullcheck);
                 }
 
                 thisPtr = gtNewLclvNode(lclNum, objp->TypeGet());
@@ -6528,7 +6528,7 @@ GenTree* Compiler::fgCreateCallDispatcherAndGetResult(GenTreeCall*          orig
 
     if (copyToRetBufNode != nullptr)
     {
-        finalTree = gtNewCommaNode(callDispatcherNode, copyToRetBufNode, TYP_VOID);
+        finalTree = gtNewCommaNode(callDispatcherNode, copyToRetBufNode);
     }
 
     if (origCall->gtType == TYP_VOID)
@@ -6688,7 +6688,7 @@ GenTree* Compiler::getRuntimeLookupTree(CORINFO_RESOLVED_TOKEN* pResolvedToken,
 
     while (!stmts.Empty())
     {
-        result = gtNewCommaNode(stmts.Pop(), result, TYP_I_IMPL);
+        result = gtNewCommaNode(stmts.Pop(), result);
     }
 
     DISPTREE(result);
@@ -6869,7 +6869,7 @@ void Compiler::fgMorphTailCallViaJitHelper(GenTreeCall* call)
                 // COMMA(tmp = "this", deref(tmp))
                 GenTree* tmp       = gtNewLclvNode(lclNum, vt);
                 GenTree* nullcheck = gtNewNullCheck(tmp, compCurBB);
-                asg                = gtNewCommaNode(asg, nullcheck, TYP_VOID);
+                asg                = gtNewCommaNode(asg, nullcheck);
                 thisPtr            = gtNewCommaNode(asg, gtNewLclvNode(lclNum, vt));
             }
             else
@@ -7444,7 +7444,7 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
             for (GenTreeCall::Use& use : call->Args())
             {
                 GenTree* const arg = use.GetNode();
-                if (arg->OperGet() != GT_ASG)
+                if (!arg->OperIs(GT_ASG))
                 {
                     continue;
                 }
@@ -7461,7 +7461,7 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
                     INDEBUG(op1->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;)
                 }
 
-                argSetup = gtNewCommaNode(op1, arg, TYP_VOID);
+                argSetup = gtNewCommaNode(op1, arg);
                 INDEBUG(argSetup->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;)
             }
 
@@ -7484,7 +7484,7 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
             GenTree* result = fgMorphTree(arrStore);
             if (argSetup != nullptr)
             {
-                result = gtNewCommaNode(argSetup, result, TYP_VOID);
+                result = gtNewCommaNode(argSetup, result);
                 INDEBUG(result->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;)
             }
 
@@ -8366,7 +8366,7 @@ GenTree* Compiler::fgMorphPromoteLocalInitBlock(LclVarDsc* destLclVar, GenTree* 
 
         if (tree != nullptr)
         {
-            tree = gtNewCommaNode(tree, asg, TYP_VOID);
+            tree = gtNewCommaNode(tree, asg);
         }
         else
         {
@@ -8796,7 +8796,7 @@ GenTree* Compiler::fgMorphCopyBlock(GenTreeOp* asg)
             }
             else
             {
-                asgFieldCommaTree = gtNewCommaNode(asgFieldCommaTree, asgField, TYP_VOID);
+                asgFieldCommaTree = gtNewCommaNode(asgFieldCommaTree, asgField);
             }
         }
 
@@ -9431,7 +9431,7 @@ GenTree* Compiler::fgMorphCopyBlock(GenTreeOp* asg)
 
         if (asgFieldCommaTree != nullptr)
         {
-            asgFieldCommaTree = gtNewCommaNode(asgFieldCommaTree, asgField, TYP_VOID);
+            asgFieldCommaTree = gtNewCommaNode(asgFieldCommaTree, asgField);
         }
         else
         {

--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -405,7 +405,7 @@ bool ObjectAllocator::MorphAllocObjNodes()
                     // definitely-stack-pointing pointers. All definitely-stack-pointing pointers are in both sets.
                     MarkLclVarAsDefinitelyStackPointing(lclNum);
                     MarkLclVarAsPossiblyStackPointing(lclNum);
-                    stmt->GetRootNode()->gtBashToNOP();
+                    stmt->GetRootNode()->ChangeToNothingNode();
                     comp->optMethodFlags |= OMF_HAS_OBJSTACKALLOC;
                     didStackAllocate = true;
                 }

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -3087,7 +3087,7 @@ public:
                     exceptions_vnp = vnStore->VNPExcSetUnion(exceptions_vnp, op2Xvnp);
 
                     // Create a comma node with the sideEffList as op1
-                    cse           = m_pCompiler->gtNewOperNode(GT_COMMA, expTyp, sideEffList, cseVal);
+                    cse           = m_pCompiler->gtNewCommaNode(sideEffList, cseVal, expTyp);
                     cse->gtVNPair = vnStore->VNPWithExc(op2vnp, exceptions_vnp);
                 }
             }
@@ -3185,7 +3185,7 @@ public:
                 }
                 cseUse->gtVNPair = val->gtVNPair;
 
-                cse = m_pCompiler->gtNewOperNode(GT_COMMA, expTyp, asgTree, cseUse);
+                cse = m_pCompiler->gtNewCommaNode(asgTree, cseUse, expTyp);
                 // COMMA's VN is the same the original expression VN because assignment does not add any exceptions.
                 cse->gtVNPair = cseUse->gtVNPair;
             }

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -2919,8 +2919,7 @@ public:
             GenTree*      cse = nullptr;
             bool          isDef;
             FieldSeqNode* fldSeq               = nullptr;
-            bool          commaOnly            = true;
-            GenTree*      effectiveExp         = exp->gtEffectiveVal(commaOnly);
+            GenTree*      effectiveExp         = exp->SkipComma();
             const bool    hasZeroMapAnnotation = m_pCompiler->GetZeroOffsetFieldMap()->Lookup(effectiveExp, &fldSeq);
 
             if (IS_CSE_USE(exp->gtCSEnum))
@@ -3137,7 +3136,7 @@ public:
                         // This can only be the case for a struct in which the 'val' was a COMMA,
                         // so the assignment is sunk below it.
                         noway_assert(asgTree->OperIs(GT_COMMA) && (asgTree == val));
-                        asg = asgTree->gtEffectiveVal(true)->AsOp();
+                        asg = asgTree->SkipComma()->AsOp();
                     }
                     else
                     {

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -7857,11 +7857,11 @@ bool Compiler::optComputeLoopSideEffectsOfBlock(BasicBlock* blk)
 
             if (oper == GT_ASG)
             {
-                GenTree* lhs = tree->AsOp()->gtOp1->gtEffectiveVal(/*commaOnly*/ true);
+                GenTree* lhs = tree->AsOp()->GetOp(0)->SkipComma();
 
-                if (lhs->OperGet() == GT_IND)
+                if (lhs->OperIs(GT_IND))
                 {
-                    GenTree* arg = lhs->AsOp()->gtOp1->gtEffectiveVal(/*commaOnly*/ true);
+                    GenTree* arg = lhs->AsIndir()->GetAddr()->SkipComma();
 
                     if ((tree->gtFlags & GTF_IND_VOLATILE) != 0)
                     {

--- a/src/coreclr/jit/simd.cpp
+++ b/src/coreclr/jit/simd.cpp
@@ -605,7 +605,7 @@ void Compiler::SIMDCoalescingBuffer::ChangeToSIMDMem(Compiler* compiler, GenTree
             compiler->gtNewArrLen(compiler->gtCloneExpr(array), OFFSETOF__CORINFO_Array__length, compiler->compCurBB);
         GenTree* arrBndsChk = compiler->gtNewArrBoundsChk(lastIndex, arrLen, SCK_RNGCHK_FAIL);
 
-        addr   = compiler->gtNewOperNode(GT_COMMA, array->GetType(), arrBndsChk, array);
+        addr   = compiler->gtNewCommaNode(arrBndsChk, array);
         offset = OFFSETOF__CORINFO_Array__data + index * varTypeSize(TYP_FLOAT);
     }
     else
@@ -1183,11 +1183,11 @@ GenTree* Compiler::impSIMDIntrinsic(OPCODE                opcode,
             GenTreeArrLen*    arrLen = gtNewArrLen(arrayRefForArgChk, OFFSETOF__CORINFO_Array__length, compCurBB);
             GenTreeBoundsChk* argChk = gtNewArrBoundsChk(checkIndexExpr, arrLen, op2CheckKind);
 
-            // Create a GT_COMMA tree for the bounds check(s).
-            op2 = gtNewOperNode(GT_COMMA, op2->TypeGet(), argChk, op2);
+            op2 = gtNewCommaNode(argChk, op2);
+
             if (argRngChk != nullptr)
             {
-                op2 = gtNewOperNode(GT_COMMA, op2->TypeGet(), argRngChk, op2);
+                op2 = gtNewCommaNode(argRngChk, op2);
             }
 
             if (op3 == nullptr)
@@ -1313,8 +1313,7 @@ GenTree* Compiler::impSIMDIntrinsic(OPCODE                opcode,
                 GenTreeBoundsChk* simdChk =
                     new (this, GT_SIMD_CHK) GenTreeBoundsChk(GT_SIMD_CHK, index, lengthNode, SCK_RNGCHK_FAIL);
 
-                // Create a GT_COMMA tree for the bounds check.
-                op2 = gtNewOperNode(GT_COMMA, op2->TypeGet(), simdChk, op2);
+                op2 = gtNewCommaNode(simdChk, op2);
             }
 
             assert(op1->TypeGet() == simdType);

--- a/src/coreclr/jit/ssabuilder.cpp
+++ b/src/coreclr/jit/ssabuilder.cpp
@@ -729,7 +729,9 @@ void SsaBuilder::RenameDef(GenTreeOp* asgNode, BasicBlock* block)
 {
     // This is perhaps temporary -- maybe should be done elsewhere.  Label GT_INDs on LHS of assignments, so we
     // can skip these during (at least) value numbering.
-    GenTree* lhs = asgNode->gtGetOp1()->gtEffectiveVal(/*commaOnly*/ true);
+
+    GenTree* lhs = asgNode->GetOp(0)->SkipComma();
+
     if (lhs->OperIs(GT_IND, GT_OBJ, GT_BLK, GT_DYN_BLK))
     {
         lhs->gtFlags |= GTF_IND_ASG_LHS;


### PR DESCRIPTION
win-x64 pmi diff:
```
Total bytes of base: 51060756
Total bytes of diff: 51060793
Total bytes of delta: 37 (0.00% of base)
    diff is a regression.


Top file regressions (bytes):
          16 : System.ComponentModel.TypeConverter.dasm (0.01% of base)
          15 : Microsoft.CodeAnalysis.VisualBasic.dasm (0.00% of base)
           2 : System.Data.Common.dasm (0.00% of base)
           2 : System.Runtime.Caching.dasm (0.00% of base)
           2 : Microsoft.Extensions.FileProviders.Physical.dasm (0.01% of base)

5 total files with Code Size differences (0 improved, 5 regressed), 266 unchanged.

Top method regressions (bytes):
          16 ( 0.26% of base) : System.ComponentModel.TypeConverter.dasm - StandardCommands:.cctor()
          15 ( 0.39% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:CompleteAggregateClauseBinding(AggregateClauseSyntax,Enumerator,ImmutableArray`1,ImmutableArray`1,BoundExpression,QueryLambdaBinder,ImmutableArray`1,TypeSymbol,BoundQueryClauseBase,IntoClauseDisallowGroupReferenceBinder,DiagnosticBag):BoundAggregateClause:this
           2 ( 2.67% of base) : System.Data.Common.dasm - DateTimeOffsetStorage:.cctor()
           2 ( 1.83% of base) : System.Runtime.Caching.dasm - ObjectCache:.cctor()
           2 ( 2.86% of base) : Microsoft.Extensions.FileProviders.Physical.dasm - PollingFileChangeToken:.cctor()

Top method regressions (percentages):
           2 ( 2.86% of base) : Microsoft.Extensions.FileProviders.Physical.dasm - PollingFileChangeToken:.cctor()
           2 ( 2.67% of base) : System.Data.Common.dasm - DateTimeOffsetStorage:.cctor()
           2 ( 1.83% of base) : System.Runtime.Caching.dasm - ObjectCache:.cctor()
          15 ( 0.39% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:CompleteAggregateClauseBinding(AggregateClauseSyntax,Enumerator,ImmutableArray`1,ImmutableArray`1,BoundExpression,QueryLambdaBinder,ImmutableArray`1,TypeSymbol,BoundQueryClauseBase,IntoClauseDisallowGroupReferenceBinder,DiagnosticBag):BoundAggregateClause:this
          16 ( 0.26% of base) : System.ComponentModel.TypeConverter.dasm - StandardCommands:.cctor()

5 total methods with Code Size differences (0 improved, 5 regressed), 263723 unchanged.
```
Regressions due to type initialization helper calls appearing inside of trees, resulting in additional callee saved register usage and/or spilling.