### PR TITLE
Cleanup VN const prop

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5134,10 +5134,12 @@ private:
 
         if (m_vnStore->IsVNHandle(vn))
         {
+            assert(vnType == TYP_I_IMPL);
+
             // Don't perform constant folding that involves a handle that needs to be recorded
             // as a relocation with the VM. The VN type should be TYP_I_IMPL but the tree may
             // sometimes be TYP_BYREF, due to things like Unsafe.As.
-            if (!m_compiler->opts.compReloc && tree->TypeIs(TYP_I_IMPL, TYP_BYREF) && (vnType == TYP_I_IMPL))
+            if (!m_compiler->opts.compReloc && tree->TypeIs(TYP_I_IMPL, TYP_BYREF))
             {
                 newTree = m_compiler->gtNewIconHandleNode(m_vnStore->ConstantValue<target_ssize_t>(vn),
                                                           m_vnStore->GetHandleFlags(vn));

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -551,9 +551,8 @@ void Compiler::optAssertionInit(bool isLocalProp)
     }
 
     optAssertionTraitsInit(optMaxAssertionCount);
-    optAssertionCount      = 0;
-    optAssertionPropagated = false;
-    bbJtrueAssertionOut    = nullptr;
+    optAssertionCount   = 0;
+    bbJtrueAssertionOut = nullptr;
 }
 
 #ifdef DEBUG
@@ -4200,7 +4199,6 @@ GenTree* Compiler::optAssertionProp_Update(GenTree* newTree, GenTree* tree, Stat
     }
 
     // Record that we propagated the assertion.
-    optAssertionPropagated            = true;
     optAssertionPropagatedCurrentStmt = true;
 
     return newTree;

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -2201,10 +2201,7 @@ void Compiler::optAssertionGen(GenTree* tree)
             GenTreeCall* const call = tree->AsCall();
             if (call->NeedsNullCheck() || (call->IsVirtual() && !call->IsTailCall()))
             {
-                //  Retrieve the 'this' arg.
-                GenTree* thisArg = gtGetThisArg(call);
-                assert(thisArg != nullptr);
-                assertionInfo = optCreateAssertion(thisArg, nullptr, OAK_NOT_EQUAL);
+                assertionInfo = optCreateAssertion(call->GetThisArg(), nullptr, OAK_NOT_EQUAL);
             }
         }
         break;
@@ -3679,7 +3676,7 @@ GenTree* Compiler::optNonNullAssertionProp_Call(ASSERT_VALARG_TP assertions, Gen
     {
         return nullptr;
     }
-    GenTree* op1 = gtGetThisArg(call);
+    GenTree* op1 = call->GetThisArg();
     noway_assert(op1 != nullptr);
     if (op1->gtOper != GT_LCL_VAR)
     {
@@ -4943,7 +4940,7 @@ private:
             return;
         }
 
-        GenTree* thisArg = m_compiler->gtGetThisArg(call);
+        GenTree* thisArg = call->GetThisArg();
         noway_assert(thisArg != nullptr);
 
         // TODO-MIKE-Review: This check is likely useless, if the VN is known to be non-null

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -2459,42 +2459,21 @@ GenTree* Compiler::optVNConstantPropTree(BasicBlock* block, GenTree* tree)
 
     GenTree* newTree = nullptr;
 
-    // TODO-MIKE-Review: The code below does some bizarre reinterpretation of constants,
-    // how could VN compute a FLOAT constant for an INT node?!?
-
     switch (vnStore->TypeOfVN(vn))
     {
         case TYP_FLOAT:
-        {
-            float value = vnStore->ConstantValue<float>(vn);
-
-            if (tree->TypeIs(TYP_INT))
+            if (tree->TypeIs(TYP_FLOAT))
             {
-                newTree = gtNewIconNode(jitstd::bit_cast<int32_t>(value));
-            }
-            else
-            {
-                assert(varTypeIsFloating(tree->GetType()));
-                newTree = gtNewDconNode(value, tree->GetType());
+                newTree = gtNewDconNode(vnStore->ConstantValue<float>(vn), TYP_FLOAT);
             }
             break;
-        }
 
         case TYP_DOUBLE:
-        {
-            double value = vnStore->ConstantValue<double>(vn);
-
-            if (tree->TypeIs(TYP_LONG))
+            if (tree->TypeIs(TYP_DOUBLE))
             {
-                newTree = gtNewLconNode(jitstd::bit_cast<int64_t>(value));
-            }
-            else
-            {
-                assert(varTypeIsFloating(tree->GetType()));
-                newTree = gtNewDconNode(value, tree->GetType());
+                newTree = gtNewDconNode(vnStore->ConstantValue<double>(vn), TYP_DOUBLE);
             }
             break;
-        }
 
         case TYP_LONG:
         {
@@ -2512,23 +2491,9 @@ GenTree* Compiler::optVNConstantPropTree(BasicBlock* block, GenTree* tree)
             }
             else
 #endif
+                if (tree->TypeIs(TYP_LONG))
             {
-                switch (tree->GetType())
-                {
-                    case TYP_INT:
-                        newTree = gtNewIconNode(static_cast<int32_t>(value));
-                        break;
-                    case TYP_LONG:
-                        newTree = gtNewLconNode(value);
-                        break;
-                    case TYP_DOUBLE:
-                        newTree = gtNewDconNode(jitstd::bit_cast<double>(value));
-                        break;
-                    case TYP_FLOAT:
-                        unreached();
-                    default:
-                        break;
-                }
+                newTree = gtNewLconNode(value);
             }
         }
         break;
@@ -2558,24 +2523,10 @@ GenTree* Compiler::optVNConstantPropTree(BasicBlock* block, GenTree* tree)
             }
             else
 #endif
+                // TODO-MIKE-Review: Shouldn't this check the actual type of the tree?
+                if (tree->TypeIs(TYP_INT))
             {
-                switch (tree->GetType())
-                {
-                    case TYP_REF:
-                    case TYP_INT:
-                        newTree = gtNewIconNode(value);
-                        break;
-                    case TYP_LONG:
-                        newTree = gtNewLconNode(value);
-                        break;
-                    case TYP_FLOAT:
-                        newTree = gtNewDconNode(jitstd::bit_cast<float>(value), TYP_FLOAT);
-                        break;
-                    case TYP_DOUBLE:
-                        unreached();
-                    default:
-                        break;
-                }
+                newTree = gtNewIconNode(value);
             }
         }
         break;

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5140,13 +5140,19 @@ private:
                 break;
 
             case GT_MUL:
+#ifndef TARGET_64BIT
                 // Don't transform long multiplies.
+                // TODO-MIKE-CQ: Why not? If the MUL node itself is constant then there's no
+                // reason not to transform it. The problem here is actually transforming its
+                // operands, because they are expected to be CASTs, not constants. Which is
+                // actually ridiculous, it means that something like (long)x * 2, that should
+                // obviously use the long MUL form, ends up being a helper call...
                 if ((tree->gtFlags & GTF_MUL_64RSLT) != 0)
                 {
-                    // TODO-MIKE-Review: Erm, why skip subtrees?!?
                     return Compiler::WALK_SKIP_SUBTREES;
                 }
                 FALLTHROUGH;
+#endif
             case GT_ADD:
             case GT_SUB:
             case GT_DIV:

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -2436,93 +2436,6 @@ AssertionIndex Compiler::optAssertionIsSubtype(GenTree* tree, GenTree* methodTab
     return NO_ASSERTION_INDEX;
 }
 
-// Replaces a tree that evaluates to a constant with a constant node.
-// If the tree contains side effects then they are preserved using
-// a COMMA node.
-GenTree* Compiler::optVNConstantPropTree(BasicBlock* block, GenTree* tree)
-{
-    assert(!tree->OperIs(GT_JTRUE));
-
-    // If relop is part of JTRUE, this should be optimized as part of the parent JTRUE.
-    if (tree->OperIsCompare() && ((tree->gtFlags & GTF_RELOP_JMP_USED) != 0))
-    {
-        return nullptr;
-    }
-
-    ValueNumPair vnp = tree->gtVNPair;
-    ValueNum     vn  = vnStore->VNConservativeNormalValue(vnp);
-
-    if (!vnStore->IsVNConstant(vn))
-    {
-        return nullptr;
-    }
-
-    var_types vnType  = vnStore->TypeOfVN(vn);
-    GenTree*  newTree = nullptr;
-
-    if (vnStore->IsVNHandle(vn))
-    {
-        // Don't perform constant folding that involves a handle that needs to be recorded
-        // as a relocation with the VM. The VN type should be TYP_I_IMPL but the tree may
-        // sometimes be TYP_BYREF, due to things like Unsafe.As.
-        if (!opts.compReloc && tree->TypeIs(TYP_I_IMPL, TYP_BYREF) && (vnType == TYP_I_IMPL))
-        {
-            newTree = gtNewIconHandleNode(vnStore->ConstantValue<target_ssize_t>(vn), vnStore->GetHandleFlags(vn));
-        }
-    }
-    // The tree type and the VN type should match but VN can't be trusted. At least for SIMD
-    // locals, VN manages to pull out a TYP_LONG 0 constant out of the hat, if the local is
-    // not explictily initialized and .localsinit is used.
-    // TODO-MIKE-Review: Shouldn't this check the actual type of the tree?
-    else if (tree->GetType() == vnType)
-    {
-        switch (vnType)
-        {
-            case TYP_FLOAT:
-                newTree = gtNewDconNode(vnStore->ConstantValue<float>(vn), TYP_FLOAT);
-                break;
-            case TYP_DOUBLE:
-                newTree = gtNewDconNode(vnStore->ConstantValue<double>(vn), TYP_DOUBLE);
-                break;
-            case TYP_INT:
-                newTree = gtNewIconNode(vnStore->ConstantValue<int32_t>(vn));
-                break;
-            case TYP_LONG:
-                newTree = gtNewLconNode(vnStore->ConstantValue<int64_t>(vn));
-                break;
-            case TYP_REF:
-                assert(vnStore->ConstantValue<size_t>(vn) == 0);
-                newTree = gtNewIconNode(0, TYP_REF);
-                break;
-            case TYP_BYREF:
-                // Do not support const byref optimization.
-                break;
-            default:
-                unreached();
-        }
-    }
-
-    if (newTree == nullptr)
-    {
-        return nullptr;
-    }
-
-    newTree->SetVNs(vnp);
-
-    GenTree* sideEffects = optVNConstantPropExtractSideEffects(tree);
-
-    if (sideEffects != nullptr)
-    {
-        assert((sideEffects->gtFlags & GTF_SIDE_EFFECT) != 0);
-
-        // TODO-MIKE-Review: So we bother setting the VN on the constant node but not on the COMMA tree?
-        // Also, the constant node gets the wrong VN, the one that includes exceptions...
-        newTree = gtNewCommaNode(sideEffects, newTree);
-    }
-
-    return newTree;
-}
-
 //------------------------------------------------------------------------------
 // optConstantAssertionProp: Possibly substitute a constant for a local use
 //
@@ -5020,6 +4933,93 @@ Compiler::fgWalkResult Compiler::optVNConstantPropTree(BasicBlock* block, Statem
     DBEXEC(VERBOSE, gtDispStmt(stmt));
 
     return WALK_SKIP_SUBTREES;
+}
+
+// Replaces a tree that evaluates to a constant with a constant node.
+// If the tree contains side effects then they are preserved using
+// a COMMA node.
+GenTree* Compiler::optVNConstantPropTree(BasicBlock* block, GenTree* tree)
+{
+    assert(!tree->OperIs(GT_JTRUE));
+
+    // If relop is part of JTRUE, this should be optimized as part of the parent JTRUE.
+    if (tree->OperIsCompare() && ((tree->gtFlags & GTF_RELOP_JMP_USED) != 0))
+    {
+        return nullptr;
+    }
+
+    ValueNumPair vnp = tree->gtVNPair;
+    ValueNum     vn  = vnStore->VNConservativeNormalValue(vnp);
+
+    if (!vnStore->IsVNConstant(vn))
+    {
+        return nullptr;
+    }
+
+    var_types vnType  = vnStore->TypeOfVN(vn);
+    GenTree*  newTree = nullptr;
+
+    if (vnStore->IsVNHandle(vn))
+    {
+        // Don't perform constant folding that involves a handle that needs to be recorded
+        // as a relocation with the VM. The VN type should be TYP_I_IMPL but the tree may
+        // sometimes be TYP_BYREF, due to things like Unsafe.As.
+        if (!opts.compReloc && tree->TypeIs(TYP_I_IMPL, TYP_BYREF) && (vnType == TYP_I_IMPL))
+        {
+            newTree = gtNewIconHandleNode(vnStore->ConstantValue<target_ssize_t>(vn), vnStore->GetHandleFlags(vn));
+        }
+    }
+    // The tree type and the VN type should match but VN can't be trusted. At least for SIMD
+    // locals, VN manages to pull out a TYP_LONG 0 constant out of the hat, if the local is
+    // not explictily initialized and .localsinit is used.
+    // TODO-MIKE-Review: Shouldn't this check the actual type of the tree?
+    else if (tree->GetType() == vnType)
+    {
+        switch (vnType)
+        {
+            case TYP_FLOAT:
+                newTree = gtNewDconNode(vnStore->ConstantValue<float>(vn), TYP_FLOAT);
+                break;
+            case TYP_DOUBLE:
+                newTree = gtNewDconNode(vnStore->ConstantValue<double>(vn), TYP_DOUBLE);
+                break;
+            case TYP_INT:
+                newTree = gtNewIconNode(vnStore->ConstantValue<int32_t>(vn));
+                break;
+            case TYP_LONG:
+                newTree = gtNewLconNode(vnStore->ConstantValue<int64_t>(vn));
+                break;
+            case TYP_REF:
+                assert(vnStore->ConstantValue<size_t>(vn) == 0);
+                newTree = gtNewIconNode(0, TYP_REF);
+                break;
+            case TYP_BYREF:
+                // Do not support const byref optimization.
+                break;
+            default:
+                unreached();
+        }
+    }
+
+    if (newTree == nullptr)
+    {
+        return nullptr;
+    }
+
+    newTree->SetVNs(vnp);
+
+    GenTree* sideEffects = optVNConstantPropExtractSideEffects(tree);
+
+    if (sideEffects != nullptr)
+    {
+        assert((sideEffects->gtFlags & GTF_SIDE_EFFECT) != 0);
+
+        // TODO-MIKE-Review: So we bother setting the VN on the constant node but not on the COMMA tree?
+        // Also, the constant node gets the wrong VN, the one that includes exceptions...
+        newTree = gtNewCommaNode(sideEffects, newTree);
+    }
+
+    return newTree;
 }
 
 GenTree* Compiler::optVNConstantPropStmtUpdate(GenTree* newTree, GenTree* tree, Statement* stmt)

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5213,8 +5213,7 @@ private:
 
     GenTree* GetConstNode(GenTree* tree)
     {
-        ValueNumPair vnp = tree->gtVNPair;
-        ValueNum     vn  = m_vnStore->VNConservativeNormalValue(vnp);
+        ValueNum vn = m_vnStore->VNConservativeNormalValue(tree->gtVNPair);
 
         if (!m_vnStore->IsVNConstant(vn))
         {
@@ -5274,7 +5273,7 @@ private:
             return nullptr;
         }
 
-        newTree->SetVNs(vnp);
+        newTree->SetVNs(ValueNumPair(vn, vn));
 
         GenTree* sideEffects = ExtractConstTreeSideEffects(tree);
 
@@ -5282,9 +5281,8 @@ private:
         {
             assert((sideEffects->gtFlags & GTF_SIDE_EFFECT) != 0);
 
-            // TODO-MIKE-Review: So we bother setting the VN on the constant node but not on the COMMA tree?
-            // Also, the constant node gets the wrong VN, the one that includes exceptions...
             newTree = m_compiler->gtNewCommaNode(sideEffects, newTree);
+            newTree->SetVNs(tree->gtVNPair);
         }
 
         return newTree;

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5244,27 +5244,10 @@ GenTree* Compiler::optVNConstantPropStmtUpdate(GenTree* newTree, GenTree* tree, 
     return newTree;
 }
 
-//------------------------------------------------------------------------------
-// optVNNonNullPropStmt
-//    Performs VN based non-null propagation on the tree node.
-//
-// Assumption:
-//    This function is called as part of a pre-order tree walk.
-//
-// Arguments:
-//    block - The block that contains the statement that contains the tree.
-//    stmt  - The statement node in which the "tree" is present.
-//    tree  - The currently visited tree node.
-//
-// Return Value:
-//    None.
-//
-// Description:
-//    Performs value number based non-null propagation on GT_CALL and
-//    indirections. This is different from flow based assertions and helps
-//    unify VN based constant prop and non-null prop in a single pre-order walk.
-//
-void Compiler::optVNNonNullPropTree(BasicBlock* block, Statement* stmt, GenTree* tree)
+// Performs value number based non-null propagation on GT_CALL and
+// indirections. This is different from flow based assertions and helps
+// unify VN based constant prop and non-null prop in a single pre-order walk.
+void Compiler::optVNNonNullPropTree(GenTree* tree)
 {
     if (GenTreeCall* call = tree->IsCall())
     {
@@ -5373,7 +5356,7 @@ Compiler::fgWalkResult Compiler::optVNAssertionPropStmtVisitor(GenTree** ppTree,
     VNAssertionPropVisitorInfo* pData = (VNAssertionPropVisitorInfo*)data->pCallbackData;
     Compiler*                   pThis = pData->pThis;
 
-    pThis->optVNNonNullPropTree(pData->block, pData->stmt, *ppTree);
+    pThis->optVNNonNullPropTree(*ppTree);
 
     return pThis->optVNConstantPropStmt(pData->block, pData->stmt, *ppTree);
 }

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5168,10 +5168,15 @@ private:
             case GT_LSH:
             case GT_RSH:
             case GT_RSZ:
+            case GT_ROL:
+            case GT_ROR:
+            case GT_BSWAP:
+            case GT_BSWAP16:
             case GT_NEG:
+            case GT_NOT:
             case GT_CAST:
+            case GT_BITCAST:
             case GT_INTRINSIC:
-                // TODO-MIKE-Review: Huh, this is missing various opers - ROL, ROR, BITCAST, NOT, BSWAP...
                 break;
 
             default:

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5336,16 +5336,9 @@ void Compiler::optVNAssertionProp()
         compCurBB           = block;
         fgRemoveRestOfBlock = false;
 
-        Statement* stmt = block->GetFirstStatement();
-
-        while (stmt != nullptr)
+        for (Statement* stmt = block->GetFirstStatement(); stmt != nullptr;)
         {
             Statement* nextStmt = optVNAssertionPropStmt(block, stmt);
-
-            if (fgRemoveRestOfBlock)
-            {
-                break;
-            }
 
             if (nextStmt != nullptr)
             {
@@ -5365,16 +5358,6 @@ void Compiler::optVNAssertionProp()
             }
 
             stmt = stmt->GetNextStmt();
-        }
-
-        if (fgRemoveRestOfBlock)
-        {
-            for (stmt = stmt->GetNextStmt(); stmt != nullptr; stmt = stmt->GetNextStmt())
-            {
-                fgRemoveStmt(block, stmt);
-            }
-
-            fgRemoveRestOfBlock = false;
         }
     }
 

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4191,11 +4191,11 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
 
     DoPhase(this, PHASE_STR_ADRLCL, &Compiler::fgMarkAddressExposedLocals);
 
-#ifdef DEBUG
     // Now that locals have address-taken and implicit byref marked, we can safely apply stress.
-    lvaStressLclFld();
-    fgStress64RsltMul();
-#endif // DEBUG
+    INDEBUG(lvaStressLclFld();)
+#ifndef TARGET_64BIT
+    INDEBUG(fgStress64RsltMul();)
+#endif
 
     // Morph the trees in all the blocks of the method
     //
@@ -8067,14 +8067,13 @@ void cTreeFlags(Compiler* comp, GenTree* tree)
                 break;
 
             case GT_MUL:
-#if !defined(TARGET_64BIT)
+#ifndef TARGET_64BIT
             case GT_MUL_LONG:
-#endif
-
-                if (tree->gtFlags & GTF_MUL_64RSLT)
+                if ((tree->gtFlags & GTF_MUL_64RSLT) != 0)
                 {
                     chars += printf("[64RSLT]");
                 }
+#endif
                 if (tree->gtFlags & GTF_ADDRMODE_NO_CSE)
                 {
                     chars += printf("[ADDRMODE_NO_CSE]");

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4418,7 +4418,7 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
             {
                 // Assertion propagation
                 //
-                DoPhase(this, PHASE_ASSERTION_PROP_MAIN, &Compiler::optAssertionPropMain);
+                DoPhase(this, PHASE_ASSERTION_PROP_MAIN, &Compiler::optVNAssertionProp);
             }
 
             if (doRangeAnalysis)

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6159,8 +6159,8 @@ protected:
 
 public:
     void optVNNonNullPropTree(BasicBlock* block, Statement* stmt, GenTree* tree);
-    GenTree* optVNNonNullPropCall(GenTreeCall* call);
-    GenTree* optVNNonNullPropIndir(GenTreeIndir* indir);
+    void optVNNonNullPropCall(GenTreeCall* call);
+    void optVNNonNullPropIndir(GenTreeIndir* indir);
     fgWalkResult optVNConstantPropStmt(BasicBlock* block, Statement* stmt, GenTree* tree);
     GenTree* optVNConstantPropStmtUpdate(GenTree* newTree, GenTree* tree, Statement* stmt);
     GenTree* optVNConstantPropOnJTrue(BasicBlock* block, GenTree* test);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2137,8 +2137,6 @@ public:
                               unsigned  flags      = GTF_SIDE_EFFECT,
                               bool      ignoreRoot = false);
 
-    GenTree* gtGetThisArg(GenTreeCall* call);
-
     // Static fields of struct types (and sometimes the types that those are reduced to) are represented by having the
     // static field contain an object pointer to the boxed struct.  This simplifies the GC implementation...but
     // complicates the JIT somewhat.  This predicate returns "true" iff a node with type "fieldNodeType", representing

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6158,8 +6158,9 @@ protected:
     AssertionIndex optMaxAssertionCount;
 
 public:
-    void optVnNonNullPropCurStmt(BasicBlock* block, Statement* stmt, GenTree* tree);
+    void optVNNonNullPropTree(BasicBlock* block, Statement* stmt, GenTree* tree);
     GenTree* optVNNonNullPropCall(GenTreeCall* call);
+    GenTree* optVNNonNullPropIndir(GenTreeIndir* indir);
     fgWalkResult optVNConstantPropStmt(BasicBlock* block, Statement* stmt, GenTree* tree);
     GenTree* optVNConstantPropStmtUpdate(GenTree* newTree, GenTree* tree, Statement* stmt);
     GenTree* optVNConstantPropOnJTrue(BasicBlock* block, GenTree* test);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6159,7 +6159,8 @@ protected:
 
 public:
     void optVnNonNullPropCurStmt(BasicBlock* block, Statement* stmt, GenTree* tree);
-    fgWalkResult optVNConstantPropCurStmt(BasicBlock* block, Statement* stmt, GenTree* tree);
+    fgWalkResult optVNConstantPropStmt(BasicBlock* block, Statement* stmt, GenTree* tree);
+    GenTree* optVNConstantPropStmtUpdate(GenTree* newTree, GenTree* tree, Statement* stmt);
     GenTree* optVNConstantPropOnJTrue(BasicBlock* block, GenTree* test);
     GenTree* optVNConstantPropOnTree(BasicBlock* block, GenTree* tree);
     GenTree* optExtractSideEffListFromConst(GenTree* tree);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -1877,7 +1877,7 @@ public:
     GenTree* gtNewStringLiteralNode(InfoAccessType iat, void* pValue);
     GenTreeIntCon* gtNewStringLiteralLength(GenTreeStrCon* node);
 
-    GenTree* gtNewLconNode(__int64 value);
+    GenTree* gtNewLconNode(int64_t value);
 
     GenTree* gtNewDconNode(double value, var_types type = TYP_DOUBLE);
 
@@ -6164,7 +6164,7 @@ public:
     fgWalkResult optVNConstantPropTree(BasicBlock* block, Statement* stmt, GenTree* tree);
     GenTree* optVNConstantPropStmtUpdate(GenTree* newTree, GenTree* tree, Statement* stmt);
     GenTree* optVNConstantPropOnJTrue(BasicBlock* block, GenTree* test);
-    GenTree* optVNConstantPropOnTree(BasicBlock* block, GenTree* tree);
+    GenTree* optVNConstantPropTree(BasicBlock* block, GenTree* tree);
     GenTree* optExtractSideEffListFromConst(GenTree* tree);
 
     AssertionIndex GetAssertionCount()

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6159,6 +6159,7 @@ protected:
 
 public:
     void optVnNonNullPropCurStmt(BasicBlock* block, Statement* stmt, GenTree* tree);
+    GenTree* optVNNonNullPropCall(GenTreeCall* call);
     fgWalkResult optVNConstantPropStmt(BasicBlock* block, Statement* stmt, GenTree* tree);
     GenTree* optVNConstantPropStmtUpdate(GenTree* newTree, GenTree* tree, Statement* stmt);
     GenTree* optVNConstantPropOnJTrue(BasicBlock* block, GenTree* test);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -1448,6 +1448,7 @@ class Compiler
     friend class LocalAddressVisitor;
     friend struct GenTree;
     friend class ClassLayout;
+    friend class VNConstPropVisitor;
 
 #ifdef FEATURE_HW_INTRINSICS
     friend struct HWIntrinsicInfo;
@@ -6158,9 +6159,6 @@ protected:
     AssertionIndex optMaxAssertionCount;
 
 public:
-    void optVNNonNullPropTree(GenTree* tree);
-    void optVNNonNullPropCall(GenTreeCall* call);
-    void optVNNonNullPropIndir(GenTreeIndir* indir);
     fgWalkResult optVNConstantPropTree(BasicBlock* block, Statement* stmt, GenTree* tree);
     GenTree* optVNConstantPropStmtUpdate(GenTree* newTree, GenTree* tree, Statement* stmt);
     GenTree* optVNConstantPropJTrue(BasicBlock* block, GenTreeUnOp* jtrue);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6181,8 +6181,7 @@ public:
 #endif
 
     // Assertion prop data flow functions.
-    void       optVNAssertionProp();
-    Statement* optVNAssertionPropStmt(BasicBlock* block, Statement* stmt);
+    void optVNAssertionProp();
     bool optIsTreeKnownIntValue(bool vnBased, GenTree* tree, ssize_t* pConstant, GenTreeFlags* pIconFlags);
     ASSERT_TP* optInitAssertionDataflowFlags();
     ASSERT_TP* optComputeAssertionGen();

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6161,7 +6161,7 @@ public:
     void optVNNonNullPropTree(GenTree* tree);
     void optVNNonNullPropCall(GenTreeCall* call);
     void optVNNonNullPropIndir(GenTreeIndir* indir);
-    fgWalkResult optVNConstantPropStmt(BasicBlock* block, Statement* stmt, GenTree* tree);
+    fgWalkResult optVNConstantPropTree(BasicBlock* block, Statement* stmt, GenTree* tree);
     GenTree* optVNConstantPropStmtUpdate(GenTree* newTree, GenTree* tree, Statement* stmt);
     GenTree* optVNConstantPropOnJTrue(BasicBlock* block, GenTree* test);
     GenTree* optVNConstantPropOnTree(BasicBlock* block, GenTree* tree);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6158,7 +6158,7 @@ protected:
     AssertionIndex optMaxAssertionCount;
 
 public:
-    void optVNNonNullPropTree(BasicBlock* block, Statement* stmt, GenTree* tree);
+    void optVNNonNullPropTree(GenTree* tree);
     void optVNNonNullPropCall(GenTreeCall* call);
     void optVNNonNullPropIndir(GenTreeIndir* indir);
     fgWalkResult optVNConstantPropStmt(BasicBlock* block, Statement* stmt, GenTree* tree);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6159,10 +6159,7 @@ protected:
     AssertionIndex optMaxAssertionCount;
 
 public:
-    fgWalkResult optVNConstantPropTree(BasicBlock* block, Statement* stmt, GenTree* tree);
-    GenTree* optVNConstantPropStmtUpdate(GenTree* newTree, GenTree* tree, Statement* stmt);
     GenTree* optVNConstantPropJTrue(BasicBlock* block, GenTreeUnOp* jtrue);
-    GenTree* optVNConstantPropTree(BasicBlock* block, GenTree* tree);
     GenTree* optVNConstantPropExtractSideEffects(GenTree* tree);
 
     AssertionIndex GetAssertionCount()

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6163,9 +6163,9 @@ public:
     void optVNNonNullPropIndir(GenTreeIndir* indir);
     fgWalkResult optVNConstantPropTree(BasicBlock* block, Statement* stmt, GenTree* tree);
     GenTree* optVNConstantPropStmtUpdate(GenTree* newTree, GenTree* tree, Statement* stmt);
-    GenTree* optVNConstantPropOnJTrue(BasicBlock* block, GenTree* test);
+    GenTree* optVNConstantPropJTrue(BasicBlock* block, GenTreeUnOp* jtrue);
     GenTree* optVNConstantPropTree(BasicBlock* block, GenTree* tree);
-    GenTree* optExtractSideEffListFromConst(GenTree* tree);
+    GenTree* optVNConstantPropExtractSideEffects(GenTree* tree);
 
     AssertionIndex GetAssertionCount()
     {

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6141,7 +6141,7 @@ public:
 
 protected:
     static fgWalkPreFn optAddCopiesCallback;
-    static fgWalkPreFn optVNAssertionPropCurStmtVisitor;
+    static fgWalkPreFn optVNAssertionPropStmtVisitor;
     unsigned           optAddCopyLclNum;
     GenTree*           optAddCopyAsgnNode;
 
@@ -6183,8 +6183,8 @@ public:
 #endif
 
     // Assertion prop data flow functions.
-    void       optAssertionPropMain();
-    Statement* optVNAssertionPropCurStmt(BasicBlock* block, Statement* stmt);
+    void       optVNAssertionProp();
+    Statement* optVNAssertionPropStmt(BasicBlock* block, Statement* stmt);
     bool optIsTreeKnownIntValue(bool vnBased, GenTree* tree, ssize_t* pConstant, GenTreeFlags* pIconFlags);
     ASSERT_TP* optInitAssertionDataflowFlags();
     ASSERT_TP* optComputeAssertionGen();

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6145,8 +6145,7 @@ protected:
     unsigned           optAddCopyLclNum;
     GenTree*           optAddCopyAsgnNode;
 
-    bool optLocalAssertionProp;  // indicates that we are performing local assertion prop
-    bool optAssertionPropagated; // set to true if we modified the trees
+    bool optLocalAssertionProp; // indicates that we are performing local assertion prop
     bool optAssertionPropagatedCurrentStmt;
 #ifdef DEBUG
     GenTree* optAssertionPropCurrentTree;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6146,7 +6146,7 @@ protected:
     GenTree*           optAddCopyAsgnNode;
 
     bool optLocalAssertionProp; // indicates that we are performing local assertion prop
-    bool optAssertionPropagatedCurrentStmt;
+    bool optVNAssertionPropStmtMorphPending;
 #ifdef DEBUG
     GenTree* optAssertionPropCurrentTree;
 #endif

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2275,6 +2275,7 @@ void Compiler::fgDumpTrees(BasicBlock* firstBlock, BasicBlock* lastBlock)
            "----------\n");
 }
 
+#ifndef TARGET_64BIT
 /*****************************************************************************
  * Try to create as many candidates for GTF_MUL_64RSLT as possible.
  * We convert 'intOp1*intOp2' into 'int(long(nop(intOp1))*long(intOp2))'.
@@ -2317,6 +2318,7 @@ void Compiler::fgStress64RsltMul()
 
     fgWalkAllTreesPre(fgStress64RsltMulCB, (void*)this);
 }
+#endif // !TARGET_64BIT
 
 // BBPredsChecker checks jumps from the block's predecessors to the block.
 class BBPredsChecker

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -5460,7 +5460,7 @@ GenTreeIntCon* Compiler::gtNewStringLiteralLength(GenTreeStrCon* node)
 
 /*****************************************************************************/
 
-GenTree* Compiler::gtNewLconNode(__int64 value)
+GenTree* Compiler::gtNewLconNode(int64_t value)
 {
 #ifdef TARGET_64BIT
     GenTree* node = new (this, GT_CNS_INT) GenTreeIntCon(TYP_LONG, value);

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2296,6 +2296,7 @@ GenTree* Compiler::gtReverseCond(GenTree* tree)
 /*****************************************************************************/
 
 #ifdef DEBUG
+#ifndef TARGET_64BIT
 
 bool GenTree::gtIsValid64RsltMul()
 {
@@ -2344,6 +2345,7 @@ bool GenTree::gtIsValid64RsltMul()
     return true;
 }
 
+#endif // !TARGET_64BIT
 #endif // DEBUG
 
 unsigned Compiler::gtSetCallArgsOrder(const GenTreeCall::UseList& args, bool lateArgs, int* callCostEx, int* callCostSz)
@@ -8467,15 +8469,15 @@ int Compiler::gtDispNodeHeader(GenTree* tree, IndentStack* indentStack, int msgL
                 goto DASH;
 
             case GT_MUL:
-#if !defined(TARGET_64BIT)
+#ifndef TARGET_64BIT
             case GT_MUL_LONG:
-#endif
-                if (tree->gtFlags & GTF_MUL_64RSLT)
+                if ((tree->gtFlags & GTF_MUL_64RSLT) != 0)
                 {
                     printf("L");
                     --msgLength;
                     break;
                 }
+#endif
                 goto DASH;
 
             case GT_DIV:

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -5709,6 +5709,20 @@ GenTreeCall::Use* Compiler::gtNewCallArgs(GenTree* node1, GenTree* node2, GenTre
     return new (this, CMK_ASTNode) GenTreeCall::Use(node1, gtNewCallArgs(node2, node3, node4));
 }
 
+GenTree* GenTreeCall::GetThisArg() const
+{
+    assert(gtCallThisArg != nullptr);
+
+    if (fgArgInfo == nullptr)
+    {
+        return gtCallThisArg->GetNode();
+    }
+
+    CallArgInfo* argInfo = GetArgInfoByArgNum(0);
+    assert(argInfo->use == gtCallThisArg);
+    return argInfo->GetNode();
+}
+
 CallArgInfo* GenTreeCall::GetArgInfoByArgNum(unsigned argNum) const
 {
     noway_assert(fgArgInfo != nullptr);
@@ -7211,21 +7225,6 @@ bool Compiler::gtCompareTree(GenTree* op1, GenTree* op2)
         }
     }
     return false;
-}
-
-GenTree* Compiler::gtGetThisArg(GenTreeCall* call)
-{
-    assert(call->gtCallThisArg != nullptr);
-
-    if (call->GetInfo() == nullptr)
-    {
-        return call->gtCallThisArg->GetNode();
-    }
-
-    CallArgInfo* argInfo = call->GetArgInfoByArgNum(0);
-    assert(argInfo->use == call->gtCallThisArg);
-    assert(argInfo->GetRegNum() == REG_ARG_0);
-    return argInfo->GetNode();
 }
 
 bool GenTree::gtSetFlags() const

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4278,6 +4278,7 @@ public:
         return UseList(gtCallLateArgs);
     }
 
+    GenTree* GetThisArg() const;
     GenTree* GetArgNodeByArgNum(unsigned argNum) const;
     CallArgInfo* GetArgInfoByArgNum(unsigned argNum) const;
     CallArgInfo* GetArgInfoByArgNode(GenTree* node) const;

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -537,7 +537,9 @@ enum GenTreeFlags : unsigned int
     GTF_ADDRMODE_NO_CSE         = 0x80000000, // GT_ADD/GT_MUL/GT_LSH -- Do not CSE this node only, forms complex
                                               //                         addressing mode
 
+#ifndef TARGET_64BIT
     GTF_MUL_64RSLT              = 0x40000000, // GT_MUL     -- produce 64-bit result
+#endif
 
     GTF_RELOP_NAN_UN            = 0x80000000, // GT_<relop> -- Is branch taken if ops are NaN?
     GTF_RELOP_JMP_USED          = 0x40000000, // GT_<relop> -- result of compare used for jump or ?:

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -3114,18 +3114,19 @@ struct GenTreeIntCon : public GenTreeIntConCommon
 
 struct GenTreeLngCon : public GenTreeIntConCommon
 {
-    INT64 gtLconVal; // Must overlap and have the same offset with the gtIconVal field in GenTreeIntCon above.
-    INT32 LoVal()
+    int64_t gtLconVal; // Must overlap and have the same offset with the gtIconVal field in GenTreeIntCon above.
+
+    int32_t LoVal() const
     {
-        return (INT32)(gtLconVal & 0xffffffff);
+        return static_cast<int32_t>(gtLconVal & 0xffffffff);
     }
 
-    INT32 HiVal()
+    int32_t HiVal() const
     {
-        return (INT32)(gtLconVal >> 32);
+        return static_cast<int32_t>(gtLconVal >> 32);
     }
 
-    GenTreeLngCon(INT64 val) : GenTreeIntConCommon(GT_CNS_NATIVELONG, TYP_LONG)
+    GenTreeLngCon(int64_t val) : GenTreeIntConCommon(GT_CNS_NATIVELONG, TYP_LONG)
     {
         SetLngValue(val);
     }

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3440,7 +3440,7 @@ GenTree* Lowering::LowerDelegateInvoke(GenTreeCall* call)
     }
     else
     {
-        thisArgNode = comp->gtGetThisArg(call);
+        thisArgNode = call->GetThisArg();
     }
 
     assert(thisArgNode != nullptr);

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -2402,7 +2402,9 @@ int LinearScan::BuildMul(GenTree* tree)
     if (tree->OperGet() != GT_MUL_LONG)
 #endif
     {
+#ifndef TARGET_64BIT
         assert((tree->gtFlags & GTF_MUL_64RSLT) == 0);
+#endif
     }
 
     BuildKills(tree, getKillSetForMul(tree->AsOp()));

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -414,11 +414,13 @@ GenTree* Compiler::fgMorphCast(GenTreeCast* cast)
                     src->AsOp()->SetOp(1, gtNewCastNode(TYP_INT, src->AsOp()->GetOp(1), false, dstType));
                 }
 
+#ifndef TARGET_64BIT
                 // Clear the GT_MUL_64RSLT if it is set.
                 if (src->OperIs(GT_MUL) && ((src->gtFlags & GTF_MUL_64RSLT) != 0))
                 {
                     src->gtFlags &= ~GTF_MUL_64RSLT;
                 }
+#endif
 
                 // The operation now produces a 32-bit result.
                 src->SetType(TYP_INT);
@@ -4409,10 +4411,12 @@ void Compiler::fgMoveOpsLeft(GenTree* tree)
             return;
         }
 
-        if (oper == GT_MUL && (op2->gtFlags & GTF_MUL_64RSLT))
+#ifndef TARGET_64BIT
+        if ((oper == GT_MUL) && ((op2->gtFlags & GTF_MUL_64RSLT) != 0))
         {
             return;
         }
+#endif
 
         // Check for GTF_ADDRMODE_NO_CSE flag on add/mul Binary Operators
         if (((oper == GT_ADD) || (oper == GT_MUL)) && ((tree->gtFlags & GTF_ADDRMODE_NO_CSE) != 0))
@@ -9996,8 +10000,8 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac)
                 }
                 else
                 {
-                    /* We are seeing this node again. We have decided to use
-                       GTF_MUL_64RSLT, so leave it alone. */
+                    // We are seeing this node again. We have decided to use
+                    // GTF_MUL_64RSLT, so leave it alone.
 
                     assert(tree->gtIsValid64RsltMul());
                 }
@@ -11444,7 +11448,6 @@ DONE_MORPHING_CHILDREN:
             break;
 
         case GT_MUL:
-
 #ifndef TARGET_64BIT
             if (typ == TYP_LONG)
             {
@@ -11452,7 +11455,7 @@ DONE_MORPHING_CHILDREN:
                 assert(tree->gtIsValid64RsltMul());
                 return tree;
             }
-#endif // TARGET_64BIT
+#endif
             goto CM_OVF_OP;
 
         case GT_SUB:

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -5130,14 +5130,16 @@ bool Compiler::optNarrowTree(GenTree* tree, var_types srct, var_types dstt, Valu
                     return false;
                 }
 
-                /* Simply change the type of the tree */
+                // Simply change the type of the tree
 
                 if (doit)
                 {
-                    if (tree->gtOper == GT_MUL && (tree->gtFlags & GTF_MUL_64RSLT))
+#ifndef TARGET_64BIT
+                    if (tree->OperIs(GT_MUL) && ((tree->gtFlags & GTF_MUL_64RSLT) != 0))
                     {
                         tree->gtFlags &= ~GTF_MUL_64RSLT;
                     }
+#endif
 
                     tree->gtType = genActualType(dstt);
                     tree->SetVNs(vnpNarrow);

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -6326,6 +6326,7 @@ void Compiler::fgValueNumber()
                     if (isZeroed)
                     {
                         // By default we will zero init these LclVars
+                        // TODO-MIKE-Cleanup: For SIMD locals this generates bogus typed LONG 0 VN constants.
                         initVal = vnStore->VNZeroForType(typ);
                     }
                     else


### PR DESCRIPTION
win-x64 PIN:

BASE | DIFF
-- | --
19719476588 | 19665771083
19726857589 | 19665460586
19723570058 | 19665345173
19719444508 | 19665639364
19719328946 | 19670740797
19721825556 | 19669532520
19724354076 | 19669592652
19727318862 | 19665554436
19720941861 | 19663726703
19724985367 | 19670524591
AVG |  
19,722,810,341 | 19,667,188,791
STDEV |  
2,888,285 | 2,459,051
DELTA |  
-55,621,551 | -0.28%

diff:
```
win-x64:

Total bytes of base: 31626543
Total bytes of diff: 31604735
Total bytes of delta: -21808 (-0.07% of base)
    diff is an improvement.

Top file improvements (bytes):
       -7966 : System.Security.Cryptography.Pkcs.dasm (-2.61% of base)
       -4577 : System.Security.Cryptography.Algorithms.dasm (-1.56% of base)
       -3363 : System.Security.Cryptography.Cng.dasm (-2.11% of base)
       -1769 : Microsoft.CodeAnalysis.CSharp.dasm (-0.09% of base)
       -1397 : System.Security.Cryptography.X509Certificates.dasm (-0.97% of base)
       -1268 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.06% of base)
        -411 : System.Diagnostics.DiagnosticSource.dasm (-0.63% of base)
        -208 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.01% of base)
        -171 : Microsoft.CodeAnalysis.dasm (-0.02% of base)
        -158 : System.Threading.Tasks.Dataflow.dasm (-0.11% of base)
         -93 : System.Net.HttpListener.dasm (-0.05% of base)
         -84 : System.Net.Http.dasm (-0.02% of base)
         -69 : Newtonsoft.Json.dasm (-0.01% of base)
         -53 : System.Net.Sockets.dasm (-0.04% of base)
         -41 : Microsoft.Extensions.DependencyModel.dasm (-0.10% of base)
         -40 : FSharp.Core.dasm (-0.00% of base)
         -40 : System.Private.CoreLib.dasm (-0.00% of base)
         -22 : System.Text.Json.dasm (-0.00% of base)
         -20 : System.Linq.Parallel.dasm (-0.00% of base)
         -20 : OSExtensions.dasm (-0.34% of base)

23 total files with Code Size differences (23 improved, 0 regressed), 247 unchanged.

Top method improvements (bytes):
        -637 (-35.85% of base) : System.Security.Cryptography.Cng.dasm - EccKeyFormatHelper:WriteSpecifiedECDomain(ECParameters,AsnWriter)
        -636 (-35.43% of base) : System.Security.Cryptography.Algorithms.dasm - EccKeyFormatHelper:WriteSpecifiedECDomain(ECParameters,AsnWriter)
        -604 (-36.39% of base) : System.Security.Cryptography.Algorithms.dasm - PasswordBasedEncryption:WritePbeAlgorithmIdentifier(AsnWriter,bool,String,Span`1,int,String,Span`1)
        -604 (-36.39% of base) : System.Security.Cryptography.Cng.dasm - PasswordBasedEncryption:WritePbeAlgorithmIdentifier(AsnWriter,bool,String,Span`1,int,String,Span`1)
        -604 (-36.39% of base) : System.Security.Cryptography.Pkcs.dasm - PasswordBasedEncryption:WritePbeAlgorithmIdentifier(AsnWriter,bool,String,Span`1,int,String,Span`1)
        -448 (-14.84% of base) : System.Security.Cryptography.Pkcs.dasm - Pkcs12Builder:SealWithMac(ReadOnlySpan`1,HashAlgorithmName,int):this
        -408 (-17.24% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxFactory:.cctor() (2 methods)
        -362 (-15.95% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SyntaxFactory:.cctor() (2 methods)
        -264 (-17.44% of base) : System.Security.Cryptography.Algorithms.dasm - RSAPrivateKeyAsn:DecodeCore(byref,Asn1Tag,ReadOnlyMemory`1,byref)
        -219 (-6.94% of base) : System.Security.Cryptography.Pkcs.dasm - Rfc3161TstInfo:DecodeCore(byref,Asn1Tag,ReadOnlyMemory`1,byref)
        -186 (-11.06% of base) : System.Security.Cryptography.Algorithms.dasm - CurveAsn:DecodeCore(byref,Asn1Tag,ReadOnlyMemory`1,byref)
        -186 (-11.06% of base) : System.Security.Cryptography.Cng.dasm - CurveAsn:DecodeCore(byref,Asn1Tag,ReadOnlyMemory`1,byref)
        -180 (-10.29% of base) : System.Security.Cryptography.Algorithms.dasm - SpecifiedECDomain:DecodeCore(byref,Asn1Tag,ReadOnlyMemory`1,byref)
        -180 (-10.29% of base) : System.Security.Cryptography.Cng.dasm - SpecifiedECDomain:DecodeCore(byref,Asn1Tag,ReadOnlyMemory`1,byref)
        -174 (-0.18% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - ApplicationServerTraceEventParser:EnumerateTemplates(Func`3,Action`1):this
        -168 (-8.77% of base) : System.Security.Cryptography.Pkcs.dasm - Rfc3161TimeStampReq:DecodeCore(byref,Asn1Tag,ReadOnlyMemory`1,byref)
        -167 (-14.53% of base) : System.Security.Cryptography.Pkcs.dasm - X509ExtensionAsn:DecodeCore(byref,Asn1Tag,ReadOnlyMemory`1,byref)
        -167 (-14.53% of base) : System.Security.Cryptography.X509Certificates.dasm - X509ExtensionAsn:DecodeCore(byref,Asn1Tag,ReadOnlyMemory`1,byref)
        -160 (-19.02% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxTriviaListBuilder:ToList():SyntaxTriviaList:this
        -150 (-27.42% of base) : System.Security.Cryptography.Algorithms.dasm - DSAKeyFormatHelper:WriteAlgorithmId(AsnWriter,byref)

Top method improvements (percentages):
         -64 (-40.00% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - PEModuleSymbol:GetCustomAttributesForToken(EntityHandle):ImmutableArray`1:this
         -64 (-40.00% of base) : Microsoft.CodeAnalysis.CSharp.dasm - PEModuleSymbol:GetCustomAttributesForToken(EntityHandle):ImmutableArray`1:this
        -604 (-36.39% of base) : System.Security.Cryptography.Algorithms.dasm - PasswordBasedEncryption:WritePbeAlgorithmIdentifier(AsnWriter,bool,String,Span`1,int,String,Span`1)
        -604 (-36.39% of base) : System.Security.Cryptography.Cng.dasm - PasswordBasedEncryption:WritePbeAlgorithmIdentifier(AsnWriter,bool,String,Span`1,int,String,Span`1)
        -604 (-36.39% of base) : System.Security.Cryptography.Pkcs.dasm - PasswordBasedEncryption:WritePbeAlgorithmIdentifier(AsnWriter,bool,String,Span`1,int,String,Span`1)
         -20 (-36.36% of base) : OSExtensions.dasm - ETWKernelControl:IsWin8orNewer():bool
        -637 (-35.85% of base) : System.Security.Cryptography.Cng.dasm - EccKeyFormatHelper:WriteSpecifiedECDomain(ECParameters,AsnWriter)
        -636 (-35.43% of base) : System.Security.Cryptography.Algorithms.dasm - EccKeyFormatHelper:WriteSpecifiedECDomain(ECParameters,AsnWriter)
         -22 (-30.99% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxFactory:Parameter(ModifiedIdentifierSyntax):ParameterSyntax
         -72 (-29.15% of base) : System.Security.Cryptography.Algorithms.dasm - RSAKeyFormatHelper:WriteAlgorithmIdentifier(AsnWriter)
        -150 (-27.42% of base) : System.Security.Cryptography.Algorithms.dasm - DSAKeyFormatHelper:WriteAlgorithmId(AsnWriter,byref)
        -126 (-27.27% of base) : Microsoft.CodeAnalysis.CSharp.dasm - AliasSymbol:CreateGlobalNamespaceAlias(NamespaceSymbol,Binder):AliasSymbol
         -30 (-26.32% of base) : Newtonsoft.Json.dasm - JsonWriter:get_ContainerPath():String:this
         -90 (-26.24% of base) : System.Security.Cryptography.Algorithms.dasm - EccKeyFormatHelper:WriteAlgorithmIdentifier(byref,AsnWriter)
         -90 (-26.24% of base) : System.Security.Cryptography.Cng.dasm - EccKeyFormatHelper:WriteAlgorithmIdentifier(byref,AsnWriter)
         -78 (-25.91% of base) : System.Security.Cryptography.Algorithms.dasm - EccKeyFormatHelper:WriteCurve(byref,AsnWriter)
         -78 (-25.91% of base) : System.Security.Cryptography.Cng.dasm - EccKeyFormatHelper:WriteCurve(byref,AsnWriter)
         -55 (-25.82% of base) : Microsoft.CodeAnalysis.CSharp.dasm - PEModuleSymbol:GetCustomAttributesFilterExtensions(EntityHandle,byref):ImmutableArray`1:this
         -54 (-23.28% of base) : System.Security.Cryptography.Algorithms.dasm - RSAKeyFormatHelper:WriteSubjectPublicKeyInfo(ReadOnlySpan`1):AsnWriter
         -32 (-22.38% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxFactory:ModifiedIdentifier(String):ModifiedIdentifierSyntax

332 total methods with Code Size differences (332 improved, 0 regressed), 192485 unchanged.

alt-linux-x64:

Total bytes of base: 44497309
Total bytes of diff: 44496311
Total bytes of delta: -998 (-0.00% of base)
    diff is an improvement.

Top file improvements (bytes):
        -708 : Microsoft.CodeAnalysis.CSharp.dasm (-0.01% of base)
        -160 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.00% of base)
         -72 : FSharp.Core.dasm (-0.01% of base)
         -32 : System.Reflection.MetadataLoadContext.dasm (-0.01% of base)
         -19 : System.Net.Http.dasm (-0.00% of base)
          -7 : System.Threading.Channels.dasm (-0.01% of base)

6 total files with Code Size differences (6 improved, 0 regressed), 264 unchanged.

Top method improvements (bytes):
        -224 (-19.05% of base) : Microsoft.CodeAnalysis.CSharp.dasm - BinaryOperatorOverloadResolutionResult:get_Best():BinaryOperatorAnalysisResult:this (2 methods)
        -168 (-17.11% of base) : Microsoft.CodeAnalysis.CSharp.dasm - UnaryOperatorOverloadResolutionResult:get_Best():UnaryOperatorAnalysisResult:this (2 methods)
        -160 (-7.82% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxTriviaListBuilder:ToList():SyntaxTriviaList:this (2 methods)
        -158 (-6.76% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SyntaxTriviaListBuilder:ToList():SyntaxTriviaList:this (2 methods)
         -70 (-2.65% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Conversion:.cctor() (2 methods)
         -52 (-1.87% of base) : Microsoft.CodeAnalysis.CSharp.dasm - DocumentationCommentCompiler:WriteDocumentationCommentXml(CSharpCompilation,String,Stream,DiagnosticBag,CancellationToken,SyntaxTree,Nullable`1) (2 methods)
         -36 (-7.79% of base) : FSharp.Core.dasm - NullableModule:ToDecimal(Nullable`1):Nullable`1 (2 methods)
         -36 (-8.22% of base) : FSharp.Core.dasm - NullableModule:ToDecimal$W(FSharpFunc`2,Nullable`1):Nullable`1 (2 methods)
         -36 (-6.62% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LambdaRewriter:GetTopLevelMethodId():DebugId:this (2 methods)
         -32 (-6.00% of base) : System.Reflection.MetadataLoadContext.dasm - RoDefinitionType:get_GUID():Guid:this
         -19 (-4.33% of base) : System.Net.Http.dasm - RawConnectionStream:WriteAsync(ReadOnlyMemory`1,CancellationToken):ValueTask:this
          -7 (-2.47% of base) : System.Threading.Channels.dasm - BoundedChannelReader:DequeueItemAndPostProcess():__Canon:this

Top method improvements (percentages):
        -224 (-19.05% of base) : Microsoft.CodeAnalysis.CSharp.dasm - BinaryOperatorOverloadResolutionResult:get_Best():BinaryOperatorAnalysisResult:this (2 methods)
        -168 (-17.11% of base) : Microsoft.CodeAnalysis.CSharp.dasm - UnaryOperatorOverloadResolutionResult:get_Best():UnaryOperatorAnalysisResult:this (2 methods)
         -36 (-8.22% of base) : FSharp.Core.dasm - NullableModule:ToDecimal$W(FSharpFunc`2,Nullable`1):Nullable`1 (2 methods)
        -160 (-7.82% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxTriviaListBuilder:ToList():SyntaxTriviaList:this (2 methods)
         -36 (-7.79% of base) : FSharp.Core.dasm - NullableModule:ToDecimal(Nullable`1):Nullable`1 (2 methods)
        -158 (-6.76% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SyntaxTriviaListBuilder:ToList():SyntaxTriviaList:this (2 methods)
         -36 (-6.62% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LambdaRewriter:GetTopLevelMethodId():DebugId:this (2 methods)
         -32 (-6.00% of base) : System.Reflection.MetadataLoadContext.dasm - RoDefinitionType:get_GUID():Guid:this
         -19 (-4.33% of base) : System.Net.Http.dasm - RawConnectionStream:WriteAsync(ReadOnlyMemory`1,CancellationToken):ValueTask:this
         -70 (-2.65% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Conversion:.cctor() (2 methods)
          -7 (-2.47% of base) : System.Threading.Channels.dasm - BoundedChannelReader:DequeueItemAndPostProcess():__Canon:this
         -52 (-1.87% of base) : Microsoft.CodeAnalysis.CSharp.dasm - DocumentationCommentCompiler:WriteDocumentationCommentXml(CSharpCompilation,String,Stream,DiagnosticBag,CancellationToken,SyntaxTree,Nullable`1) (2 methods)

12 total methods with Code Size differences (12 improved, 0 regressed), 192405 unchanged.

alt-arm64:

Total bytes of base: 51187768
Total bytes of diff: 51183656
Total bytes of delta: -4112 (-0.01% of base)
    diff is an improvement.

Top file improvements (bytes):
       -2048 : Microsoft.CodeAnalysis.CSharp.dasm (-0.04% of base)
       -1176 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.02% of base)
        -276 : System.Diagnostics.DiagnosticSource.dasm (-0.28% of base)
        -144 : System.Security.Cryptography.Cng.dasm (-0.07% of base)
         -80 : System.Threading.Tasks.Dataflow.dasm (-0.03% of base)
         -64 : System.Net.Http.dasm (-0.01% of base)
         -56 : System.Net.Sockets.dasm (-0.03% of base)
         -52 : Microsoft.Extensions.DependencyModel.dasm (-0.08% of base)
         -36 : Newtonsoft.Json.dasm (-0.00% of base)
         -32 : System.Net.HttpListener.dasm (-0.01% of base)
         -32 : System.Reflection.MetadataLoadContext.dasm (-0.01% of base)
         -32 : Microsoft.CodeAnalysis.dasm (-0.00% of base)
         -24 : System.Data.Common.dasm (-0.00% of base)
         -20 : System.Private.CoreLib.dasm (-0.00% of base)
         -16 : System.Security.Cryptography.Csp.dasm (-0.02% of base)
         -16 : OSExtensions.dasm (-0.21% of base)
          -8 : System.Threading.Channels.dasm (-0.01% of base)

17 total files with Code Size differences (17 improved, 0 regressed), 253 unchanged.

Top method improvements (bytes):
        -472 (-10.46% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxFactory:.cctor() (4 methods)
        -440 (-9.75% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SyntaxFactory:.cctor() (4 methods)
        -176 (-15.28% of base) : Microsoft.CodeAnalysis.CSharp.dasm - BinaryOperatorOverloadResolutionResult:get_Best():BinaryOperatorAnalysisResult:this (2 methods)
        -152 (-7.66% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxTriviaListBuilder:ToList():SyntaxTriviaList:this (2 methods)
        -136 (-13.60% of base) : Microsoft.CodeAnalysis.CSharp.dasm - UnaryOperatorOverloadResolutionResult:get_Best():UnaryOperatorAnalysisResult:this (2 methods)
        -128 (-5.65% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SyntaxTriviaListBuilder:ToList():SyntaxTriviaList:this (2 methods)
        -112 (-14.29% of base) : Microsoft.CodeAnalysis.CSharp.dasm - AliasSymbol:CreateGlobalNamespaceAlias(NamespaceSymbol,Binder):AliasSymbol (2 methods)
         -72 (-3.88% of base) : System.Diagnostics.DiagnosticSource.dasm - ActivitySource:CreateActivity(String,int,ActivityContext,String,IEnumerable`1,IEnumerable`1,DateTimeOffset,bool,int):Activity:this
         -72 (-0.88% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ForEachLoopBinder:BindForEachPartsWorker(DiagnosticBag,Binder):BoundForEachStatement:this (2 methods)
         -72 (-1.97% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:FinalTranslation(QueryTranslationState,DiagnosticBag):BoundExpression:this (2 methods)
         -72 (-14.88% of base) : System.Security.Cryptography.Cng.dasm - ECDiffieHellmanCng:GetKey():CngKey:this
         -72 (-14.88% of base) : System.Security.Cryptography.Cng.dasm - ECDsaCng:GetKey():CngKey:this
         -64 (-30.77% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - PEModuleSymbol:GetCustomAttributesForToken(EntityHandle):ImmutableArray`1:this (2 methods)
         -64 (-2.83% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Conversion:.cctor() (2 methods)
         -64 (-30.77% of base) : Microsoft.CodeAnalysis.CSharp.dasm - PEModuleSymbol:GetCustomAttributesForToken(EntityHandle):ImmutableArray`1:this (2 methods)
         -64 (-7.27% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:CreateSpan(SyntaxTokenList,SyntaxNodeOrToken,SyntaxNodeOrToken):TextSpan (2 methods)
         -60 (-7.11% of base) : System.Diagnostics.DiagnosticSource.dasm - ActivityCreationOptions`1:get_TraceId():ActivityTraceId:this (3 methods)
         -56 (-0.98% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - ConstraintsHelper:ReportIndirectConstraintConflicts(SourceTypeParameterSymbol,ArrayBuilder`1,byref) (2 methods)
         -52 (-6.81% of base) : Microsoft.Extensions.DependencyModel.dasm - DependencyContextJsonReader:Read(Stream):DependencyContext:this
         -48 (-6.98% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxFactory:WhitespaceTrivia(String):SyntaxTrivia (2 methods)

Top method improvements (percentages):
         -64 (-30.77% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - PEModuleSymbol:GetCustomAttributesForToken(EntityHandle):ImmutableArray`1:this (2 methods)
         -64 (-30.77% of base) : Microsoft.CodeAnalysis.CSharp.dasm - PEModuleSymbol:GetCustomAttributesForToken(EntityHandle):ImmutableArray`1:this (2 methods)
         -16 (-25.00% of base) : OSExtensions.dasm - ETWKernelControl:IsWin8orNewer():bool
         -32 (-21.05% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxFactory:Parameter(ModifiedIdentifierSyntax):ParameterSyntax (2 methods)
         -16 (-16.00% of base) : System.Diagnostics.DiagnosticSource.dasm - ActivitySource:CreateActivity(String,int):Activity:this
         -16 (-15.38% of base) : System.Diagnostics.DiagnosticSource.dasm - ActivitySource:StartActivity(String,int):Activity:this
        -176 (-15.28% of base) : Microsoft.CodeAnalysis.CSharp.dasm - BinaryOperatorOverloadResolutionResult:get_Best():BinaryOperatorAnalysisResult:this (2 methods)
         -72 (-14.88% of base) : System.Security.Cryptography.Cng.dasm - ECDiffieHellmanCng:GetKey():CngKey:this
         -72 (-14.88% of base) : System.Security.Cryptography.Cng.dasm - ECDsaCng:GetKey():CngKey:this
         -16 (-14.29% of base) : System.Diagnostics.DiagnosticSource.dasm - ActivitySource:CreateActivity(String,int,String,IEnumerable`1,IEnumerable`1,int):Activity:this
         -16 (-14.29% of base) : System.Diagnostics.DiagnosticSource.dasm - ActivitySource:StartActivity(String,int,String,IEnumerable`1,IEnumerable`1,DateTimeOffset):Activity:this
        -112 (-14.29% of base) : Microsoft.CodeAnalysis.CSharp.dasm - AliasSymbol:CreateGlobalNamespaceAlias(NamespaceSymbol,Binder):AliasSymbol (2 methods)
         -16 (-13.79% of base) : Newtonsoft.Json.dasm - JsonWriter:get_ContainerPath():String:this
        -136 (-13.60% of base) : Microsoft.CodeAnalysis.CSharp.dasm - UnaryOperatorOverloadResolutionResult:get_Best():UnaryOperatorAnalysisResult:this (2 methods)
         -32 (-12.50% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxFactory:ModifiedIdentifier(String):ModifiedIdentifierSyntax (2 methods)
         -24 (-12.50% of base) : System.Data.Common.dasm - SqlString:.cctor()
         -16 (-12.12% of base) : System.Net.Http.dasm - HttpContentHeaders:get_LastModified():Nullable`1:this
         -16 (-12.12% of base) : System.Net.Http.dasm - HttpGeneralHeaders:get_Date():Nullable`1:this
         -16 (-12.12% of base) : System.Net.Http.dasm - HttpRequestHeaders:get_IfModifiedSince():Nullable`1:this
         -16 (-12.12% of base) : System.Net.Http.dasm - HttpRequestHeaders:get_IfUnmodifiedSince():Nullable`1:this

76 total methods with Code Size differences (76 improved, 0 regressed), 196851 unchanged.
```
