### PR TITLE
Remove useless OBJs

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -1374,13 +1374,10 @@ GenTree* Compiler::impCanonicalizeStructCallArg(GenTree* arg, ClassLayout* argLa
         case GT_RET_EXPR:
             // TODO-MIKE-Cleanup: We do need a local temp for calls that return structs via
             // a return buffer. Do we also need a temp if structs are returned in registers?
-            {
-                argLclNum = lvaGrabTemp(true DEBUGARG("struct arg temp"));
-                impAppendTempAssign(argLclNum, arg, argLayout, curLevel);
-                arg = gtNewLclvNode(argLclNum, lvaGetDesc(argLclNum)->GetType());
-            }
-
-            isCanonical = false;
+            argLclNum = lvaGrabTemp(true DEBUGARG("struct arg temp"));
+            impAppendTempAssign(argLclNum, arg, argLayout, curLevel);
+            arg = gtNewLclvNode(argLclNum, lvaGetDesc(argLclNum)->GetType());
+            isCanonical = true;
             break;
 
         case GT_LCL_VAR:

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -1393,15 +1393,15 @@ GenTree* Compiler::impCanonicalizeStructCallArg(GenTree* arg, ClassLayout* argLa
             }
             break;
 
+#ifdef FEATURE_SIMD
         case GT_IND:
-            arg = gtNewObjNode(argLayout, arg->AsIndir()->GetAddr());
-            break;
-
 #ifdef FEATURE_HW_INTRINSICS
         case GT_HWINTRINSIC:
-            assert(varTypeIsSIMD(arg->GetType()));
-            FALLTHROUGH;
 #endif
+            assert(varTypeIsSIMD(arg->GetType()));
+            break;
+#endif
+
         case GT_MKREFANY:
         case GT_LCL_FLD:
         case GT_INDEX:

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -1379,9 +1379,7 @@ GenTree* Compiler::impCanonicalizeStructCallArg(GenTree* arg, ClassLayout* argLa
             break;
 
         case GT_LCL_VAR:
-        case GT_LCL_FLD:
-            argLclNum = arg->AsLclVarCommon()->GetLclNum();
-            assert(arg->GetType() == lvaGetDesc(argLclNum)->GetType());
+            assert(arg->GetType() == lvaGetDesc(arg->AsLclVar())->GetType());
             break;
 
         case GT_FIELD:
@@ -1405,6 +1403,7 @@ GenTree* Compiler::impCanonicalizeStructCallArg(GenTree* arg, ClassLayout* argLa
             FALLTHROUGH;
 #endif
         case GT_MKREFANY:
+        case GT_LCL_FLD:
         case GT_INDEX:
         case GT_OBJ:
             break;

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -1365,10 +1365,10 @@ GenTree* Compiler::impCanonicalizeStructCallArg(GenTree* arg, ClassLayout* argLa
 {
     assert(arg->GetType() == typGetStructType(argLayout));
 
-    unsigned argLclNum = BAD_VAR_NUM;
-
     switch (arg->GetOper())
     {
+        unsigned argLclNum;
+
         case GT_CALL:
         case GT_RET_EXPR:
             // TODO-MIKE-Cleanup: We do need a local temp for calls that return structs via
@@ -1467,19 +1467,7 @@ GenTree* Compiler::impCanonicalizeStructCallArg(GenTree* arg, ClassLayout* argLa
 
     if (arg->OperIs(GT_OBJ))
     {
-        if (argLclNum != BAD_VAR_NUM)
-        {
-            // A OBJ on a ADDR(LCL_VAR) can never raise an exception so we don't set GTF_EXCEPT here.
-            if (!lvaGetDesc(argLclNum)->IsImplicitByRefParam())
-            {
-                arg->gtFlags &= ~GTF_GLOB_REF;
-            }
-        }
-        else
-        {
-            // In general a OBJ is an indirection and could raise an exception.
-            arg->gtFlags |= GTF_EXCEPT;
-        }
+        arg->gtFlags |= GTF_EXCEPT;
     }
 
     return arg;


### PR DESCRIPTION
win-x64 diff:
```
Total bytes of base: 31532807
Total bytes of diff: 31506222
Total bytes of delta: -26585 (-0.08 % of base)
    diff is an improvement.

Top file regressions (bytes):
           4 : System.Threading.Tasks.Dataflow.dasm (0.00% of base)

Top file improvements (bytes):
       -9416 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.43% of base)
       -3252 : Microsoft.CodeAnalysis.CSharp.dasm (-0.16% of base)
       -3223 : System.Linq.Parallel.dasm (-0.58% of base)
       -1709 : System.Private.Xml.dasm (-0.06% of base)
       -1051 : System.Text.Json.dasm (-0.18% of base)
       -1041 : System.Security.Cryptography.Pkcs.dasm (-0.35% of base)
        -939 : System.Security.Cryptography.Algorithms.dasm (-0.33% of base)
        -657 : FSharp.Core.dasm (-0.08% of base)
        -383 : Microsoft.CodeAnalysis.dasm (-0.05% of base)
        -369 : System.Transactions.Local.dasm (-0.38% of base)
        -325 : System.Diagnostics.DiagnosticSource.dasm (-0.51% of base)
        -319 : System.Data.Common.dasm (-0.03% of base)
        -315 : System.Net.Security.dasm (-0.15% of base)
        -280 : System.Security.Cryptography.Cng.dasm (-0.18% of base)
        -258 : System.Collections.Immutable.dasm (-0.11% of base)
        -245 : System.Text.RegularExpressions.dasm (-0.14% of base)
        -238 : System.IO.Pipelines.dasm (-0.48% of base)
        -197 : ILCompiler.Reflection.ReadyToRun.dasm (-0.16% of base)
        -143 : System.Private.CoreLib.dasm (-0.01% of base)
        -141 : System.IO.Compression.dasm (-0.19% of base)

62 total files with Code Size differences (61 improved, 1 regressed), 208 unchanged.

Top method regressions (bytes):
          18 ( 2.88% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SyntheticBoundNodeFactory:SwitchSection(List`1,ref):BoundSwitchSection:this
           9 ( 1.07% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SourceDestructorSymbol:.ctor(SourceMemberContainerTypeSymbol,DestructorDeclarationSyntax,DiagnosticBag):this
           8 ( 1.10% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SourceConstructorSymbol:.ctor(SourceMemberContainerTypeSymbol,Location,ConstructorDeclarationSyntax,int,DiagnosticBag):this
           7 ( 1.18% of base) : System.Private.Xml.dasm - BinHexEncoder:Encode(ref,int,int,XmlWriter)
           7 ( 0.76% of base) : System.Private.Xml.dasm - XsltLoader:XslValueOf():XslNode:this
           6 ( 0.25% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:VisitLockStatement(BoundLockStatement):BoundNode:this
           6 ( 1.68% of base) : System.Text.Json.dasm - Utf8JsonReader:ConsumeString():bool:this
           6 ( 1.61% of base) : System.Text.Json.dasm - Utf8JsonReader:ConsumeStringMultiSegment():bool:this
           4 ( 2.72% of base) : System.Runtime.Numerics.dasm - BigInteger:op_Decrement(BigInteger):BigInteger
           4 ( 2.72% of base) : System.Runtime.Numerics.dasm - BigInteger:op_Increment(BigInteger):BigInteger
           4 ( 2.56% of base) : System.Runtime.Numerics.dasm - BigInteger:op_OnesComplement(BigInteger):BigInteger
           4 ( 0.40% of base) : System.Threading.Tasks.Dataflow.dasm - DataflowBlock:ChooseCore(ISourceBlock`1,Action`1,ISourceBlock`1,Action`1,ISourceBlock`1,Action`1,DataflowBlockOptions):Task`1 (2 methods)
           4 ( 0.44% of base) : System.Security.Cryptography.Encoding.dasm - FromBase64Transform:TransformFinalBlock(ref,int,int):ref:this
           4 ( 0.99% of base) : System.Text.Json.dasm - Utf8JsonReader:ReadFirstToken(ubyte):bool:this
           3 ( 0.35% of base) : System.Private.Xml.dasm - <EncodeAsync>d__3:MoveNext():this
           3 ( 0.07% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindCollectionRangeVariables(QueryClauseSyntax,BoundQueryClauseBase,SeparatedSyntaxList`1,byref,DiagnosticBag):BoundQueryClauseBase:this
           3 ( 0.08% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LanguageParser:ParseNamespaceBody(byref,byref,byref,ushort):this
           2 ( 0.32% of base) : System.Reflection.Metadata.dasm - BlobHeap:GetDocumentName(DocumentNameBlobHandle):String:this
           2 ( 3.70% of base) : System.Reflection.Metadata.dasm - BlobReader:.ctor(long,int):this
           2 ( 0.23% of base) : System.Reflection.Metadata.dasm - CustomAttributeDecoder`1:DecodeValue(EntityHandle,BlobHandle):CustomAttributeValue`1:this

Top method improvements (bytes):
       -1404 (-34.62% of base) : System.Linq.Parallel.dasm - ParallelEnumerableWrapper`1:.ctor(IEnumerable`1):this (26 methods)
        -604 (-30.54% of base) : System.Linq.Parallel.dasm - ScanQueryOperator`1:.ctor(IEnumerable`1):this (11 methods)
        -569 (-4.45% of base) : FSharp.Core.dasm - $Query:.cctor()
        -265 (-14.68% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindTypeParameterConstraint(Symbol,ConstraintSyntax,byref,ArrayBuilder`1,DiagnosticBag):this
        -241 (-18.17% of base) : System.Diagnostics.DiagnosticSource.dasm - LinkedList`1:.ctor(IEnumerator`1):this (4 methods)
        -237 (-4.48% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceMemberMethodSymbol:BindSingleHandlesClause(HandlesClauseItemSyntax,Binder,DiagnosticBag,ArrayBuilder`1,ArrayBuilder`1,ArrayBuilder`1,byref):HandledEvent:this
        -234 (-7.99% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:InferFunctionLambdaReturnType(UnboundLambda,TargetSignature):KeyValuePair`2:this
        -224 (-5.39% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:DecodeParameterList(Symbol,bool,int,SeparatedSyntaxList`1,ArrayBuilder`1,CheckParameterModifierDelegate,DiagnosticBag):this
        -210 (-10.01% of base) : System.Collections.Immutable.dasm - ImmutableExtensions:GetEnumerableDisposable(IEnumerable`1):DisposableEnumeratorAdapter`2 (5 methods)
        -196 (-10.85% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:DecodeModifiedIdentifierType(ModifiedIdentifierSyntax,TypeSymbol,AsClauseSyntax,VisualBasicSyntaxNode,Func`1,DiagnosticBag,int):TypeSymbol:this
        -196 (-7.47% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceNonPropertyAccessorMethodSymbol:GetReturnType(SourceModuleSymbol,byref,DiagnosticBag):TypeSymbol:this
        -192 (-4.88% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:DecodeModifiers(SyntaxTokenList,int,int,int,DiagnosticBag):MemberModifiers:this
        -172 (-9.77% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceDelegateMethodSymbol:MakeDelegateMembers(NamedTypeSymbol,VisualBasicSyntaxNode,ParameterListSyntax,Binder,byref,byref,byref,byref,DiagnosticBag)
        -155 (-19.18% of base) : System.Private.Xml.dasm - XmlILVisitor:VisitNodeProperty(QilUnary):QilNode:this
        -149 (-2.15% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceMemberFieldSymbol:Create(SourceMemberContainerTypeSymbol,FieldDeclarationSyntax,Binder,MembersAndInitializersBuilder,byref,byref,DiagnosticBag)
        -137 (-3.57% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindRaiseEventStatement(RaiseEventStatementSyntax,DiagnosticBag):BoundStatement:this
        -134 (-23.51% of base) : System.Linq.Parallel.dasm - QueryExecutionOption`1:.ctor(QueryOperator`1,QuerySettings):this (2 methods)
        -132 (-3.99% of base) : System.Security.Cryptography.Algorithms.dasm - KeyFormatHelper:ReadEncryptedPkcs8(ref,ReadOnlySpan`1,ReadOnlySpan`1,KeyReader`1,byref,byref) (8 methods)
        -131 (-15.88% of base) : System.Security.Cryptography.Algorithms.dasm - CngCommon:SignHash(SafeNCryptKeyHandle,ReadOnlySpan`1,int,long,int):ref
        -131 (-15.88% of base) : System.Security.Cryptography.Cng.dasm - CngCommon:SignHash(SafeNCryptKeyHandle,ReadOnlySpan`1,int,long,int):ref

Top method regressions (percentages):
           2 ( 3.70% of base) : System.Reflection.Metadata.dasm - BlobReader:.ctor(long,int):this
          18 ( 2.88% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SyntheticBoundNodeFactory:SwitchSection(List`1,ref):BoundSwitchSection:this
           4 ( 2.72% of base) : System.Runtime.Numerics.dasm - BigInteger:op_Decrement(BigInteger):BigInteger
           4 ( 2.72% of base) : System.Runtime.Numerics.dasm - BigInteger:op_Increment(BigInteger):BigInteger
           4 ( 2.56% of base) : System.Runtime.Numerics.dasm - BigInteger:op_OnesComplement(BigInteger):BigInteger
           6 ( 1.68% of base) : System.Text.Json.dasm - Utf8JsonReader:ConsumeString():bool:this
           6 ( 1.61% of base) : System.Text.Json.dasm - Utf8JsonReader:ConsumeStringMultiSegment():bool:this
           7 ( 1.18% of base) : System.Private.Xml.dasm - BinHexEncoder:Encode(ref,int,int,XmlWriter)
           8 ( 1.10% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SourceConstructorSymbol:.ctor(SourceMemberContainerTypeSymbol,Location,ConstructorDeclarationSyntax,int,DiagnosticBag):this
           1 ( 1.09% of base) : System.Reflection.Metadata.dasm - BlobHeap:GetBlobReader(BlobHandle):BlobReader:this
           1 ( 1.09% of base) : System.Reflection.Metadata.dasm - StringHeap:GetBlobReader(StringHandle):BlobReader:this
           9 ( 1.07% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SourceDestructorSymbol:.ctor(SourceMemberContainerTypeSymbol,DestructorDeclarationSyntax,DiagnosticBag):this
           1 ( 1.02% of base) : System.Reflection.Metadata.dasm - MetadataReader:GetBlobReader(StringHandle):BlobReader:this
           1 ( 0.99% of base) : System.Reflection.Metadata.dasm - MetadataReader:GetBlobReader(BlobHandle):BlobReader:this
           4 ( 0.99% of base) : System.Text.Json.dasm - Utf8JsonReader:ReadFirstToken(ubyte):bool:this
           2 ( 0.90% of base) : Microsoft.CodeAnalysis.dasm - PdbWriter:GetOrCreateSerializedTypeName(ITypeReference):String:this
           1 ( 0.82% of base) : System.Text.Json.dasm - Utf8JsonReader:ConsumeMultiLineComment(ReadOnlySpan`1,int):bool:this
           1 ( 0.82% of base) : System.Text.Json.dasm - Utf8JsonReader:ConsumeSingleLineComment(ReadOnlySpan`1,int):bool:this
           7 ( 0.76% of base) : System.Private.Xml.dasm - XsltLoader:XslValueOf():XslNode:this
           1 ( 0.70% of base) : System.Reflection.Metadata.dasm - AbstractMemoryBlock:GetReader():BlobReader:this

Top method improvements (percentages):
         -72 (-50.00% of base) : System.Private.CoreLib.dasm - Quaternion:get_IsIdentity():bool:this
         -54 (-40.00% of base) : System.Linq.Parallel.dasm - EmptyEnumerable`1:.ctor():this
         -61 (-39.35% of base) : System.Linq.Parallel.dasm - RangeEnumerable:.ctor(int,int):this
         -61 (-36.75% of base) : System.Linq.Parallel.dasm - RepeatEnumerable`1:.ctor(__Canon,int):this
         -54 (-34.62% of base) : System.Linq.Parallel.dasm - ParallelEnumerableWrapper:.ctor(IEnumerable):this
       -1404 (-34.62% of base) : System.Linq.Parallel.dasm - ParallelEnumerableWrapper`1:.ctor(IEnumerable`1):this (26 methods)
         -54 (-33.75% of base) : System.Linq.Parallel.dasm - PartitionerQueryOperator`1:.ctor(Partitioner`1):this
         -64 (-32.32% of base) : System.Linq.Parallel.dasm - EmptyEnumerable`1:get_Instance():EmptyEnumerable`1
        -604 (-30.54% of base) : System.Linq.Parallel.dasm - ScanQueryOperator`1:.ctor(IEnumerable`1):this (11 methods)
         -64 (-28.32% of base) : System.Linq.Parallel.dasm - ParallelEnumerable:AsParallel(IEnumerable`1):ParallelQuery`1
         -64 (-27.83% of base) : System.Linq.Parallel.dasm - ParallelEnumerable:AsParallel(Partitioner`1):ParallelQuery`1
         -61 (-26.99% of base) : System.Linq.Parallel.dasm - ParallelEnumerable:Range(int,int):ParallelQuery`1
         -54 (-25.84% of base) : System.Linq.Parallel.dasm - ParallelEnumerable:AsParallel(IEnumerable):ParallelQuery
         -54 (-25.71% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SyntaxTreeSemanticModel:AnalyzeDataFlow(StatementSyntax,StatementSyntax):DataFlowAnalysis:this
         -32 (-25.00% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:HasDefaultType(ModifiedIdentifierSyntax,AsClauseSyntax):bool:this
         -93 (-25.00% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LookupPosition:IsInBody(int,BaseMethodDeclarationSyntax):bool
         -22 (-24.18% of base) : System.IO.Compression.dasm - InputBuffer:SetInput(ref,int,int):this
         -57 (-24.15% of base) : System.Linq.Parallel.dasm - ParallelEnumerable:Repeat(__Canon,int):ParallelQuery`1
         -22 (-23.91% of base) : System.IO.Compression.dasm - InflaterManaged:SetInput(ref,int,int):this
        -134 (-23.51% of base) : System.Linq.Parallel.dasm - QueryExecutionOption`1:.ctor(QueryOperator`1,QuerySettings):this (2 methods)

832 total methods with Code Size differences (781 improved, 51 regressed), 191985 unchanged.
```