### PR TITLE
VN const prop small int

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5189,6 +5189,16 @@ private:
             case GT_CAST:
             case GT_BITCAST:
             case GT_INTRINSIC:
+                // Normally these nodes should not have small int type. If they do, it's either due
+                // to bogus JIT code or due to BOOL optimizations that "infect" AND/OR (though that
+                // is still more or less due to bogus desig/code). The former case is best ignored,
+                // in order to avoid surprises due to bad VN, the later case is unlikely to involve
+                // constants, as BOOL expressions tend to use BOOL indirs or BOOL HWINTRINSIC nodes
+                // that aren't currently constant evaluated.
+                if (varTypeIsSmall(tree->GetType()))
+                {
+                    return Compiler::WALK_CONTINUE;
+                }
                 break;
 
             default:
@@ -5249,9 +5259,8 @@ private:
         }
         // The tree type and the VN type should match but VN can't be trusted. At least for SIMD
         // locals, VN manages to pull out a TYP_LONG 0 constant out of the hat, if the local is
-        // not explictily initialized and .localsinit is used.
-        // TODO-MIKE-Review: Shouldn't this check the actual type of the tree?
-        else if (tree->GetType() == vnType)
+        // not explictily initialized and .locals init is used.
+        else if (varActualType(tree->GetType()) == vnType)
         {
             switch (vnType)
             {
@@ -5260,6 +5269,19 @@ private:
                     break;
                 case TYP_DOUBLE:
                     newTree = m_compiler->gtNewDconNode(m_vnStore->ConstantValue<double>(vn), TYP_DOUBLE);
+                    break;
+                case TYP_UBYTE:
+                case TYP_BOOL:
+                    newTree = m_compiler->gtNewIconNode(m_vnStore->CoercedConstantValue<uint8_t>(vn));
+                    break;
+                case TYP_BYTE:
+                    newTree = m_compiler->gtNewIconNode(m_vnStore->CoercedConstantValue<int8_t>(vn));
+                    break;
+                case TYP_USHORT:
+                    newTree = m_compiler->gtNewIconNode(m_vnStore->CoercedConstantValue<uint16_t>(vn));
+                    break;
+                case TYP_SHORT:
+                    newTree = m_compiler->gtNewIconNode(m_vnStore->CoercedConstantValue<int16_t>(vn));
                     break;
                 case TYP_INT:
                     newTree = m_compiler->gtNewIconNode(m_vnStore->ConstantValue<int32_t>(vn));


### PR DESCRIPTION
win-x64 diff:
```
Total bytes of base: 31603667
Total bytes of diff: 31596382
Total bytes of delta: -7285 (-0.02% of base)
    diff is an improvement.


Top file regressions (bytes):
          10 : xunit.performance.execution.dasm (0.07% of base)
           4 : System.Net.Security.dasm (0.00% of base)

Top file improvements (bytes):
       -1624 : System.Drawing.Primitives.dasm (-4.59% of base)
        -745 : System.Data.Common.dasm (-0.07% of base)
        -579 : FSharp.Core.dasm (-0.07% of base)
        -538 : System.Net.Http.dasm (-0.10% of base)
        -432 : System.Text.RegularExpressions.dasm (-0.24% of base)
        -373 : Microsoft.CodeAnalysis.CSharp.dasm (-0.02% of base)
        -358 : System.Private.CoreLib.dasm (-0.03% of base)
        -336 : Newtonsoft.Json.dasm (-0.06% of base)
        -207 : System.Linq.Parallel.dasm (-0.04% of base)
        -191 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.01% of base)
        -169 : System.Text.Json.dasm (-0.03% of base)
        -137 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.01% of base)
        -113 : Microsoft.CodeAnalysis.dasm (-0.02% of base)
        -100 : System.Private.Xml.dasm (-0.00% of base)
        -100 : xunit.console.dasm (-0.15% of base)
         -84 : xunit.runner.utility.netcoreapp10.dasm (-0.06% of base)
         -82 : System.Linq.dasm (-0.06% of base)
         -77 : System.Security.Cryptography.Cng.dasm (-0.05% of base)
         -70 : System.Formats.Asn1.dasm (-0.11% of base)
         -62 : xunit.runner.reporters.netcoreapp10.dasm (-0.15% of base)

74 total files with Code Size differences (72 improved, 2 regressed), 196 unchanged.

Top method regressions (bytes):
          56 ( 1.23% of base) : Newtonsoft.Json.dasm - JsonWriter:WriteValueAsync(JsonWriter,int,Object,CancellationToken):Task
          56 ( 1.27% of base) : Newtonsoft.Json.dasm - JsonWriter:WriteValue(JsonWriter,int,Object)
           6 ( 1.34% of base) : xunit.performance.execution.dasm - BenchmarkEventSource:BenchmarkIterationStart(String,String,int):this
           6 ( 1.17% of base) : xunit.performance.execution.dasm - BenchmarkEventSource:BenchmarkIterationStop(String,String,int,long):this
           6 ( 0.47% of base) : System.Private.Xml.dasm - XmlILVisitor:CreateSetIterator(QilBinary,String,Type,MethodInfo,MethodInfo,MethodInfo):QilNode:this
           2 ( 0.10% of base) : System.Net.Security.dasm - <WriteMessageAsync>d__10`1:MoveNext():this (3 methods)
           2 ( 0.02% of base) : System.Net.Security.dasm - <ForceAuthenticationAsync>d__171`1:MoveNext():this (3 methods)
           2 ( 0.07% of base) : xunit.console.dasm - ConsoleRunner:ExecuteAssembly(Object,XunitProjectAssembly,bool,bool,Nullable`1,Nullable`1,bool,bool,Nullable`1,bool,bool,XunitFilters,bool):XElement:this
           1 ( 0.20% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - CallerCalleeNode:.ctor(String,CallTree):this
           1 ( 0.03% of base) : System.Net.Security.dasm - <<WriteSingleChunk>g__WaitAndWriteAsync|177_0>d`1:MoveNext():this (3 methods)
           1 ( 0.02% of base) : System.Net.Security.dasm - <WriteAsync>d__110`1:MoveNext():this (3 methods)

Top method improvements (bytes):
        -432 (-3.20% of base) : System.Text.RegularExpressions.dasm - RegexCharClass:.cctor()
        -365 (-3.05% of base) : System.Net.Http.dasm - KnownHeaders:.cctor()
        -210 (-5.66% of base) : System.Drawing.Primitives.dasm - ColorTranslator:InitializeHtmlSysColorTable()
        -175 (-8.08% of base) : System.Drawing.Primitives.dasm - ColorTranslator:FromOle(int):Color
        -129 (-19.28% of base) : System.Private.CoreLib.dasm - HebrewNumber:.cctor()
         -70 (-4.35% of base) : xunit.runner.utility.netcoreapp10.dasm - ConfigReader_Json:Load(Stream):TestAssemblyConfiguration
         -62 (-1.30% of base) : xunit.console.dasm - CommandLine:Parse(Predicate`1):XunitProject:this
         -54 (-6.80% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - DynamicManifestTraceEventData:.ctor(Action`1,ProviderManifest):this
         -48 (-1.76% of base) : Newtonsoft.Json.dasm - JsonSchemaBuilder:ProcessSchemaProperties(JObject):this
         -48 (-2.51% of base) : Newtonsoft.Json.dasm - JsonSchemaGenerator:GenerateInternal(Type,int,bool):JsonSchema:this
         -42 (-1.49% of base) : System.Data.Common.dasm - SqlInt16Storage:Aggregate(ref,int):Object:this
         -42 (-1.49% of base) : System.Data.Common.dasm - SqlInt32Storage:Aggregate(ref,int):Object:this
         -42 (-1.49% of base) : System.Data.Common.dasm - SqlByteStorage:Aggregate(ref,int):Object:this
         -40 (-1.30% of base) : System.Data.Common.dasm - SqlDoubleStorage:Aggregate(ref,int):Object:this
         -38 (-2.12% of base) : System.Data.Odbc.dasm - OdbcMetaDataFactory:.ctor(Stream,String,String,OdbcConnection):this
         -37 (-5.17% of base) : Microsoft.CodeAnalysis.CSharp.dasm - BinderFactoryVisitor:VisitDelegateDeclaration(DelegateDeclarationSyntax):Binder:this
         -36 (-1.11% of base) : System.Data.Common.dasm - SqlInt64Storage:Aggregate(ref,int):Object:this
         -36 (-1.19% of base) : System.Data.Common.dasm - SqlSingleStorage:Aggregate(ref,int):Object:this
         -36 (-6.10% of base) : System.Net.Http.dasm - HttpMethod:.cctor()
         -35 (-2.05% of base) : Newtonsoft.Json.dasm - DefaultContractResolver:SetPropertySettingsFromAttributes(JsonProperty,Object,String,Type,int,byref):this

Top method regressions (percentages):
           6 ( 1.34% of base) : xunit.performance.execution.dasm - BenchmarkEventSource:BenchmarkIterationStart(String,String,int):this
          56 ( 1.27% of base) : Newtonsoft.Json.dasm - JsonWriter:WriteValue(JsonWriter,int,Object)
          56 ( 1.23% of base) : Newtonsoft.Json.dasm - JsonWriter:WriteValueAsync(JsonWriter,int,Object,CancellationToken):Task
           6 ( 1.17% of base) : xunit.performance.execution.dasm - BenchmarkEventSource:BenchmarkIterationStop(String,String,int,long):this
           6 ( 0.47% of base) : System.Private.Xml.dasm - XmlILVisitor:CreateSetIterator(QilBinary,String,Type,MethodInfo,MethodInfo,MethodInfo):QilNode:this
           1 ( 0.20% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - CallerCalleeNode:.ctor(String,CallTree):this
           2 ( 0.10% of base) : System.Net.Security.dasm - <WriteMessageAsync>d__10`1:MoveNext():this (3 methods)
           2 ( 0.07% of base) : xunit.console.dasm - ConsoleRunner:ExecuteAssembly(Object,XunitProjectAssembly,bool,bool,Nullable`1,Nullable`1,bool,bool,Nullable`1,bool,bool,XunitFilters,bool):XElement:this
           1 ( 0.03% of base) : System.Net.Security.dasm - <<WriteSingleChunk>g__WaitAndWriteAsync|177_0>d`1:MoveNext():this (3 methods)
           1 ( 0.02% of base) : System.Net.Security.dasm - <WriteAsync>d__110`1:MoveNext():this (3 methods)
           2 ( 0.02% of base) : System.Net.Security.dasm - <ForceAuthenticationAsync>d__171`1:MoveNext():this (3 methods)

Top method improvements (percentages):
          -4 (-26.67% of base) : System.Data.Common.dasm - SqlInt64:op_Implicit(long):SqlInt64
          -6 (-26.09% of base) : System.Composition.Convention.dasm - ImportConventionBuilder:AsMany(bool):ImportConventionBuilder:this
         -30 (-25.64% of base) : System.Data.Common.dasm - SqlByte:.cctor()
          -6 (-25.00% of base) : System.Net.Http.dasm - QPackDecoder:OnIndexedHeaderName(int):this
          -7 (-24.14% of base) : Microsoft.Extensions.FileSystemGlobbing.dasm - PatternTestResult:Success(String):PatternTestResult
          -6 (-24.00% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ArgumentAnalysisResult:RequiredParameterMissing(int):ArgumentAnalysisResult
         -28 (-22.76% of base) : System.Data.Common.dasm - SqlInt16:.cctor()
          -4 (-22.22% of base) : Newtonsoft.Json.dasm - JsonSerializer:set_Formatting(int):this
          -4 (-22.22% of base) : Newtonsoft.Json.dasm - JsonSerializer:set_DateFormatHandling(int):this
          -4 (-22.22% of base) : Newtonsoft.Json.dasm - JsonSerializer:set_DateTimeZoneHandling(int):this
          -4 (-22.22% of base) : Newtonsoft.Json.dasm - JsonSerializer:set_DateParseHandling(int):this
          -4 (-22.22% of base) : Newtonsoft.Json.dasm - JsonSerializer:set_FloatParseHandling(int):this
          -4 (-22.22% of base) : Newtonsoft.Json.dasm - JsonSerializer:set_FloatFormatHandling(int):this
          -4 (-22.22% of base) : Newtonsoft.Json.dasm - JsonSerializer:set_StringEscapeHandling(int):this
          -4 (-22.22% of base) : Newtonsoft.Json.dasm - JsonSerializerSettings:set_ReferenceLoopHandling(int):this
          -4 (-22.22% of base) : Newtonsoft.Json.dasm - JsonSerializerSettings:set_MissingMemberHandling(int):this
          -4 (-22.22% of base) : Newtonsoft.Json.dasm - JsonSerializerSettings:set_ObjectCreationHandling(int):this
          -4 (-22.22% of base) : Newtonsoft.Json.dasm - JsonSerializerSettings:set_NullValueHandling(int):this
          -4 (-22.22% of base) : Newtonsoft.Json.dasm - JsonSerializerSettings:set_DefaultValueHandling(int):this
          -4 (-22.22% of base) : Newtonsoft.Json.dasm - JsonSerializerSettings:set_PreserveReferencesHandling(int):this

885 total methods with Code Size differences (874 improved, 11 regressed), 191932 unchanged.
```
alt-arm64 diff:
```
Total bytes of base: 51181656
Total bytes of diff: 51178980
Total bytes of delta: -2676 (-0.01% of base)
    diff is an improvement.


Top file regressions (bytes):
          12 : Microsoft.Extensions.Logging.Console.dasm (0.05% of base)
           4 : System.Text.RegularExpressions.dasm (0.00% of base)

Top file improvements (bytes):
        -776 : System.Private.CoreLib.dasm (-0.02% of base)
        -296 : Microsoft.CodeAnalysis.CSharp.dasm (-0.01% of base)
        -220 : System.Net.Http.dasm (-0.03% of base)
        -212 : System.Data.Common.dasm (-0.01% of base)
        -208 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.00% of base)
        -208 : System.Private.Xml.dasm (-0.00% of base)
         -76 : System.Formats.Asn1.dasm (-0.09% of base)
         -68 : xunit.console.dasm (-0.07% of base)
         -64 : System.Security.Cryptography.Cng.dasm (-0.03% of base)
         -60 : System.Linq.Parallel.dasm (-0.01% of base)
         -48 : System.Text.Json.dasm (-0.01% of base)
         -48 : xunit.runner.reporters.netcoreapp10.dasm (-0.08% of base)
         -40 : System.Net.Security.dasm (-0.01% of base)
         -32 : Microsoft.CodeAnalysis.dasm (-0.00% of base)
         -32 : Microsoft.Extensions.DependencyModel.dasm (-0.05% of base)
         -32 : System.Drawing.Primitives.dasm (-0.08% of base)
         -20 : ILCompiler.Reflection.ReadyToRun.dasm (-0.01% of base)
         -20 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
         -16 : Microsoft.Extensions.Configuration.Xml.dasm (-0.12% of base)
         -16 : System.Drawing.Common.dasm (-0.00% of base)

45 total files with Code Size differences (43 improved, 2 regressed), 225 unchanged.

Top method regressions (bytes):
          32 ( 0.68% of base) : Newtonsoft.Json.dasm - JsonWriter:WriteValueAsync(JsonWriter,int,Object,CancellationToken):Task
          32 ( 0.70% of base) : Newtonsoft.Json.dasm - JsonWriter:WriteValue(JsonWriter,int,Object)
          16 ( 4.17% of base) : Microsoft.CodeAnalysis.dasm - GreenNode:GetFirstTerminal():GreenNode:this (2 methods)
          12 ( 2.65% of base) : Microsoft.Extensions.Logging.Console.dasm - SimpleConsoleFormatter:GetLogLevelConsoleColors(int):ConsoleColors:this
           8 ( 0.84% of base) : Microsoft.CodeAnalysis.dasm - SimpleDiagnostic:.ctor(DiagnosticDescriptor,int,int,Location,IEnumerable`1,ref,ImmutableDictionary`2,bool):this (2 methods)
           4 ( 0.03% of base) : System.Text.RegularExpressions.dasm - RegexCharClass:.cctor()

Top method improvements (bytes):
        -200 (-1.80% of base) : System.Net.Http.dasm - KnownHeaders:.cctor()
         -48 (-12.90% of base) : System.Formats.Asn1.dasm - Asn1Tag:.cctor()
         -48 (-7.23% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ConversionsBase:HasImplicitConversionFromDelegate(TypeSymbol,TypeSymbol,byref):bool:this (2 methods)
         -36 (-0.53% of base) : xunit.console.dasm - CommandLine:Parse(Predicate`1):XunitProject:this
         -32 (-1.59% of base) : Microsoft.CodeAnalysis.dasm - DesktopAssemblyIdentityComparer:Port(AssemblyIdentity):AssemblyIdentity:this (2 methods)
         -32 (-14.04% of base) : Microsoft.Extensions.DependencyModel.dasm - CompilationOptions:.cctor()
         -32 (-1.56% of base) : Newtonsoft.Json.dasm - DefaultContractResolver:SetPropertySettingsFromAttributes(JsonProperty,Object,String,Type,int,byref):this
         -32 (-14.04% of base) : xunit.console.dasm - CompilationOptions:.cctor()
         -32 (-17.39% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - LexicalSortKey:.cctor() (2 methods)
         -32 (-23.53% of base) : System.Data.Common.dasm - SqlByte:.cctor()
         -28 (-2.97% of base) : System.Formats.Asn1.dasm - AsnWriter:SortContents(ref,int,int)
         -24 (-3.41% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Symbol:MatchAttributeTarget(IAttributeTargetSymbol,int,AttributeTargetSyntax):bool (2 methods)
         -24 (-1.95% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - MemberLookup:AddInterfaceConstraints(TypeParameterSymbol,byref,byref,byref) (2 methods)
         -24 (-5.17% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:GetXmlString(SyntaxToken):String (2 methods)
         -24 (-0.60% of base) : Microsoft.CodeAnalysis.CSharp.dasm - AbstractFlowPass`1:VisitTryStatement(BoundTryStatement):BoundNode:this (3 methods)
         -24 (-17.65% of base) : System.Data.Common.dasm - SqlInt16:.cctor()
         -24 (-6.59% of base) : System.Data.Common.dasm - SqlInt16Storage:ConvertXmlToObject(String):Object:this
         -24 (-6.59% of base) : System.Data.Common.dasm - SqlByteStorage:ConvertXmlToObject(String):Object:this
         -24 (-2.82% of base) : System.Private.CoreLib.dasm - List`1:System.Collections.Generic.IEnumerable<T>.GetEnumerator():IEnumerator`1:this (9 methods)
         -24 (-2.82% of base) : System.Private.CoreLib.dasm - List`1:System.Collections.IEnumerable.GetEnumerator():IEnumerator:this (9 methods)

Top method regressions (percentages):
          16 ( 4.17% of base) : Microsoft.CodeAnalysis.dasm - GreenNode:GetFirstTerminal():GreenNode:this (2 methods)
          12 ( 2.65% of base) : Microsoft.Extensions.Logging.Console.dasm - SimpleConsoleFormatter:GetLogLevelConsoleColors(int):ConsoleColors:this
           8 ( 0.84% of base) : Microsoft.CodeAnalysis.dasm - SimpleDiagnostic:.ctor(DiagnosticDescriptor,int,int,Location,IEnumerable`1,ref,ImmutableDictionary`2,bool):this (2 methods)
          32 ( 0.70% of base) : Newtonsoft.Json.dasm - JsonWriter:WriteValue(JsonWriter,int,Object)
          32 ( 0.68% of base) : Newtonsoft.Json.dasm - JsonWriter:WriteValueAsync(JsonWriter,int,Object,CancellationToken):Task
           4 ( 0.03% of base) : System.Text.RegularExpressions.dasm - RegexCharClass:.cctor()

Top method improvements (percentages):
         -32 (-23.53% of base) : System.Data.Common.dasm - SqlByte:.cctor()
         -12 (-20.00% of base) : Microsoft.Extensions.FileSystemGlobbing.dasm - PatternTestResult:.cctor()
         -12 (-18.75% of base) : System.Configuration.ConfigurationManager.dasm - OverrideModeSetting:.cctor()
         -12 (-18.75% of base) : System.Private.CoreLib.dasm - Half:.cctor()
         -24 (-17.65% of base) : System.Data.Common.dasm - SqlInt16:.cctor()
         -32 (-17.39% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - LexicalSortKey:.cctor() (2 methods)
         -12 (-15.79% of base) : System.Drawing.Common.dasm - TriState:.cctor()
         -32 (-14.04% of base) : Microsoft.Extensions.DependencyModel.dasm - CompilationOptions:.cctor()
         -32 (-14.04% of base) : xunit.console.dasm - CompilationOptions:.cctor()
         -48 (-12.90% of base) : System.Formats.Asn1.dasm - Asn1Tag:.cctor()
         -16 (-12.50% of base) : System.Data.Common.dasm - SqlInt32:.cctor()
         -16 (-12.50% of base) : System.Data.Common.dasm - SqlInt64:.cctor()
         -16 (-12.50% of base) : System.Data.Common.dasm - SqlMoney:.cctor()
         -12 (-12.00% of base) : System.Runtime.Numerics.dasm - BigNumberBuffer:Create():BigNumberBuffer
          -8 (-11.76% of base) : System.IO.FileSystem.Watcher.dasm - WaitForChangedResult:.cctor()
          -4 (-10.00% of base) : System.Linq.Parallel.dasm - ConcatKey`2:MakeRight(__Canon):ConcatKey`2
          -8 (-9.09% of base) : System.Drawing.Primitives.dasm - Color:FromArgb(int):Color (2 methods)
         -12 (-8.82% of base) : System.Private.Xml.dasm - StorageDescriptor:Current(LocalBuilder,MethodInfo,Type):StorageDescriptor
          -4 (-8.33% of base) : System.Text.Json.dasm - JsonArray:.ctor(ref):this
          -8 (-8.33% of base) : System.Private.CoreLib.dasm - ValueTask:FromResult(__Canon):ValueTask`1 (2 methods)
```
Regressions due to changes in register allocation. On XARCH, 0 containment on small int stores can also lead to small size increases.