### PR TITLE
Remove useless OBJs

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -6620,8 +6620,8 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk)
     GenTreeFieldList* const fieldList = putArgStk->gtOp1->AsFieldList();
     assert(fieldList != nullptr);
 
-    assert((putArgStk->gtPutArgStkKind == GenTreePutArgStk::Kind::Push) ||
-           (putArgStk->gtPutArgStkKind == GenTreePutArgStk::Kind::PushAllSlots));
+    assert((putArgStk->GetKind() == GenTreePutArgStk::Kind::Push) ||
+           (putArgStk->GetKind() == GenTreePutArgStk::Kind::PushAllSlots));
 
     bool pushStkArg = true;
 
@@ -6878,6 +6878,96 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* putArgStk)
         return;
     }
 
+#ifdef WINDOWS_AMD64_ABI
+    assert(putArgStk->GetSlotCount() == 1);
+#else
+    if (src->IsIntegralConst(0) && (putArgStk->GetSlotCount() > 1))
+    {
+        if (putArgStk->GetKind() == GenTreePutArgStk::Kind::RepInstrZero)
+        {
+            regNumber srcReg = genConsumeReg(src);
+            genCopyRegIfNeeded(src, REG_RAX);
+
+            assert((putArgStk->gtRsvdRegs & (RBM_RCX | RBM_RDI)) == (RBM_RCX | RBM_RDI));
+
+#ifdef TARGET_X86
+            genPreAdjustStackForPutArgStk(putArgStk->GetArgSize());
+            GetEmitter()->emitIns_Mov(INS_mov, EA_4BYTE, REG_RDI, REG_SPBASE, /* canSkip */ false);
+#else
+            GetEmitter()->emitIns_R_S(INS_lea, EA_PTRSIZE, REG_RDI, outArgLclNum, static_cast<int>(outArgLclOffs));
+#endif
+            GetEmitter()->emitIns_R_I(INS_mov, EA_4BYTE, REG_RCX, putArgStk->GetSlotCount());
+            GetEmitter()->emitIns(INS_r_stosp);
+        }
+#ifdef TARGET_X86
+        else if (putArgStk->GetArgSize() < XMM_REGSIZE_BYTES)
+        {
+            assert(src->isContained());
+            assert(putArgStk->gtRsvdRegs == 0);
+
+            for (unsigned i = 0; i < putArgStk->GetSlotCount(); i++)
+            {
+                GetEmitter()->emitIns_I(INS_push, EA_4BYTE, 0);
+                AddStackLevel(4);
+            }
+        }
+#endif // TARGET_X86
+        else
+        {
+            assert(putArgStk->GetKind() == GenTreePutArgStk::Kind::UnrollZero);
+            assert(src->isContained());
+
+            unsigned size = putArgStk->GetSlotCount() * REGSIZE_BYTES;
+
+#ifdef TARGET_X86
+            genPreAdjustStackForPutArgStk(size);
+#endif
+            regNumber zeroXmmReg = putArgStk->GetSingleTempReg(RBM_ALLFLOAT);
+            GetEmitter()->emitIns_R_R(INS_xorps, EA_16BYTE, zeroXmmReg, zeroXmmReg);
+
+            unsigned offset = 0;
+
+            while (offset + XMM_REGSIZE_BYTES <= size)
+            {
+#ifdef TARGET_X86
+                GetEmitter()->emitIns_AR_R(INS_movups, EA_16BYTE, zeroXmmReg, REG_SPBASE, offset);
+#else
+                GetEmitter()->emitIns_S_R(INS_movups, EA_16BYTE, zeroXmmReg, outArgLclNum,
+                                          static_cast<int>(outArgLclOffs + offset));
+#endif
+                offset += XMM_REGSIZE_BYTES;
+            }
+
+#ifdef TARGET_X86
+            assert(((size - offset) & ~12) == 0);
+#else
+            assert(((size - offset) & ~8) == 0);
+#endif
+
+            if (size - offset >= 8)
+            {
+#ifdef TARGET_X86
+                GetEmitter()->emitIns_AR_R(INS_movq, EA_8BYTE, zeroXmmReg, REG_SPBASE, offset);
+#else
+                GetEmitter()->emitIns_S_R(INS_movq, EA_8BYTE, zeroXmmReg, outArgLclNum,
+                                          static_cast<int>(outArgLclOffs + offset));
+#endif
+                offset += 8;
+            }
+
+#ifdef TARGET_X86
+            if (size - offset != 0)
+            {
+                assert(size - offset == 4);
+                GetEmitter()->emitIns_AR_R(INS_movd, EA_4BYTE, zeroXmmReg, REG_SPBASE, offset);
+            }
+#endif
+        }
+
+        return;
+    }
+#endif // !WINDOWS_AMD64_ABI
+
 #if defined(TARGET_AMD64) || !defined(FEATURE_SIMD)
     assert(roundUp(varTypeSize(srcType), REGSIZE_BYTES) <= putArgStk->GetSlotCount() * REGSIZE_BYTES);
 #else
@@ -7071,7 +7161,7 @@ void CodeGen::genPutStructArgStk(GenTreePutArgStk* putArgStk NOT_X86_ARG(unsigne
         srcAddrAttr = emitTypeSize(srcAddr->GetType());
     }
 
-    if (putArgStk->gtPutArgStkKind == GenTreePutArgStk::Kind::Unroll)
+    if (putArgStk->GetKind() == GenTreePutArgStk::Kind::Unroll)
     {
         assert(!srcLayout->HasGCPtr());
 
@@ -7208,7 +7298,7 @@ void CodeGen::genPutStructArgStk(GenTreePutArgStk* putArgStk NOT_X86_ARG(unsigne
     }
 
 #ifdef TARGET_X86
-    if (putArgStk->gtPutArgStkKind == GenTreePutArgStk::Kind::Push)
+    if (putArgStk->GetKind() == GenTreePutArgStk::Kind::Push)
     {
         // On x86, any struct that has contains GC references must be stored to the stack using `push` instructions so
         // that the emitter properly detects the need to update the method's GC information.
@@ -7241,7 +7331,7 @@ void CodeGen::genPutStructArgStk(GenTreePutArgStk* putArgStk NOT_X86_ARG(unsigne
         return;
     }
 
-    assert(putArgStk->gtPutArgStkKind == GenTreePutArgStk::Kind::RepInstr);
+    assert(putArgStk->GetKind() == GenTreePutArgStk::Kind::RepInstr);
     assert((putArgStk->gtRsvdRegs & (RBM_RSI | RBM_RDI | RBM_RCX)) == (RBM_RSI | RBM_RDI | RBM_RCX));
 
     genPreAdjustStackForPutArgStk(putArgStk->GetArgSize());
@@ -7269,8 +7359,8 @@ void CodeGen::genPutStructArgStk(GenTreePutArgStk* putArgStk NOT_X86_ARG(unsigne
     regNumber intTmpReg = REG_NA;
     regNumber xmmTmpReg = REG_NA;
 
-    if ((putArgStk->gtPutArgStkKind == GenTreePutArgStk::Kind::RepInstr) ||
-        (putArgStk->gtPutArgStkKind == GenTreePutArgStk::Kind::RepInstrXMM))
+    if ((putArgStk->GetKind() == GenTreePutArgStk::Kind::RepInstr) ||
+        (putArgStk->GetKind() == GenTreePutArgStk::Kind::RepInstrXMM))
     {
         assert((putArgStk->gtRsvdRegs & (RBM_RSI | RBM_RDI | RBM_RCX)) == (RBM_RSI | RBM_RDI | RBM_RCX));
 
@@ -7292,7 +7382,7 @@ void CodeGen::genPutStructArgStk(GenTreePutArgStk* putArgStk NOT_X86_ARG(unsigne
 
         if (!srcLayout->HasGCPtr())
         {
-            assert(putArgStk->gtPutArgStkKind == GenTreePutArgStk::Kind::RepInstr);
+            assert(putArgStk->GetKind() == GenTreePutArgStk::Kind::RepInstr);
             GetEmitter()->emitIns_R_I(INS_mov, EA_4BYTE, REG_RCX, srcLayout->GetSize());
             GetEmitter()->emitIns(INS_r_movsb);
             return;
@@ -7308,14 +7398,14 @@ void CodeGen::genPutStructArgStk(GenTreePutArgStk* putArgStk NOT_X86_ARG(unsigne
     }
     else
     {
-        assert((putArgStk->gtPutArgStkKind == GenTreePutArgStk::Kind::GCUnroll) ||
-               (putArgStk->gtPutArgStkKind == GenTreePutArgStk::Kind::GCUnrollXMM));
+        assert((putArgStk->GetKind() == GenTreePutArgStk::Kind::GCUnroll) ||
+               (putArgStk->GetKind() == GenTreePutArgStk::Kind::GCUnrollXMM));
 
         intTmpReg = putArgStk->GetSingleTempReg(RBM_ALLINT);
     }
 
-    if ((putArgStk->gtPutArgStkKind == GenTreePutArgStk::Kind::RepInstrXMM) ||
-        (putArgStk->gtPutArgStkKind == GenTreePutArgStk::Kind::GCUnrollXMM))
+    if ((putArgStk->GetKind() == GenTreePutArgStk::Kind::RepInstrXMM) ||
+        (putArgStk->GetKind() == GenTreePutArgStk::Kind::GCUnrollXMM))
     {
         xmmTmpReg = putArgStk->GetSingleTempReg(RBM_ALLFLOAT);
     }
@@ -7378,8 +7468,8 @@ void CodeGen::genPutStructArgStk(GenTreePutArgStk* putArgStk NOT_X86_ARG(unsigne
             continue;
         }
 
-        assert((putArgStk->gtPutArgStkKind == GenTreePutArgStk::Kind::RepInstr) ||
-               (putArgStk->gtPutArgStkKind == GenTreePutArgStk::Kind::RepInstrXMM));
+        assert((putArgStk->GetKind() == GenTreePutArgStk::Kind::RepInstr) ||
+               (putArgStk->GetKind() == GenTreePutArgStk::Kind::RepInstrXMM));
         assert(srcAddrBaseReg == REG_RSI);
         assert(srcAddrIndexReg == REG_NA);
 

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -7300,15 +7300,15 @@ void CodeGen::genPutStructArgStk(GenTreePutArgStk* putArgStk NOT_X86_ARG(unsigne
 #ifdef TARGET_X86
     if (putArgStk->GetKind() == GenTreePutArgStk::Kind::Push)
     {
-        // On x86, any struct that has contains GC references must be stored to the stack using `push` instructions so
-        // that the emitter properly detects the need to update the method's GC information.
+        // On x86, any struct that has contains GC references must be stored to the stack using `push` instructions
+        // so that the emitter properly detects the need to update the method's GC information. We also use `push`
+        // for structs that are 8 bytes (or less, if the arg is a local var).
         //
         // Strictly speaking, it is only necessary to use `push` to store the GC references themselves, so for structs
         // with large numbers of consecutive non-GC-ref-typed fields, we may be able to improve the code size in the
         // future.
 
-        // We assume that the size of a struct which contains GC pointers is a multiple of the slot size.
-        assert(srcLayout->GetSize() % REGSIZE_BYTES == 0);
+        assert((srcLclNum != BAD_VAR_NUM) || (srcLayout->GetSize() % REGSIZE_BYTES == 0));
 
         for (int i = putArgStk->GetSlotCount() - 1; i >= 0; --i)
         {

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1354,6 +1354,19 @@ inline GenTreeIntCon* GenTree::ChangeToIntCon(ssize_t value)
     return intCon;
 }
 
+inline GenTreeDblCon* GenTree::ChangeToDblCon(var_types type, double value)
+{
+    // TODO-MIKE-Review: This should just call SetOperResetFlags but that one seems to be broken,
+    // it keeps only GTF_NODE_MASK flags and GTF_NODE_MASK does not contain GTF_LATE_ARG.
+    SetOper(GT_CNS_DBL);
+    gtFlags &= GTF_NODE_MASK | GTF_LATE_ARG;
+
+    GenTreeDblCon* dblCon = AsDblCon();
+    dblCon->SetType(type);
+    dblCon->SetValue(value);
+    return dblCon;
+}
+
 inline GenTreeFieldList* GenTree::ChangeToFieldList()
 {
     // TODO-MIKE-Review: This should just call SetOperResetFlags but that one seems to be broken,

--- a/src/coreclr/jit/compphases.h
+++ b/src/coreclr/jit/compphases.h
@@ -93,7 +93,7 @@ CompPhaseNameMacro(PHASE_LCLVARLIVENESS_PERBLOCK,"Per block local var liveness",
 CompPhaseNameMacro(PHASE_LCLVARLIVENESS_INTERBLOCK,  "Global local var liveness",  "LIV-GLBL", false, PHASE_LCLVARLIVENESS, false)
 
 CompPhaseNameMacro(PHASE_LOWERING_DECOMP,        "Lowering decomposition",         "LWR-DEC",  false, -1, false)
-CompPhaseNameMacro(PHASE_LOWERING,               "Lowering nodeinfo",              "LWR-INFO", false, -1, true)
+CompPhaseNameMacro(PHASE_LOWERING,               "Lowering",                       "LWR",      false, -1, true)
 CompPhaseNameMacro(PHASE_STACK_LEVEL_SETTER,     "Calculate stack level slots",    "STK-SET",  false, -1, false)
 CompPhaseNameMacro(PHASE_LINEAR_SCAN,            "Linear scan register alloc",     "LSRA",     true, -1, true)
 CompPhaseNameMacro(PHASE_LINEAR_SCAN_BUILD,      "LSRA build intervals",           "LSRA-BLD", false, PHASE_LINEAR_SCAN, false)

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -9711,7 +9711,7 @@ void Compiler::gtDispTree(GenTree*     tree,
             printf(" (%d slots", tree->AsPutArgStk()->GetSlotCount());
 #ifdef TARGET_XARCH
             const char* kindName;
-            switch (tree->AsPutArgStk()->gtPutArgStkKind)
+            switch (tree->AsPutArgStk()->GetKind())
             {
                 case GenTreePutArgStk::Kind::RepInstr:
                     kindName = "RepInst";

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1821,6 +1821,7 @@ public:
 
     void ChangeOperConst(genTreeOps oper); // ChangeOper(constOper)
     GenTreeIntCon* ChangeToIntCon(ssize_t value);
+    GenTreeDblCon* ChangeToDblCon(var_types type, double value);
     GenTreeFieldList* ChangeToFieldList();
     // set gtOper and only keep GTF_COMMON_MASK flags
     void ChangeOper(genTreeOps oper, ValueNumberUpdate vnUpdate = CLEAR_VN);

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -1359,7 +1359,6 @@ GenTree* Compiler::impCanonicalizeStructCallArg(GenTree* arg, ClassLayout* argLa
         case GT_LCL_VAR:
         case GT_LCL_FLD:
             argLclNum = arg->AsLclVarCommon()->GetLclNum();
-            arg       = gtNewObjNode(argLayout, gtNewAddrNode(arg));
             assert(arg->GetType() == lvaGetDesc(argLclNum)->GetType());
             isCanonical = true;
             break;

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -663,11 +663,29 @@ private:
         INDEBUG(val.Consume();)
         assert(user != nullptr);
 
-        if (val.Node()->OperIs(GT_LCL_VAR, GT_LCL_FLD))
-        {
-            // If the location is accessed directly then we don't need to do anything.
+        LclVarDsc* lcl  = m_compiler->lvaGetDesc(val.LclNum());
+        GenTree*   node = val.Node();
 
-            assert(val.Node()->AsLclVarCommon()->GetLclNum() == val.LclNum());
+        if (node->OperIs(GT_LCL_VAR, GT_LCL_FLD))
+        {
+            assert(node->AsLclVarCommon()->GetLclNum() == val.LclNum());
+
+            // TODO-MIKE-Cleanup: This shouldn't be restricted to call args but ASG LHS
+            // requires special handling. In fact, the LCL_VAR|FLD special casing should
+            // probably be removed and left to a generalized MorphLocalIndir.
+
+            if (node->OperIs(GT_LCL_VAR) && lcl->IsPromoted() && (lcl->GetPromotedFieldCount() == 1) && user->IsCall())
+            {
+                unsigned   fieldLclNum = lcl->GetPromotedFieldLclNum(0);
+                LclVarDsc* fieldLcl    = m_compiler->lvaGetDesc(fieldLclNum);
+
+                if (lcl->GetLayout()->GetSize() == varTypeSize(fieldLcl->GetType()))
+                {
+                    node->AsLclVar()->SetLclNum(fieldLclNum);
+                    node->SetType(fieldLcl->GetType());
+                }
+            }
+
             return;
         }
 
@@ -685,9 +703,8 @@ private:
         // *(long*)&int32Var has undefined behavior and it's practically useless but reading,
         // say, 2 consecutive Int32 struct fields as Int64 has more practical value.
 
-        LclVarDsc* varDsc    = m_compiler->lvaGetDesc(val.LclNum());
-        unsigned   indirSize = GetIndirSize(val.Node(), user);
-        bool       isWide;
+        unsigned indirSize = GetIndirSize(node, user);
+        bool     isWide;
 
         if (indirSize == 0)
         {
@@ -702,9 +719,9 @@ private:
             {
                 isWide = true;
             }
-            else if (varDsc->GetType() == TYP_STRUCT)
+            else if (lcl->GetType() == TYP_STRUCT)
             {
-                isWide = (endOffset.Value() > varDsc->GetLayout()->GetSize());
+                isWide = (endOffset.Value() > lcl->GetLayout()->GetSize());
             }
             else
             {
@@ -719,24 +736,24 @@ private:
                 //
                 // For TYP_BLK variables the type size is 0 so they're always address
                 // exposed.
-                isWide = (endOffset.Value() > varTypeSize(varDsc->GetType()));
+                isWide = (endOffset.Value() > varTypeSize(lcl->GetType()));
             }
         }
 
         if (isWide)
         {
-            m_compiler->lvaSetVarAddrExposed(varDsc->lvIsStructField ? varDsc->lvParentLcl : val.LclNum());
+            m_compiler->lvaSetVarAddrExposed(lcl->lvIsStructField ? lcl->lvParentLcl : val.LclNum());
             return;
         }
 
-        if (varTypeIsStruct(varDsc->GetType()) && varDsc->IsPromoted())
+        if (varTypeIsStruct(lcl->GetType()) && lcl->IsPromoted())
         {
             // If this is a promoted variable then we can use a promoted field if it completly
             // overlaps the indirection. With a lot of work, we could also handle cases where
             // the indirection spans multiple fields (e.g. reading two consecutive INT fields
             // as LONG) which would prevent dependent promotion.
 
-            unsigned fieldLclNum = FindPromotedField(varDsc, val.Offset(), indirSize);
+            unsigned fieldLclNum = FindPromotedField(lcl, val.Offset(), indirSize);
 
             if (fieldLclNum != BAD_VAR_NUM)
             {
@@ -1004,7 +1021,7 @@ private:
             // this case would be hit only due to user code reinterpretation. System.Half seems to
             // have some cases.
 
-            if (indir->OperIs(GT_OBJ) && (indirType == TYP_STRUCT) && user->OperIs(GT_CALL))
+            if (indir->OperIs(GT_OBJ) && (indirType == TYP_STRUCT) && user->IsCall())
             {
                 ClassLayout* indirLayout         = indir->AsObj()->GetLayout();
                 bool         isSingleFieldStruct = false;

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -1685,11 +1685,16 @@ private:
         //
         // CALL(OBJ(ADDR(LCL_VAR...)))
 
-        if ((m_ancestors.Height() >= 4) && m_ancestors.Top(0)->OperIs(GT_LCL_VAR) &&
-            m_ancestors.Top(1)->OperIs(GT_ADDR) && m_ancestors.Top(2)->OperIs(GT_OBJ) &&
-            m_ancestors.Top(3)->OperIs(GT_CALL))
+        // TODO-MIKE-Cleanup: The OBJ check is likely useless since the importer no
+        // longer wraps struct args in OBJs.
+
+        if (((m_ancestors.Height() >= 4) && m_ancestors.Top(0)->OperIs(GT_LCL_VAR) &&
+             m_ancestors.Top(1)->OperIs(GT_ADDR) && m_ancestors.Top(2)->OperIs(GT_OBJ) &&
+             m_ancestors.Top(3)->OperIs(GT_CALL)) ||
+            ((m_ancestors.Height() >= 2) && m_ancestors.Top(0)->OperIs(GT_LCL_VAR) &&
+             m_ancestors.Top(0)->TypeIs(TYP_STRUCT) && m_ancestors.Top(1)->OperIs(GT_CALL)))
         {
-            JITDUMP("LocalAddressVisitor incrementing weighted ref count from %d to %d"
+            JITDUMP("LocalAddressVisitor incrementing weighted ref count from %f to %f"
                     " for implict byref V%02d arg passed to call\n",
                     lcl->lvRefCntWtd(RCS_EARLY), lcl->lvRefCntWtd(RCS_EARLY) + 1, lclNum);
             lcl->incLvRefCntWtd(1, RCS_EARLY);

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -1055,7 +1055,7 @@ GenTree* Lowering::InsertPutArg(GenTreeCall* call, CallArgInfo* info)
                 }
             }
         }
-        else
+        else if (!arg->IsIntegralConst(0))
         {
             ClassLayout* layout;
 

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -333,6 +333,29 @@ void Lowering::LowerPutArgStk(GenTreePutArgStk* putArgStk)
     }
 
 #ifdef TARGET_ARM64
+    if (src->IsIntegralConst(0) && (putArgStk->GetSlotCount() > 1))
+    {
+        assert(comp->typIsLayoutNum(putArgStk->GetArgInfo()->GetSigTypeNum()));
+        assert(putArgStk->GetSlotCount() == 2);
+
+        src->SetContained();
+
+        return;
+    }
+
+    if (src->IsIntegralConst(0) && comp->typIsLayoutNum(putArgStk->GetArgInfo()->GetSigTypeNum()))
+    {
+        ClassLayout* layout = comp->typGetLayoutByNum(putArgStk->GetArgInfo()->GetSigTypeNum());
+        assert(layout->GetSize() <= REGSIZE_BYTES);
+
+        if (layout->GetSize() > 4)
+        {
+            src->SetType(TYP_LONG);
+        }
+
+        return;
+    }
+
     if (src->IsIntegralConst(0) || src->IsDblConPositiveZero())
     {
         src->SetContained();

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -578,7 +578,11 @@ void Lowering::LowerPutArgStk(GenTreePutArgStk* putArgStk)
         // TODO-X86-CQ: The helper call either is not supported on x86 or required more work
         // (I don't know which).
 
-        if (!layout->HasGCPtr())
+        if (!layout->HasGCPtr()
+#ifdef TARGET_X86
+            && (size != 8)
+#endif
+                )
         {
             putArgStk->SetKind(size <= CPBLK_UNROLL_LIMIT ? GenTreePutArgStk::Kind::Unroll
                                                           : GenTreePutArgStk::Kind::RepInstr);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -2041,7 +2041,7 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
             size = 1;
 #else
             // On 32 bit targets LONG and DOUBLE are passed in 2 regs/slots.
-            size                      = genTypeStSz(argx->GetType());
+            size = genTypeStSz(argx->GetType());
 #endif
         }
 
@@ -2069,7 +2069,8 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
             }
         }
 #elif defined(TARGET_ARM64)
-        const bool passUsingFloatRegs = (hfaType != TYP_UNDEF) || varTypeUsesFloatReg(argx->GetType());
+        const bool passUsingFloatRegs =
+            (hfaType != TYP_UNDEF) || (!isStructArg && varTypeUsesFloatReg(argx->GetType()));
 #elif defined(TARGET_AMD64)
         const bool passUsingFloatRegs = !isStructArg && varTypeIsFloating(argx->GetType());
 #elif defined(TARGET_X86)

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -3865,7 +3865,7 @@ GenTree* Compiler::abiMorphMultiRegSimdArg(CallArgInfo* argInfo, GenTree* arg)
 #error Unknown target.
 #endif
 
-    ClassLayout* argLayout = typGetLayoutByNum(argInfo->use->GetSigTypeNum());
+    ClassLayout* argLayout = typGetLayoutByNum(argInfo->GetSigTypeNum());
 
     unsigned tempLclNum = lvaNewTemp(argLayout, true DEBUGARG("multi-reg SIMD arg temp"));
     GenTree* tempAssign = gtNewAssignNode(gtNewLclvNode(tempLclNum, arg->GetType()), arg);
@@ -4383,7 +4383,7 @@ void Compiler::abiMorphImplicitByRefStructArg(GenTreeCall* call, CallArgInfo* ar
     // A<Canon> vs. A<C> issue. In general it doesn't matter if the 2 layouts
     // do not match. VN might get confused due to mismatched field sequences but
     // then this temp is never read from.
-    ClassLayout* argLayout = typGetLayoutByNum(argInfo->use->GetSigTypeNum());
+    ClassLayout* argLayout = typGetLayoutByNum(argInfo->GetSigTypeNum());
 
     unsigned tempLclNum = abiAllocateStructArgTemp(argLayout);
 


### PR DESCRIPTION
win-x64 diff:
```
Total bytes of base: 31596382
Total bytes of diff: 31534702
Total bytes of delta: -61680 (-0.20% of base)
    diff is an improvement.


Top file improvements (bytes):
      -11718 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.53% of base)
      -11058 : System.Linq.Parallel.dasm (-1.95% of base)
       -4920 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.15% of base)
       -4458 : System.Private.CoreLib.dasm (-0.31% of base)
       -4245 : Microsoft.CodeAnalysis.CSharp.dasm (-0.21% of base)
       -3062 : System.Security.Cryptography.Algorithms.dasm (-1.06% of base)
       -2971 : System.Text.Json.dasm (-0.50% of base)
       -2006 : System.Data.Common.dasm (-0.18% of base)
       -1641 : System.Drawing.Common.dasm (-0.51% of base)
       -1411 : System.Net.Http.dasm (-0.26% of base)
       -1369 : System.Security.Cryptography.Pkcs.dasm (-0.46% of base)
       -1107 : System.DirectoryServices.dasm (-0.30% of base)
       -1060 : System.Security.Cryptography.Cng.dasm (-0.68% of base)
        -971 : Microsoft.CodeAnalysis.dasm (-0.13% of base)
        -714 : System.Collections.Immutable.dasm (-0.32% of base)
        -703 : xunit.runner.utility.netcoreapp10.dasm (-0.51% of base)
        -638 : System.Private.Xml.dasm (-0.02% of base)
        -580 : System.Diagnostics.EventLog.dasm (-0.69% of base)
        -518 : System.Diagnostics.DiagnosticSource.dasm (-0.80% of base)
        -477 : System.Text.RegularExpressions.dasm (-0.27% of base)

75 total files with Code Size differences (75 improved, 0 regressed), 195 unchanged.

Top method regressions (bytes):
        3848 (15.61% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - ClrTraceEventParser:EnumerateTemplates(Func`3,Action`1):this
        2378 ( 8.77% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - ClrPrivateTraceEventParser:EnumerateTemplates(Func`3,Action`1):this
        1042 ( 2.79% of base) : Microsoft.CodeAnalysis.dasm - DesktopAssemblyIdentityComparer:.cctor()
         110 (23.35% of base) : System.Net.Http.dasm - HttpHeaders:Add(HeaderDescriptor,IEnumerable`1):this
          60 ( 9.39% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateBillboard(Vector3,Vector3,Vector3,Vector3):Matrix4x4
          51 (16.45% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:CreateSpan(SyntaxTokenList,SyntaxNodeOrToken,SyntaxNodeOrToken):TextSpan
          42 ( 3.50% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateConstrainedBillboard(Vector3,Vector3,Vector3,Vector3,Vector3):Matrix4x4
          35 ( 8.01% of base) : Microsoft.CodeAnalysis.dasm - MetadataHeapsBuilder:WriteAlignedBlobHeap(BlobBuilder):this
          32 ( 4.03% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateLookAt(Vector3,Vector3,Vector3):Matrix4x4
          30 (15.23% of base) : Microsoft.CodeAnalysis.dasm - MetadataWriter:GetLocalSlotDebugInfos(ImmutableArray`1):ImmutableArray`1
          25 ( 4.46% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateWorld(Vector3,Vector3,Vector3):Matrix4x4
          23 ( 8.27% of base) : System.Private.CoreLib.dasm - Plane:CreateFromVertices(Vector3,Vector3,Vector3):Plane
          21 ( 1.22% of base) : System.Private.Xml.dasm - XsltLoader:LoadRealStylesheet():this
          18 ( 0.91% of base) : System.Private.CoreLib.dasm - Utf8Formatter:TryFormat(long,Span`1,byref,StandardFormat):bool (2 methods)
          18 ( 1.06% of base) : System.Private.Xml.dasm - XsltLoader:LoadInstructions(List`1,int):List`1:this
          16 (12.21% of base) : System.Runtime.Numerics.dasm - BigInteger:op_Increment(BigInteger):BigInteger
          16 (12.21% of base) : System.Runtime.Numerics.dasm - BigInteger:op_Decrement(BigInteger):BigInteger
          15 ( 3.21% of base) : System.Security.Cryptography.Pkcs.dasm - MacData:Encode(AsnWriter,Asn1Tag):this
          14 ( 1.21% of base) : System.Private.Xml.dasm - XsltLoader:LoadAttributeSet(NsDecl):this
          14 ( 1.38% of base) : System.Private.Xml.dasm - XsltLoader:LoadWithParams(int):List`1:this

Top method improvements (bytes):
       -1665 (-34.26% of base) : System.Linq.Parallel.dasm - UnaryQueryOperator`2:.ctor(QueryOperator`1,bool,QuerySettings):this (45 methods)
       -1414 (-26.73% of base) : System.Linq.Parallel.dasm - InlinedAggregationOperator`3:Open(QuerySettings,bool):QueryResults`1:this (25 methods)
       -1364 (-30.02% of base) : System.Linq.Parallel.dasm - SelectQueryOperatorResults:NewResults(QueryResults`1,SelectQueryOperator`2,QuerySettings,bool):QueryResults`1 (11 methods)
       -1014 (-46.43% of base) : System.Linq.Parallel.dasm - QueryOperator`1:.ctor(bool,QuerySettings):this (26 methods)
        -936 (-52.94% of base) : System.Linq.Parallel.dasm - ParallelQuery`1:.ctor(QuerySettings):this (26 methods)
        -901 (-7.75% of base) : System.Net.Http.dasm - KnownHeaders:.cctor()
        -884 (-45.33% of base) : System.Linq.Parallel.dasm - QueryOperator`1:.ctor(QuerySettings):this (26 methods)
        -686 (-26.84% of base) : System.Linq.Parallel.dasm - AssociativeAggregationOperator`3:Open(QuerySettings,bool):QueryResults`1:this (12 methods)
        -495 (-13.13% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - ConstraintsHelper:RemoveDirectConstraintConflicts(TypeParameterSymbol,ImmutableArray`1,ConsList`1,int,ArrayBuilder`1):ImmutableArray`1
        -444 (-16.50% of base) : System.Diagnostics.EventLog.dasm - NativeWrapper:EvtRenderBufferWithContextSystem(EventLogHandle,EventLogHandle,int,SystemProperties,int)
        -374 (-21.79% of base) : System.Linq.Parallel.dasm - SelectQueryOperatorResults:.ctor(QueryResults`1,SelectQueryOperator`2,QuerySettings,bool):this (11 methods)
        -320 (-10.70% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:ReportNoConversionError(VisualBasicSyntaxNode,TypeSymbol,TypeSymbol,DiagnosticBag,String):this
        -318 (-1.75% of base) : System.Text.RegularExpressions.dasm - RegexCompiler:GenerateOneCode():this
        -253 (-6.04% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:DecodeModifiers(SyntaxTokenList,int,int,int,DiagnosticBag):MemberModifiers:this
        -231 (-4.71% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:BindCompoundAssignment(AssignmentExpressionSyntax,DiagnosticBag):BoundExpression:this
        -226 (-14.29% of base) : System.Drawing.Common.dasm - Encoder:.cctor()
        -224 (-6.47% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindAttributeNamedArgument(TypeSymbol,SimpleArgumentSyntax,DiagnosticBag):BoundExpression:this
        -202 (-11.74% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - EmitHelpers:MapToCompilation(VisualBasicCompilation,PEDeltaAssemblyBuilder):EmitBaseline
        -202 (-11.22% of base) : Microsoft.CodeAnalysis.CSharp.dasm - EmitHelpers:MapToCompilation(CSharpCompilation,PEDeltaAssemblyBuilder):EmitBaseline
        -192 (-3.98% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:MakeVarianceConversionSuggestion(int,VisualBasicSyntaxNode,TypeSymbol,TypeSymbol,DiagnosticBag,bool):bool:this

Top method regressions (percentages):
          11 (61.11% of base) : System.Private.CoreLib.dasm - TimeSpanTokenizer:.ctor(ReadOnlySpan`1):this
         110 (23.35% of base) : System.Net.Http.dasm - HttpHeaders:Add(HeaderDescriptor,IEnumerable`1):this
          11 (18.03% of base) : System.IO.FileSystem.dasm - FileSystemEntry:Initialize(byref,long,ReadOnlySpan`1,ReadOnlySpan`1,ReadOnlySpan`1)
          51 (16.45% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:CreateSpan(SyntaxTokenList,SyntaxNodeOrToken,SyntaxNodeOrToken):TextSpan
        3848 (15.61% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - ClrTraceEventParser:EnumerateTemplates(Func`3,Action`1):this
          30 (15.23% of base) : Microsoft.CodeAnalysis.dasm - MetadataWriter:GetLocalSlotDebugInfos(ImmutableArray`1):ImmutableArray`1
          16 (12.21% of base) : System.Runtime.Numerics.dasm - BigInteger:op_Increment(BigInteger):BigInteger
          16 (12.21% of base) : System.Runtime.Numerics.dasm - BigInteger:op_Decrement(BigInteger):BigInteger
          14 (10.37% of base) : Newtonsoft.Json.dasm - JsonTextWriter:WriteValueAsync(int,CancellationToken):Task:this (2 methods)
           7 ( 9.86% of base) : Newtonsoft.Json.dasm - JsonTextWriter:WriteValueAsync(ubyte,CancellationToken):Task:this
          60 ( 9.39% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateBillboard(Vector3,Vector3,Vector3,Vector3):Matrix4x4
           7 ( 9.21% of base) : Newtonsoft.Json.dasm - JsonTextWriter:WriteValueAsync(byte,CancellationToken):Task:this
           7 ( 9.21% of base) : Newtonsoft.Json.dasm - JsonTextWriter:WriteValueAsync(short,CancellationToken):Task:this
        2378 ( 8.77% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - ClrPrivateTraceEventParser:EnumerateTemplates(Func`3,Action`1):this
          23 ( 8.27% of base) : System.Private.CoreLib.dasm - Plane:CreateFromVertices(Vector3,Vector3,Vector3):Plane
          35 ( 8.01% of base) : Microsoft.CodeAnalysis.dasm - MetadataHeapsBuilder:WriteAlignedBlobHeap(BlobBuilder):this
          11 ( 7.59% of base) : System.Runtime.Numerics.dasm - BigInteger:op_OnesComplement(BigInteger):BigInteger
           3 ( 7.14% of base) : System.Private.CoreLib.dasm - Vector3:Multiply(Vector3,float):Vector3
           7 ( 6.48% of base) : Newtonsoft.Json.dasm - JsonTextWriter:WriteValueAsync(long,CancellationToken):Task:this (2 methods)
           3 ( 5.77% of base) : System.Private.CoreLib.dasm - Vector3:Divide(Vector3,float):Vector3

Top method improvements (percentages):
        -102 (-84.30% of base) : System.Data.Common.dasm - SqlString:LessThan(SqlString,SqlString):SqlBoolean
        -166 (-84.26% of base) : System.Data.Common.dasm - SqlString:NotEquals(SqlString,SqlString):SqlBoolean
        -102 (-82.26% of base) : System.Data.Common.dasm - SqlString:Equals(SqlString,SqlString):SqlBoolean
        -102 (-82.26% of base) : System.Data.Common.dasm - SqlString:GreaterThan(SqlString,SqlString):SqlBoolean
        -102 (-82.26% of base) : System.Data.Common.dasm - SqlString:LessThanOrEqual(SqlString,SqlString):SqlBoolean
        -102 (-82.26% of base) : System.Data.Common.dasm - SqlString:GreaterThanOrEqual(SqlString,SqlString):SqlBoolean
         -88 (-77.88% of base) : System.Data.Common.dasm - SqlDecimal:NotEquals(SqlDecimal,SqlDecimal):SqlBoolean
        -102 (-76.69% of base) : System.Data.Common.dasm - SqlString:op_Inequality(SqlString,SqlString):SqlBoolean
         -58 (-69.88% of base) : System.Data.Common.dasm - SqlDateTime:NotEquals(SqlDateTime,SqlDateTime):SqlBoolean
         -46 (-64.79% of base) : System.Data.Common.dasm - SqlDouble:NotEquals(SqlDouble,SqlDouble):SqlBoolean
         -29 (-64.44% of base) : System.Private.CoreLib.dasm - AccessViolationException:.ctor(SerializationInfo,StreamingContext):this
         -29 (-64.44% of base) : System.Private.CoreLib.dasm - AppDomainUnloadedException:.ctor(SerializationInfo,StreamingContext):this
         -29 (-64.44% of base) : System.Private.CoreLib.dasm - ArithmeticException:.ctor(SerializationInfo,StreamingContext):this
         -29 (-64.44% of base) : System.Private.CoreLib.dasm - ArrayTypeMismatchException:.ctor(SerializationInfo,StreamingContext):this
         -29 (-64.44% of base) : System.Private.CoreLib.dasm - CannotUnloadAppDomainException:.ctor(SerializationInfo,StreamingContext):this
         -29 (-64.44% of base) : System.Private.CoreLib.dasm - ContextMarshalException:.ctor(SerializationInfo,StreamingContext):this
         -29 (-64.44% of base) : System.Private.CoreLib.dasm - DataMisalignedException:.ctor(SerializationInfo,StreamingContext):this
         -29 (-64.44% of base) : System.Private.CoreLib.dasm - DivideByZeroException:.ctor(SerializationInfo,StreamingContext):this
         -29 (-64.44% of base) : System.Private.CoreLib.dasm - ExecutionEngineException:.ctor(SerializationInfo,StreamingContext):this
         -29 (-64.44% of base) : System.Private.CoreLib.dasm - FieldAccessException:.ctor(SerializationInfo,StreamingContext):this

2588 total methods with Code Size differences (2518 improved, 70 regressed), 190229 unchanged.
```
Largest regressions in `Microsoft.Diagnostics.Tracing.TraceEvent` and `System.Net.Http` due to extra inlining. Other regressions due to removal of temps that leads to poor register allocation or increased number of uses of DNER/AX/implicit by ref locals/args.