### PR TITLE
Delete GTF_IND_ARR_INDEX

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6236,8 +6236,6 @@ public:
                                               BasicBlock*       slow);
 
 protected:
-    ssize_t optGetArrayRefScaleAndIndex(GenTree* mul, GenTree** pIndex DEBUGARG(bool bRngChk));
-
     bool optReachWithoutCall(BasicBlock* srcBB, BasicBlock* dstBB);
 
 protected:

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2145,11 +2145,7 @@ public:
 
     unsigned gtSetCallArgsOrder(const GenTreeCall::UseList& args, bool lateArgs, int* callCostEx, int* callCostSz);
 
-#ifdef DEBUG
-    unsigned gtHashValue(GenTree* tree);
-
-    GenTree* gtWalkOpEffectiveVal(GenTree* op);
-#endif
+    INDEBUG(unsigned gtHashValue(GenTree* tree);)
 
     void gtPrepareCost(GenTree* tree);
     bool gtIsLikelyRegVar(GenTree* tree);

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -802,11 +802,11 @@ inline GenTree* Compiler::gtNewOperNode(genTreeOps oper, var_types type, GenTree
         if (oper == GT_IND)
         {
             // IND(ADDR(IND(x)) == IND(x)
-            if (op1->gtOper == GT_ADDR)
+            if (op1->OperIs(GT_ADDR))
             {
-                GenTreeUnOp* addr  = op1->AsUnOp();
-                GenTree*     indir = addr->gtGetOp1();
-                if (indir->OperIs(GT_IND) && ((indir->gtFlags & GTF_IND_ARR_INDEX) == 0))
+                GenTree* indir = op1->AsUnOp()->GetOp(0);
+
+                if (indir->OperIs(GT_IND))
                 {
                     op1 = indir->AsIndir()->Addr();
                 }
@@ -815,15 +815,13 @@ inline GenTree* Compiler::gtNewOperNode(genTreeOps oper, var_types type, GenTree
         else if (oper == GT_ADDR)
         {
             // if "x" is not an array index, ADDR(IND(x)) == x
-            if (op1->gtOper == GT_IND && (op1->gtFlags & GTF_IND_ARR_INDEX) == 0)
+            if (op1->OperIs(GT_IND))
             {
-                return op1->AsOp()->gtOp1;
+                return op1->AsIndir()->GetAddr();
             }
-            else
-            {
-                // Addr source can't be CSE-ed.
-                op1->SetDoNotCSE();
-            }
+
+            // Addr source can't be CSE-ed.
+            op1->SetDoNotCSE();
         }
     }
 
@@ -836,7 +834,7 @@ inline GenTree* Compiler::gtNewAddrNode(GenTree* location, var_types type)
 {
     assert(!location->OperIs(GT_LCL_VAR, GT_LCL_FLD));
 
-    if (location->OperIs(GT_IND) && ((location->gtFlags & GTF_IND_ARR_INDEX) == 0))
+    if (location->OperIs(GT_IND))
     {
         return location->AsIndir()->GetAddr();
     }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -7815,12 +7815,6 @@ int Compiler::gtDispNodeHeader(GenTree* tree, IndentStack* indentStack, int msgL
                         --msgLength;
                         break;
                     }
-                    if (tree->gtFlags & GTF_IND_ARR_INDEX)
-                    {
-                        printf("a");
-                        --msgLength;
-                        break;
-                    }
                     if (tree->gtFlags & GTF_IND_NONFAULTING)
                     {
                         printf("n"); // print a n for non-faulting

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2366,54 +2366,6 @@ unsigned Compiler::gtSetCallArgsOrder(const GenTreeCall::UseList& args, bool lat
     return level;
 }
 
-#ifdef DEBUG
-/*****************************************************************************
- * This is a workaround. It is to help implement an assert in gtSetEvalOrder() that the values
- * gtWalkOp() leaves in op1 and op2 correspond with the values of adr, idx, mul, and cns
- * that are returned by genCreateAddrMode(). It's essentially impossible to determine
- * what gtWalkOp() *should* return for all possible trees. This simply loosens one assert
- * to handle the following case:
-
-         indir     int
-                    const(h)  int    4 field
-                 +         byref
-                    lclVar    byref  V00 this               <-- op2
-              comma     byref                           <-- adr (base)
-                 indir     byte
-                    lclVar    byref  V00 this
-           +         byref
-                 const     int    2                     <-- mul == 4
-              <<        int                                 <-- op1
-                 lclVar    int    V01 arg1              <-- idx
-
- * Here, we are planning to generate the address mode [edx+4*eax], where eax = idx and edx = the GT_COMMA expression.
- * To check adr equivalence with op2, we need to walk down the GT_ADD tree just like gtWalkOp() does.
- */
-GenTree* Compiler::gtWalkOpEffectiveVal(GenTree* op)
-{
-    for (;;)
-    {
-        op = op->SkipComma();
-
-        if ((op->gtOper != GT_ADD) || op->gtOverflow() || !op->AsOp()->gtOp2->IsCnsIntOrI())
-        {
-            break;
-        }
-
-        op = op->AsOp()->gtOp1;
-    }
-
-    return op;
-}
-#endif // DEBUG
-
-/*****************************************************************************
- *
- *  Given a tree, set the GetCostEx and GetCostSz() fields which
- *  are used to measure the relative costs of the codegen of the tree
- *
- */
-
 void Compiler::gtPrepareCost(GenTree* tree)
 {
     gtSetEvalOrder(tree);

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -3191,20 +3191,6 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                     level++;
                     break;
 
-                case GT_ADDR:
-
-                    costEx = 0;
-                    costSz = 1;
-
-                    // If we have a GT_ADDR of an GT_IND we can just copy the costs from indOp1
-                    if (op1->OperGet() == GT_IND)
-                    {
-                        GenTree* indOp1 = op1->AsOp()->gtOp1;
-                        costEx          = indOp1->GetCostEx();
-                        costSz          = indOp1->GetCostSz();
-                    }
-                    break;
-
                 case GT_ARR_LENGTH:
                     level++;
 
@@ -3508,14 +3494,7 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
         {
             GenTree* op1Val = op1;
 
-            // Skip over the GT_IND/GT_ADDR tree (if one exists)
-            //
-            if ((op1->gtOper == GT_IND) && (op1->AsOp()->gtOp1->gtOper == GT_ADDR))
-            {
-                op1Val = op1->AsOp()->gtOp1->AsOp()->gtOp1;
-            }
-
-            switch (op1Val->gtOper)
+            switch (op1Val->GetOper())
             {
                 case GT_IND:
                 case GT_BLK:

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -6390,7 +6390,7 @@ struct GenTreeIndir : public GenTreeOp
     void SetAddr(GenTree* addr)
     {
         assert(addr != nullptr);
-        assert(addr->TypeIs(TYP_I_IMPL, TYP_BYREF));
+        assert(varTypeIsI(addr->GetType()));
         gtOp1 = addr;
     }
 

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -563,11 +563,10 @@ enum GenTreeFlags : unsigned int
     GTF_IND_UNALIGNED           = 0x02000000, // GT_IND   -- the load or store is unaligned (we assume worst case
                                               //             alignment of 1 byte)
     GTF_IND_INVARIANT           = 0x01000000, // GT_IND   -- the target is invariant (a prejit indirection)
-    GTF_IND_ARR_INDEX           = 0x00800000, // GT_IND   -- the indirection represents an (SZ) array index
     GTF_IND_NONNULL             = 0x00400000, // GT_IND   -- the indirection never returns null (zero)
 
     GTF_IND_FLAGS = GTF_IND_VOLATILE | GTF_IND_NONFAULTING | GTF_IND_TGT_HEAP | GTF_IND_NONNULL | \
-                    GTF_IND_UNALIGNED | GTF_IND_INVARIANT | GTF_IND_ARR_INDEX | GTF_IND_TGT_NOT_HEAP,
+                    GTF_IND_UNALIGNED | GTF_IND_INVARIANT | GTF_IND_TGT_NOT_HEAP,
 
     GTF_CLS_VAR_INITCLASS       = 0x20000000, // GT_CLS_VAR_ADDR
 

--- a/src/coreclr/jit/gschecks.cpp
+++ b/src/coreclr/jit/gschecks.cpp
@@ -223,15 +223,6 @@ Compiler::fgWalkResult Compiler::gsMarkPtrsAndAssignGroups(GenTree** pTree, fgWa
             }
             return WALK_SKIP_SUBTREES;
 
-        case GT_ADDR:
-            newState.isUnderIndir = false;
-            // We'll assume p in "**p = " can be vulnerable because by changing 'p', someone
-            // could control where **p stores to.
-            {
-                comp->fgWalkTreePre(&tree->AsOp()->gtOp1, comp->gsMarkPtrsAndAssignGroups, (void*)&newState);
-            }
-            return WALK_SKIP_SUBTREES;
-
         case GT_ASG:
         {
             GenTreeOp* asg = tree->AsOp();

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -2073,6 +2073,12 @@ bool Compiler::optExtractArrIndex(GenTree* tree, ArrIndex* result, unsigned lhsN
     {
         return false;
     }
+    // TODO-1stClassStructs: Remove this check to enable optimization of array bounds checks for struct
+    // type fields.
+    if (GetZeroOffsetFieldSeq(sibo) != nullptr)
+    {
+        return false;
+    }
     GenTree* base = sibo->gtGetOp1();
     GenTree* sio  = sibo->gtGetOp2(); // sio == scale*index + offset
     if (base->OperGet() != GT_LCL_VAR || base->AsLclVarCommon()->GetLclNum() != arrLcl)

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -4874,21 +4874,7 @@ GenTree* Compiler::fgMorphArrayIndex(GenTreeIndex* tree)
 
     if (elemSize > 1)
     {
-        GenTree* size = gtNewIconNode(elemSize, TYP_I_IMPL);
-
-        // Fix 392756 WP7 Crossgen
-        //
-        // During codegen optGetArrayRefScaleAndIndex() makes the assumption that op2 of a GT_MUL node
-        // is a constant and is not capable of handling CSE'ing the elemSize constant into a lclvar.
-
-        // TODO-MIKE-Review: It's not clear what optGetArrayRefScaleAndIndex has to do with CSE. It's
-        // used to build address modes and of course that if the constant gets CSEd then address mode
-        // can't include the "constant". But was this a bug fix or a CQ fix? And why would the kind of
-        // constant that can participate in address modes get CSEd anyway?
-
-        size->SetDoNotCSE();
-
-        offset = gtNewOperNode(GT_MUL, TYP_I_IMPL, offset, size);
+        offset = gtNewOperNode(GT_MUL, TYP_I_IMPL, offset, gtNewIconNode(elemSize, TYP_I_IMPL));
     }
 
     // The element address is ADD(array, ADD(MUL(index, elemSize), dataOffs)). Compared to other possible

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -7159,28 +7159,20 @@ bool Compiler::optComputeLoopSideEffectsOfBlock(BasicBlock* blk)
                         tree->gtVNPair = tree->AsOp()->gtOp2->gtVNPair;
                         break;
 
-                    case GT_ADDR:
-                        // Is it an addr of a array index expression?
+                    case GT_ADD:
+                    {
+                        ArrayInfo arrInfo;
+                        if (optIsArrayElemAddr(tree, &arrInfo))
                         {
-                            GenTree* addrArg = tree->AsOp()->gtOp1;
-                            if (addrArg->OperGet() == GT_IND)
-                            {
-                                ArrayInfo arrInfo;
-
-                                // Is the LHS an array index expression?
-                                if (optIsArrayElemAddr(addrArg->AsIndir()->GetAddr(), &arrInfo))
-                                {
-                                    ValueNum elemTypeEqVN = vnStore->VNForTypeNum(arrInfo.m_elemTypeNum);
-                                    ValueNum ptrToArrElemVN =
-                                        vnStore->VNForFunc(TYP_BYREF, VNF_PtrToArrElem, elemTypeEqVN,
-                                                           // The rest are dummy arguments.
-                                                           vnStore->VNForNull(), vnStore->VNForNull(),
-                                                           vnStore->VNForNull());
-                                    tree->gtVNPair.SetBoth(ptrToArrElemVN);
-                                }
-                            }
+                            ValueNum elemTypeEqVN = vnStore->VNForTypeNum(arrInfo.m_elemTypeNum);
+                            ValueNum ptrToArrElemVN =
+                                vnStore->VNForFunc(TYP_BYREF, VNF_PtrToArrElem, elemTypeEqVN,
+                                                   // The rest are dummy arguments.
+                                                   vnStore->VNForNull(), vnStore->VNForNull(), vnStore->VNForNull());
+                            tree->gtVNPair.SetBoth(ptrToArrElemVN);
                         }
-                        break;
+                    }
+                    break;
 
                     case GT_LOCKADD:
                     case GT_XORR:

--- a/src/coreclr/jit/rationalize.h
+++ b/src/coreclr/jit/rationalize.h
@@ -37,7 +37,6 @@ private:
     void RewriteIntrinsicAsUserCall(GenTree** use, ArrayStack<GenTree*>& parents);
     void RewriteAssignment(LIR::Use& use);
     void RewriteLocalAssignment(GenTreeOp* assignment, GenTreeLclVarCommon* location);
-    void RewriteAddress(LIR::Use& use);
 
     // Root visitor
     Compiler::fgWalkResult RewriteNode(GenTree** useEdge, ArrayStack<GenTree*>& parents);

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -3900,7 +3900,14 @@ ValueNum ValueNumStore::ExtendPtrVN(GenTreeOp* add)
             }
 #endif
 
-            ValueNum fldSeqVN = VNForFieldSeq(arrInfo.m_elemOffsetConst->GetFieldSeq()->GetNext());
+            FieldSeqNode* fieldSeq = arrInfo.m_elemOffsetConst->GetFieldSeq()->GetNext();
+
+            if (FieldSeqNode* zeroFieldSeq = m_pComp->GetZeroOffsetFieldSeq(add))
+            {
+                fieldSeq = m_pComp->GetFieldSeqStore()->Append(fieldSeq, zeroFieldSeq);
+            }
+
+            ValueNum fldSeqVN = VNForFieldSeq(fieldSeq);
 
             return VNForFunc(TYP_BYREF, VNF_PtrToArrElem, elemTypeEqVN, arrVN, indexVN, fldSeqVN);
         }

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -7586,44 +7586,7 @@ void Compiler::fgValueNumberTree(GenTree* tree)
         }
         else if (oper == GT_ADDR)
         {
-            GenTree* arg = tree->AsUnOp()->GetOp(0);
-
-            if (arg->OperIs(GT_IND, GT_OBJ))
-            {
-                GenTree* addr = arg->AsIndir()->GetAddr();
-
-                // Usually the ADDR and IND just cancel out...
-                // except when this GT_ADDR has a valid zero-offset field sequence
-                FieldSeqNode* zeroOffsetFieldSeq = GetZeroOffsetFieldSeq(tree);
-
-                if ((zeroOffsetFieldSeq != nullptr) && (zeroOffsetFieldSeq != FieldSeqStore::NotAField()))
-                {
-                    ValueNum addrExtended = vnStore->ExtendPtrVN(addr, zeroOffsetFieldSeq);
-                    if (addrExtended != ValueNumStore::NoVN)
-                    {
-                        tree->gtVNPair.SetBoth(addrExtended); // We don't care about lib/cons differences for addresses.
-                    }
-                    else
-                    {
-                        // ExtendPtrVN returned a failure result
-                        // So give this address a new unique value
-                        tree->gtVNPair.SetBoth(vnStore->VNForExpr(compCurBB, TYP_BYREF));
-                    }
-                }
-                else
-                {
-                    // They just cancel, so fetch the ValueNumber from the op1 of the GT_IND node.
-                    tree->gtVNPair = addr->gtVNPair;
-
-                    // For the CSE phase mark the address as GTF_DONT_CSE
-                    // because it will end up with the same value number as tree (the GT_ADDR).
-                    addr->gtFlags |= GTF_DONT_CSE;
-                }
-            }
-            else
-            {
-                tree->gtVNPair.SetBoth(vnStore->VNForExpr(compCurBB, tree->GetType()));
-            }
+            unreached();
         }
         else if ((oper == GT_IND) || GenTree::OperIsBlk(oper))
         {

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -3972,7 +3972,8 @@ ValueNum ValueNumStore::ExtractArrayElementIndex(const ArrayInfo& arrayInfo)
 
         // TODO-MIKE-Cleanup: Would be good to actually retrieve the field offset
         // from the field sequence but that currently requires calling the VM.
-        // Anyway, this path is pretty much never hit due to GTF_IND_ARR_INDEX.
+        // Anyway, this path is pretty much never hit due to the COMMA added by
+        // fgMorphArrayIndex.
 
         offset -= fieldOffset;
         assert(offset % elemSize == 0);


### PR DESCRIPTION
win-x64 diff:
```
Total bytes of base: 31505917
Total bytes of diff: 31505977
Total bytes of delta: 60 (0.00 % of base)
    diff is a regression.

Top file regressions (bytes):
          72 : System.Data.Common.dasm (0.01% of base)
          51 : System.Private.Xml.dasm (0.00% of base)
           2 : System.Net.Sockets.dasm (0.00% of base)
           2 : System.Private.CoreLib.dasm (0.00% of base)

Top file improvements (bytes):
         -27 : System.Runtime.Caching.dasm (-0.05% of base)
         -24 : Microsoft.CSharp.dasm (-0.01% of base)
         -12 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
          -3 : System.Reflection.Metadata.dasm (-0.00% of base)
          -1 : System.Linq.Expressions.dasm (-0.00% of base)

9 total files with Code Size differences (5 improved, 4 regressed), 261 unchanged.

Top method regressions (bytes):
          44 (42.31% of base) : System.Private.Xml.dasm - OutputScopeManager:LookupNamespace(String):String:this
          31 ( 3.43% of base) : System.Runtime.Caching.dasm - UsageBucket:UpdateCacheEntry(MemoryCacheEntry):this
          19 ( 0.68% of base) : System.Data.Common.dasm - SqlByteStorage:Aggregate(ref,int):Object:this
          19 ( 0.69% of base) : System.Data.Common.dasm - SqlInt16Storage:Aggregate(ref,int):Object:this
          19 ( 0.69% of base) : System.Data.Common.dasm - SqlInt32Storage:Aggregate(ref,int):Object:this
          15 ( 6.10% of base) : System.Runtime.Caching.dasm - ExpiresBucket:RemoveCacheEntryNoLock(MemoryCacheEntry):this
          11 ( 0.37% of base) : System.Data.Common.dasm - SqlSingleStorage:Aggregate(ref,int):Object:this
          10 ( 4.57% of base) : System.Runtime.Caching.dasm - UsageBucket:AddUsageEntryToFreeList(UsageEntryRef):this
          10 ( 1.35% of base) : System.Private.Xml.dasm - XmlWellFormedWriter:.ctor(XmlWriter,XmlWriterSettings):this
           4 ( 0.09% of base) : System.Data.Common.dasm - DbDataAdapter:Update(ref,DataTableMapping):int:this
           2 ( 0.24% of base) : System.Private.CoreLib.dasm - RuntimeType:ForwardCallToInvokeMember(String,int,Object,ref,ref,ref,ref,Type):Object:this
           1 ( 0.06% of base) : System.Runtime.Caching.dasm - ExpiresBucket:FlushExpiredItems(DateTime,bool):int:this
           1 ( 0.09% of base) : System.Net.Sockets.dasm - SocketPal:Receive(SafeSocketHandle,IList`1,int,byref):int
           1 ( 0.08% of base) : System.Net.Sockets.dasm - SocketPal:Send(SafeSocketHandle,IList`1,int,byref):int

Top method improvements (bytes):
         -39 (-2.91% of base) : System.Runtime.Caching.dasm - UsageBucket:Reduce():this
         -32 (-4.40% of base) : System.Runtime.Caching.dasm - ExpiresBucket:Reduce():this
         -14 (-3.90% of base) : Microsoft.CSharp.dasm - RuntimeBinder:BindAssignment(ICSharpBinder,ref,ref):Expr:this
          -8 (-0.49% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - ETWTraceEventSource:InitializeFiles():this
          -6 (-1.70% of base) : Microsoft.CSharp.dasm - RuntimeBinder:CreateCallingObjectForCall(ICSharpInvokeOrInvokeMemberBinder,ref,ref):Expr:this
          -6 (-0.69% of base) : System.Runtime.Caching.dasm - UsageBucket:AddCacheEntry(MemoryCacheEntry):this
          -4 (-4.94% of base) : Microsoft.CSharp.dasm - CSharpIsEventBinder:PopulateSymbolTableWithName(Type,ref):this
          -4 (-1.15% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - ETWTraceEventSource:Initialize(String,int):this
          -4 (-2.86% of base) : System.Runtime.Caching.dasm - ExpiresBucket:GetFreeExpiresEntry():ExpiresEntryRef:this
          -3 (-1.80% of base) : System.Reflection.Metadata.dasm - PEHeaders:GetContainingSectionIndex(int):int:this
          -3 (-2.48% of base) : System.Runtime.Caching.dasm - UsageBucket:GetFreeUsageEntry():UsageEntryRef:this
          -1 (-0.78% of base) : System.Private.Xml.dasm - CompilerScopeManager`1:.ctor():this
          -1 (-0.78% of base) : System.Private.Xml.dasm - CompilerScopeManager`1:.ctor(KeywordsTable):this
          -1 (-0.09% of base) : System.Linq.Expressions.dasm - LambdaCompiler:EmitSwitchExpression(Expression,int):this
          -1 (-0.61% of base) : System.Private.Xml.dasm - XmlSqlBinaryReader:AddInitNamespace(String,String):this

Top method regressions (percentages):
          44 (42.31% of base) : System.Private.Xml.dasm - OutputScopeManager:LookupNamespace(String):String:this
          15 ( 6.10% of base) : System.Runtime.Caching.dasm - ExpiresBucket:RemoveCacheEntryNoLock(MemoryCacheEntry):this
          10 ( 4.57% of base) : System.Runtime.Caching.dasm - UsageBucket:AddUsageEntryToFreeList(UsageEntryRef):this
          31 ( 3.43% of base) : System.Runtime.Caching.dasm - UsageBucket:UpdateCacheEntry(MemoryCacheEntry):this
          10 ( 1.35% of base) : System.Private.Xml.dasm - XmlWellFormedWriter:.ctor(XmlWriter,XmlWriterSettings):this
          19 ( 0.69% of base) : System.Data.Common.dasm - SqlInt32Storage:Aggregate(ref,int):Object:this
          19 ( 0.69% of base) : System.Data.Common.dasm - SqlInt16Storage:Aggregate(ref,int):Object:this
          19 ( 0.68% of base) : System.Data.Common.dasm - SqlByteStorage:Aggregate(ref,int):Object:this
          11 ( 0.37% of base) : System.Data.Common.dasm - SqlSingleStorage:Aggregate(ref,int):Object:this
           2 ( 0.24% of base) : System.Private.CoreLib.dasm - RuntimeType:ForwardCallToInvokeMember(String,int,Object,ref,ref,ref,ref,Type):Object:this
           4 ( 0.09% of base) : System.Data.Common.dasm - DbDataAdapter:Update(ref,DataTableMapping):int:this
           1 ( 0.09% of base) : System.Net.Sockets.dasm - SocketPal:Receive(SafeSocketHandle,IList`1,int,byref):int
           1 ( 0.08% of base) : System.Net.Sockets.dasm - SocketPal:Send(SafeSocketHandle,IList`1,int,byref):int
           1 ( 0.06% of base) : System.Runtime.Caching.dasm - ExpiresBucket:FlushExpiredItems(DateTime,bool):int:this

Top method improvements (percentages):
          -4 (-4.94% of base) : Microsoft.CSharp.dasm - CSharpIsEventBinder:PopulateSymbolTableWithName(Type,ref):this
         -32 (-4.40% of base) : System.Runtime.Caching.dasm - ExpiresBucket:Reduce():this
         -14 (-3.90% of base) : Microsoft.CSharp.dasm - RuntimeBinder:BindAssignment(ICSharpBinder,ref,ref):Expr:this
         -39 (-2.91% of base) : System.Runtime.Caching.dasm - UsageBucket:Reduce():this
          -4 (-2.86% of base) : System.Runtime.Caching.dasm - ExpiresBucket:GetFreeExpiresEntry():ExpiresEntryRef:this
          -3 (-2.48% of base) : System.Runtime.Caching.dasm - UsageBucket:GetFreeUsageEntry():UsageEntryRef:this
          -3 (-1.80% of base) : System.Reflection.Metadata.dasm - PEHeaders:GetContainingSectionIndex(int):int:this
          -6 (-1.70% of base) : Microsoft.CSharp.dasm - RuntimeBinder:CreateCallingObjectForCall(ICSharpInvokeOrInvokeMemberBinder,ref,ref):Expr:this
          -4 (-1.15% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - ETWTraceEventSource:Initialize(String,int):this
          -1 (-0.78% of base) : System.Private.Xml.dasm - CompilerScopeManager`1:.ctor(KeywordsTable):this
          -1 (-0.78% of base) : System.Private.Xml.dasm - CompilerScopeManager`1:.ctor():this
          -6 (-0.69% of base) : System.Runtime.Caching.dasm - UsageBucket:AddCacheEntry(MemoryCacheEntry):this
          -1 (-0.61% of base) : System.Private.Xml.dasm - XmlSqlBinaryReader:AddInitNamespace(String,String):this
          -8 (-0.49% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - ETWTraceEventSource:InitializeFiles():this
          -1 (-0.09% of base) : System.Linq.Expressions.dasm - LambdaCompiler:EmitSwitchExpression(Expression,int):this

29 total methods with Code Size differences (15 improved, 14 regressed), 192788 unchanged.
```
Diffs due to changes in tree costs and/or address mode marking that lead to CSE related changes.