### PR TITLE
Remove some useless null checks

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4944,16 +4944,6 @@ private:
         GenTree* thisArg = call->GetThisArg();
         noway_assert(thisArg != nullptr);
 
-        // TODO-MIKE-Review: This check is likely useless, if the VN is known to be non-null
-        // then it doesn't matter what kind of node the arg is. It's unlikely that VN will be
-        // able to prove that anything else other than a LCL_VAR is non-null conservatively,
-        // maybe a LCL_FLD?
-
-        if (!thisArg->OperIs(GT_LCL_VAR))
-        {
-            return;
-        }
-
         if (!m_vnStore->IsKnownNonNull(thisArg->gtVNPair.GetConservative()))
         {
             return;
@@ -4980,16 +4970,6 @@ private:
         if (addr->OperIs(GT_ADD) && addr->AsOp()->GetOp(1)->IsIntCon())
         {
             addr = addr->AsOp()->GetOp(0);
-        }
-
-        // TODO-MIKE-Review: This check is likely useless, if the VN is known to be non-null
-        // then it doesn't matter what kind of node the addr is. It's unlikely that VN will be
-        // able to prove that anything else other than a LCL_VAR is non-null conservatively,
-        // maybe a LCL_FLD?
-
-        if (!addr->OperIs(GT_LCL_VAR))
-        {
-            return;
         }
 
         if (!m_vnStore->IsKnownNonNull(addr->gtVNPair.GetConservative()))


### PR DESCRIPTION
win-x64 diff:
```
Total bytes of base: 31604735
Total bytes of diff: 31604009
Total bytes of delta: -726 (-0.00% of base)
    diff is an improvement.


Top file improvements (bytes):
        -132 : System.Private.Xml.dasm (-0.00% of base)
         -38 : Microsoft.Extensions.Primitives.dasm (-0.25% of base)
         -38 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
         -36 : ILCompiler.Reflection.ReadyToRun.dasm (-0.03% of base)
         -36 : System.Net.Security.dasm (-0.02% of base)
         -32 : System.Private.DataContractSerialization.dasm (-0.00% of base)
         -32 : System.Speech.dasm (-0.01% of base)
         -28 : System.Runtime.Serialization.Formatters.dasm (-0.03% of base)
         -28 : System.Security.Cryptography.Algorithms.dasm (-0.01% of base)
         -26 : System.Data.Common.dasm (-0.00% of base)
         -26 : CommandLine.dasm (-0.02% of base)
         -22 : System.Data.OleDb.dasm (-0.01% of base)
         -20 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.00% of base)
         -20 : System.Transactions.Local.dasm (-0.02% of base)
         -16 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00% of base)
         -16 : System.Security.Cryptography.Cng.dasm (-0.01% of base)
         -12 : Newtonsoft.Json.dasm (-0.00% of base)
         -12 : System.Net.HttpListener.dasm (-0.01% of base)
         -12 : System.Data.Odbc.dasm (-0.01% of base)
         -12 : System.Drawing.Common.dasm (-0.00% of base)

52 total files with Code Size differences (52 improved, 0 regressed), 218 unchanged.

Top method improvements (bytes):
         -24 (-0.36% of base) : System.Net.Security.dasm - <SendBlobAsync>d__122`1:MoveNext():this (3 methods)
         -10 (-3.80% of base) : ILCompiler.Reflection.ReadyToRun.dasm - GcSlot:GetRegisterName(int,ushort):String
         -10 (-1.02% of base) : System.Private.Xml.dasm - XmlQueryOutput:ThrowInvalidStateError(int):this
         -10 (-2.04% of base) : System.Private.Xml.dasm - XmlILConstructInfo:ToString():String:this
         -10 (-0.50% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VisualBasicCompilationOptions:ValidateOptions(ArrayBuilder`1):this
          -8 (-2.77% of base) : Microsoft.Extensions.Primitives.dasm - StringSegment:<ThrowInvalidArguments>g__GetInvalidArgumentsException|53_0(byref):Exception
          -8 (-2.76% of base) : Microsoft.Extensions.Primitives.dasm - StringSegment:<ThrowInvalidArguments>g__GetInvalidArgumentsException|54_0(bool,byref):Exception
          -8 (-2.91% of base) : ILCompiler.Reflection.ReadyToRun.dasm - DebugInfo:GetPlatformSpecificRegister(ushort,int):String
          -8 (-0.51% of base) : System.Private.Xml.dasm - ValidateNames:ValidateNameInternal(String,String,String,int,int,bool):bool
          -8 (-0.44% of base) : System.Security.Principal.Windows.dasm - WindowsIdentity:AddGroupSidClaims(List`1):this
          -8 (-2.38% of base) : System.Transactions.Local.dasm - TransactionsEtwProvider:TransactionstateEnlist(EnlistmentTraceIdentifier,int,int):this
          -6 (-1.08% of base) : System.Data.Common.dasm - ExceptionBuilder:_InvalidEnumArgumentException(int):Exception (3 methods)
          -6 (-0.28% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CSharpCompilationOptions:ValidateOptions(ArrayBuilder`1):this
          -6 (-0.08% of base) : System.Net.HttpListener.dasm - HttpListener:HandleAuthentication(HttpListenerSession,RequestContextBase,byref):HttpListenerContext:this
          -6 (-0.05% of base) : System.Net.Security.dasm - <ForceAuthenticationAsync>d__171`1:MoveNext():this (3 methods)
          -6 (-1.87% of base) : System.Reflection.Metadata.dasm - SignatureHeader:ToString():String:this
          -6 (-0.47% of base) : System.Speech.dasm - PromptBuilder:AppendText(String,int):this (3 methods)
          -6 (-0.67% of base) : System.Speech.dasm - PromptBuilder:StartStyle(PromptStyle):this
          -4 (-2.15% of base) : System.Data.Common.dasm - ExceptionBuilder:CantChangeDateTimeMode(int,int):Exception
          -4 (-1.73% of base) : System.Data.Common.dasm - ExprException:UnknownToken(int,int,int):Exception

Top method improvements (percentages):
          -2 (-4.88% of base) : Microsoft.Extensions.Primitives.dasm - ThrowHelper:GetArgumentName(int):String
          -2 (-4.88% of base) : Microsoft.Extensions.Primitives.dasm - ThrowHelper:GetResourceName(int):String
          -2 (-4.88% of base) : System.Text.Encodings.Web.dasm - ThrowHelper:GetArgumentName(int):String
          -2 (-4.88% of base) : ILCompiler.Reflection.ReadyToRun.dasm - GcInfo:GetRegisterName(int):String:this
          -2 (-4.88% of base) : System.Private.Xml.dasm - SchemaObjectWriter:Write11_XmlSchemaDerivationMethod(int):String:this
          -2 (-4.44% of base) : System.Security.Cryptography.Algorithms.dasm - RSASignaturePadding:ToString():String:this
          -2 (-4.00% of base) : Microsoft.Extensions.Primitives.dasm - ThrowHelper:GetResourceText(int):String
         -10 (-3.80% of base) : ILCompiler.Reflection.ReadyToRun.dasm - GcSlot:GetRegisterName(int,ushort):String
          -2 (-3.12% of base) : System.Net.Primitives.dasm - RequestCachePolicy:ToString():String:this
          -2 (-2.94% of base) : Microsoft.Extensions.Primitives.dasm - ThrowHelper:ThrowArgumentNullException(int)
          -2 (-2.94% of base) : Microsoft.Extensions.Primitives.dasm - ThrowHelper:ThrowArgumentOutOfRangeException(int)
          -2 (-2.94% of base) : System.Text.Encodings.Web.dasm - ThrowHelper:ThrowArgumentNullException(int)
          -2 (-2.94% of base) : System.Security.Cryptography.Encoding.dasm - ThrowHelper:ThrowArgumentNull(int)
          -8 (-2.91% of base) : ILCompiler.Reflection.ReadyToRun.dasm - DebugInfo:GetPlatformSpecificRegister(ushort,int):String
          -2 (-2.90% of base) : Microsoft.Extensions.Primitives.dasm - ThrowHelper:GetArgumentNullException(int):ArgumentNullException
          -2 (-2.90% of base) : Microsoft.Extensions.Primitives.dasm - ThrowHelper:GetArgumentOutOfRangeException(int):ArgumentOutOfRangeException
          -2 (-2.90% of base) : System.Memory.dasm - ThrowHelper:CreateArgumentNullException(int):Exception
          -2 (-2.90% of base) : System.Memory.dasm - ThrowHelper:CreateArgumentOutOfRangeException(int):Exception
          -2 (-2.90% of base) : System.IO.Pipelines.dasm - ThrowHelper:CreateArgumentOutOfRangeException(int):Exception
          -2 (-2.90% of base) : System.IO.Pipelines.dasm - ThrowHelper:CreateArgumentNullException(int):Exception

275 total methods with Code Size differences (275 improved, 0 regressed), 192542 unchanged.
```