### PR TITLE
Sink promoted field offset

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -9151,10 +9151,10 @@ GenTree* Compiler::fgMorphCopyStruct(GenTreeOp* asg)
                 }
             }
 
-            if (gtClone(addr) != nullptr)
+            if (addr->OperIs(GT_LCL_VAR) && !lvaGetDesc(addr->AsLclVar())->lvDoNotEnregister)
             {
-                // addr is a simple expression, no need to spill.
-                noway_assert((addr->gtFlags & GTF_PERSISTENT_SIDE_EFFECTS) == 0);
+                // TODO-MIKE-Review: What if the address is a promoted destination field?
+                assert(addr->GetSideEffects() == 0);
             }
             else
             {
@@ -9195,9 +9195,7 @@ GenTree* Compiler::fgMorphCopyStruct(GenTreeOp* asg)
             }
             else
             {
-                fieldAddr = (i == 0) ? addr : gtClone(addr);
-
-                noway_assert(fieldAddr != nullptr);
+                fieldAddr = (i == 0) ? addr : gtNewLclvNode(addr->AsLclVar()->GetLclNum(), addr->GetType());
             }
 
             if (addrOffset != 0)

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -9110,6 +9110,11 @@ GenTree* Compiler::fgMorphCopyStruct(GenTreeOp* asg)
 
         if (promotedLcl->GetPromotedFieldCount() > 1)
         {
+            // TODO-MIKE-CQ: This doesn't handle the array case. The array data offset (or the entire
+            // element offset if the index is constant) is hidden under a COMMA and another ADD. We
+            // could try to extract the offset from that tree but then optIsArrayElemAddr will have
+            // a difficult time recovering array element information.
+
             if (addr->OperIs(GT_ADD) && !addr->gtOverflow())
             {
                 if (GenTreeIntCon* offset = addr->AsOp()->GetOp(1)->IsIntCon())

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -9173,9 +9173,9 @@ GenTree* Compiler::fgMorphCopyStruct(GenTreeOp* asg)
             }
             else
             {
-                addrSpillLclNum = lvaNewTemp(TYP_BYREF, true DEBUGARG("BlockOp address local"));
+                addrSpillLclNum = lvaNewTemp(addr->GetType(), true DEBUGARG("promoted struct address"));
                 promotedLcl     = lvaGetDesc(promotedLclNum);
-                addrAssign      = gtNewAssignNode(gtNewLclvNode(addrSpillLclNum, TYP_BYREF), addr);
+                addrAssign      = gtNewAssignNode(gtNewLclvNode(addrSpillLclNum, addr->GetType()), addr);
             }
         }
 
@@ -9193,7 +9193,7 @@ GenTree* Compiler::fgMorphCopyStruct(GenTreeOp* asg)
 
             if (addrSpillLclNum != BAD_VAR_NUM)
             {
-                fieldAddr = gtNewLclvNode(addrSpillLclNum, TYP_BYREF);
+                fieldAddr = gtNewLclvNode(addrSpillLclNum, addr->GetType());
             }
             else
             {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -9158,17 +9158,8 @@ GenTree* Compiler::fgMorphCopyStruct(GenTreeOp* asg)
             }
             else
             {
-                // addr is a complex expression and we need to use it multiple times, spill it.
-
-                // A part of the address tree was already morphed and we're morphing
-                // it again, GTF_DEBUG_NODE_MORPHED seems pretty useless...
-                INDEBUG(fgMorphClearDebugNodeMorphed(addr);)
-
                 // We'll introduce a new temp, that may invalidate promotedLcl so we need the number.
                 unsigned promotedLclNum = static_cast<unsigned>(promotedLcl - lvaTable);
-
-                // Simplify the address if possible, and mark as DONT_CSE as needed.
-                addr = fgMorphTree(addr);
 
                 addrSpillLclNum = lvaNewTemp(TYP_BYREF, true DEBUGARG("BlockOp address local"));
                 addrAssign      = gtNewAssignNode(gtNewLclvNode(addrSpillLclNum, TYP_BYREF), addr);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -9119,7 +9119,17 @@ GenTree* Compiler::fgMorphCopyStruct(GenTreeOp* asg)
             {
                 if (GenTreeIntCon* offset = addr->AsOp()->GetOp(1)->IsIntCon())
                 {
-                    if ((offset->GetValue() > 0) && (offset->GetValue() <= INT32_MAX))
+#ifdef TARGET_XARCH
+                    unsigned maxOffset = INT32_MAX;
+#else
+                    unsigned maxOffset = 4095;
+#endif
+                    // The maximum offset depends on the last promoted field offset, not the struct
+                    // size. But such cases are so rare that it's not worth the trouble to get the
+                    // last field offset.
+                    maxOffset -= promotedLcl->GetSize();
+
+                    if ((offset->GetValue() > 0) && (offset->GetValue() <= maxOffset))
                     {
                         addrOffset   = offset->GetUInt32Value();
                         addrFieldSeq = offset->GetFieldSeq();

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -3918,7 +3918,7 @@ ValueNum ValueNumStore::ExtendPtrVN(GenTreeOp* add)
         FieldSeqNode* fldSeq = intCon->GetFieldSeq();
         if ((fldSeq != nullptr) && !fldSeq->IsArrayElement())
         {
-            return ExtendPtrVN(add->GetOp(0)->gtVNPair, fldSeq, intCon->GetValue());
+            return ExtendPtrVN(add->GetOp(0)->gtVNPair, fldSeq, static_cast<target_size_t>(intCon->GetValue()));
         }
     }
 


### PR DESCRIPTION
win-x64 diff:
```
Total bytes of base: 31497186
Total bytes of diff: 31489475
Total bytes of delta: -7711 (-0.02 % of base)
    diff is an improvement.

Top file regressions (bytes):
          39 : xunit.performance.core.dasm (1.24% of base)
          18 : System.Diagnostics.Process.dasm (0.03% of base)
           1 : System.Data.Odbc.dasm (0.00% of base)

Top file improvements (bytes):
       -1103 : System.Private.Xml.dasm (-0.04% of base)
        -780 : System.Memory.dasm (-0.95% of base)
        -775 : System.Linq.Expressions.dasm (-0.03% of base)
        -702 : System.Reflection.Metadata.dasm (-0.22% of base)
        -467 : Microsoft.CodeAnalysis.dasm (-0.06% of base)
        -434 : Newtonsoft.Json.dasm (-0.07% of base)
        -356 : System.Data.Common.dasm (-0.03% of base)
        -335 : System.Text.Json.dasm (-0.06% of base)
        -252 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.01% of base)
        -238 : System.Net.Http.dasm (-0.04% of base)
        -207 : System.Formats.Asn1.dasm (-0.33% of base)
        -194 : System.Private.CoreLib.dasm (-0.01% of base)
        -155 : xunit.runner.utility.netcoreapp10.dasm (-0.11% of base)
        -135 : System.Linq.Parallel.dasm (-0.02% of base)
        -105 : xunit.console.dasm (-0.16% of base)
         -95 : System.Private.DataContractSerialization.dasm (-0.01% of base)
         -85 : System.Transactions.Local.dasm (-0.09% of base)
         -85 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00% of base)
         -71 : System.Formats.Cbor.dasm (-0.18% of base)
         -69 : System.Collections.Immutable.dasm (-0.03% of base)

86 total files with Code Size differences (83 improved, 3 regressed), 184 unchanged.

Top method regressions (bytes):
          78 ( 2.61% of base) : Newtonsoft.Json.dasm - JsonTextReader:ParseReadNumber(int,ushort,int):this
          57 ( 5.57% of base) : System.Reflection.Metadata.dasm - MetadataReaderExtensions:GetTableMetadataBlock(MetadataReader,ubyte):MemoryBlock
          39 ( 9.68% of base) : xunit.performance.core.dasm - Benchmark:Iterate(Action)
          20 ( 1.47% of base) : System.Data.Common.dasm - Select:CreateIndex():this
          18 ( 2.39% of base) : Newtonsoft.Json.dasm - DefaultContractResolver:CreatePropertyFromConstructorParameter(JsonProperty,ParameterInfo):JsonProperty:this
          16 ( 4.68% of base) : Newtonsoft.Json.dasm - JsonObjectContract:get_HasRequiredOrDefaultValueProperties():bool:this
          15 ( 0.19% of base) : System.Data.Common.dasm - XmlTreeGen:SchemaTree(XmlDocument,XmlWriter,DataSet,DataTable,bool):this
          14 ( 6.42% of base) : System.Net.Http.dasm - DynamicTable:Insert(ReadOnlySpan`1,ReadOnlySpan`1):this
          13 (20.63% of base) : System.Diagnostics.Process.dasm - ProcessThread:get_PriorityBoostEnabled():bool:this
          13 (22.41% of base) : System.Diagnostics.Process.dasm - ProcessThread:get_PriorityLevel():int:this
          13 ( 0.84% of base) : System.Text.Json.dasm - Utf8JsonReader:CheckLiteralMultiSegment(ReadOnlySpan`1,ReadOnlySpan`1,byref):bool:this
          11 ( 1.01% of base) : System.Private.Xml.dasm - QilGenerator:.ctor(bool):this
          10 ( 2.86% of base) : System.Private.CoreLib.dasm - __DTString:RemoveTrailingInQuoteSpaces():this
          10 ( 2.12% of base) : System.Net.HttpListener.dasm - HttpListenerRequest:get_KeepAlive():bool:this
          10 ( 0.69% of base) : System.Memory.dasm - SequenceReader`1:IsNextSlow(ReadOnlySpan`1,bool):bool:this (2 methods)
           9 ( 5.52% of base) : System.Security.Cryptography.Cng.dasm - CngProperty:GetHashCode():int:this
           9 ( 0.76% of base) : xunit.execution.dotnet.dasm - ExecutionErrorTestCaseRunner:RunTestAsync():Task`1:this
           9 ( 0.68% of base) : Microsoft.CodeAnalysis.dasm - FullMetadataWriter:.ctor(EmitContext,MetadataHeapsBuilder,MetadataHeapsBuilder,CommonMessageProvider,bool,bool,CancellationToken):this
           8 ( 1.30% of base) : System.DirectoryServices.AccountManagement.dasm - GroupPrincipal:IsSmallGroup():bool:this
           7 ( 1.89% of base) : System.Net.Http.dasm - HttpHeaderValueCollection`1:CopyTo(ref,int):this

Top method improvements (bytes):
        -630 (-0.06% of base) : System.Linq.Expressions.dasm - FuncCallInstruction`3:Run(InterpretedFrame):int:this (3375 methods)
        -105 (-0.54% of base) : Microsoft.CodeAnalysis.dasm - AttributeDescription:.cctor()
        -101 (-2.14% of base) : System.Reflection.Metadata.dasm - PEBuilder:WritePEHeader(BlobBuilder,PEDirectoriesBuilder,ImmutableArray`1):this
        -101 (-7.79% of base) : System.Memory.dasm - SequenceReaderExtensions:TryReadMultisegment(byref,byref):bool (4 methods)
         -75 (-0.12% of base) : System.Linq.Expressions.dasm - ActionCallInstruction`2:Run(InterpretedFrame):int:this (225 methods)
         -73 (-6.95% of base) : System.Memory.dasm - SequenceReader`1:GetNextSpan():this (2 methods)
         -69 (-3.08% of base) : System.Linq.Parallel.dasm - ScanQueryOperator`1:Open(QuerySettings,bool):QueryResults`1:this (11 methods)
         -68 (-0.34% of base) : System.Text.Json.dasm - JsonConverter`1:TryRead(byref,Type,JsonSerializerOptions,byref,byref):bool:this (20 methods)
         -60 (-26.67% of base) : System.Private.CoreLib.dasm - TaskAsyncResult:.ctor(Task,Object,AsyncCallback):this
         -46 (-2.32% of base) : xunit.console.dasm - ConsoleRunner:RunProject(XunitProject,bool,Nullable`1,Nullable`1,Nullable`1,bool,bool,Nullable`1,bool,bool,bool):int:this
         -45 (-12.30% of base) : System.Memory.dasm - SequenceReader`1:AdvancePastAny(__Canon,__Canon,__Canon,__Canon):long:this
         -43 (-0.68% of base) : Newtonsoft.Json.dasm - JToken:op_Explicit(JToken):Nullable`1 (17 methods)
         -42 (-15.85% of base) : System.Formats.Asn1.dasm - Asn1Tag:.cctor()
         -42 (-0.89% of base) : xunit.console.dasm - CommandLine:Parse(Predicate`1):XunitProject:this
         -41 (-2.66% of base) : xunit.runner.utility.netcoreapp10.dasm - ConfigReader_Json:Load(Stream):TestAssemblyConfiguration
         -40 (-2.80% of base) : System.Memory.dasm - SequenceReader`1:TryReadTo(byref,ubyte,ubyte,bool):bool:this (2 methods)
         -39 (-5.05% of base) : System.Linq.Parallel.dasm - QuerySettings:Merge(QuerySettings):QuerySettings:this
         -38 (-4.13% of base) : System.Transactions.Local.dasm - InternalEnlistment:get_EnlistmentTraceId():EnlistmentTraceIdentifier:this
         -38 (-1.74% of base) : System.Memory.dasm - SequenceReader`1:TryReadTo(byref,ReadOnlySpan`1,bool):bool:this (4 methods)
         -37 (-4.25% of base) : System.Private.Xml.dasm - QilScopedVisitor:AfterVisit(QilNode):this

Top method regressions (percentages):
          13 (22.41% of base) : System.Diagnostics.Process.dasm - ProcessThread:get_PriorityLevel():int:this
          13 (20.63% of base) : System.Diagnostics.Process.dasm - ProcessThread:get_PriorityBoostEnabled():bool:this
          39 ( 9.68% of base) : xunit.performance.core.dasm - Benchmark:Iterate(Action)
          14 ( 6.42% of base) : System.Net.Http.dasm - DynamicTable:Insert(ReadOnlySpan`1,ReadOnlySpan`1):this
          57 ( 5.57% of base) : System.Reflection.Metadata.dasm - MetadataReaderExtensions:GetTableMetadataBlock(MetadataReader,ubyte):MemoryBlock
           9 ( 5.52% of base) : System.Security.Cryptography.Cng.dasm - CngProperty:GetHashCode():int:this
          16 ( 4.68% of base) : Newtonsoft.Json.dasm - JsonObjectContract:get_HasRequiredOrDefaultValueProperties():bool:this
           4 ( 3.48% of base) : Microsoft.CSharp.dasm - AggregateSymbol:HasConversion():bool:this
           5 ( 3.40% of base) : System.Private.CoreLib.dasm - __DTString:TrimTail():this
           5 ( 3.38% of base) : System.Reflection.Metadata.dasm - MetadataReaderExtensions:GetMetadataBlock(MetadataReader,int):MemoryBlock
           3 ( 3.30% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - CtfEvent:get_IsPacked():bool:this
           5 ( 3.21% of base) : System.Data.Common.dasm - DbProviderFactory:get_CanCreateCommandBuilder():bool:this
           5 ( 3.21% of base) : System.Data.Common.dasm - DbProviderFactory:get_CanCreateDataAdapter():bool:this
          10 ( 2.86% of base) : System.Private.CoreLib.dasm - __DTString:RemoveTrailingInQuoteSpaces():this
          78 ( 2.61% of base) : Newtonsoft.Json.dasm - JsonTextReader:ParseReadNumber(int,ushort,int):this
          18 ( 2.39% of base) : Newtonsoft.Json.dasm - DefaultContractResolver:CreatePropertyFromConstructorParameter(JsonProperty,ParameterInfo):JsonProperty:this
           2 ( 2.35% of base) : Microsoft.CodeAnalysis.CSharp.dasm - OverloadResolution:get_Strict():bool:this
           6 ( 2.29% of base) : System.Data.Common.dasm - SqlConvert:ConvertToSqlDateTime(Object):SqlDateTime
          10 ( 2.12% of base) : System.Net.HttpListener.dasm - HttpListenerRequest:get_KeepAlive():bool:this
           7 ( 1.89% of base) : System.Net.Http.dasm - HttpHeaderValueCollection`1:CopyTo(ref,int):this

Top method improvements (percentages):
          -3 (-30.00% of base) : Microsoft.CodeAnalysis.dasm - SubText:get_Length():int:this
          -3 (-27.27% of base) : Microsoft.Extensions.FileProviders.Physical.dasm - PhysicalFileProvider:set_UseActivePolling(bool):this
         -60 (-26.67% of base) : System.Private.CoreLib.dasm - TaskAsyncResult:.ctor(Task,Object,AsyncCallback):this
          -3 (-21.43% of base) : System.Composition.Convention.dasm - ImportConventionBuilder:AsMany(bool):ImportConventionBuilder:this
          -4 (-21.05% of base) : System.ComponentModel.Annotations.dasm - DisplayAttribute:set_AutoGenerateField(bool):this
          -4 (-21.05% of base) : System.ComponentModel.Annotations.dasm - DisplayAttribute:set_AutoGenerateFilter(bool):this
          -4 (-21.05% of base) : System.ComponentModel.Annotations.dasm - DisplayAttribute:set_Order(int):this
          -4 (-21.05% of base) : Microsoft.CodeAnalysis.dasm - FullMetadataWriter:GetEventDefs():IReadOnlyList`1:this
          -4 (-21.05% of base) : Microsoft.CodeAnalysis.dasm - FullMetadataWriter:GetFieldDefs():IReadOnlyList`1:this
          -4 (-21.05% of base) : Microsoft.CodeAnalysis.dasm - FullMetadataWriter:GetTypeDefs():IReadOnlyList`1:this
          -4 (-21.05% of base) : Newtonsoft.Json.dasm - JsonContainerAttribute:set_IsReference(bool):this
          -4 (-21.05% of base) : Newtonsoft.Json.dasm - JsonContainerAttribute:set_ItemIsReference(bool):this
          -4 (-21.05% of base) : Newtonsoft.Json.dasm - JsonContainerAttribute:set_ItemReferenceLoopHandling(int):this
          -4 (-21.05% of base) : Newtonsoft.Json.dasm - JsonContainerAttribute:set_ItemTypeNameHandling(int):this
          -4 (-21.05% of base) : Newtonsoft.Json.dasm - JsonObjectAttribute:set_ItemNullValueHandling(int):this
          -4 (-21.05% of base) : Newtonsoft.Json.dasm - JsonObjectAttribute:set_ItemRequired(int):this
          -4 (-21.05% of base) : Newtonsoft.Json.dasm - JsonPropertyAttribute:set_DefaultValueHandling(int):this
          -4 (-21.05% of base) : Newtonsoft.Json.dasm - JsonPropertyAttribute:set_IsReference(bool):this
          -4 (-21.05% of base) : Newtonsoft.Json.dasm - JsonPropertyAttribute:set_ItemIsReference(bool):this
          -4 (-21.05% of base) : Newtonsoft.Json.dasm - JsonPropertyAttribute:set_ItemReferenceLoopHandling(int):this

1195 total methods with Code Size differences (1132 improved, 63 regressed), 191622 unchanged.
```
Regressions usually caused by larger instruction encoding due to address modes. Some extra CSEs due to adding missing field sequences.

win-x64 pmi diff:
```
Total bytes of base: 50776820
Total bytes of diff: 50741136
Total bytes of delta: -35684 (-0.07 % of base)
    diff is an improvement.

Top file regressions (bytes):
          37 : xunit.performance.core.dasm (0.98% of base)

Top file improvements (bytes):
       -6191 : FSharp.Core.dasm (-0.17% of base)
       -6073 : System.Memory.dasm (-2.29% of base)
       -2438 : Microsoft.CodeAnalysis.dasm (-0.14% of base)
       -1520 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.03% of base)
       -1489 : CommandLine.dasm (-0.30% of base)
       -1235 : System.Private.Xml.dasm (-0.04% of base)
       -1173 : Microsoft.CodeAnalysis.CSharp.dasm (-0.03% of base)
       -1015 : System.Text.Json.dasm (-0.13% of base)
        -812 : System.Reflection.Metadata.dasm (-0.19% of base)
        -773 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.02% of base)
        -760 : System.Numerics.Tensors.dasm (-0.28% of base)
        -707 : System.Net.Http.dasm (-0.10% of base)
        -666 : System.Collections.Immutable.dasm (-0.05% of base)
        -623 : System.Collections.dasm (-0.11% of base)
        -619 : Newtonsoft.Json.dasm (-0.07% of base)
        -552 : System.Security.Cryptography.Pkcs.dasm (-0.14% of base)
        -544 : System.Linq.Parallel.dasm (-0.03% of base)
        -511 : System.Private.CoreLib.dasm (-0.02% of base)
        -340 : System.Linq.dasm (-0.03% of base)
        -319 : System.Security.Cryptography.Cng.dasm (-0.19% of base)

129 total files with Code Size differences (128 improved, 1 regressed), 141 unchanged.

Top method regressions (bytes):
         195 ( 3.14% of base) : System.Threading.Tasks.Dataflow.dasm - BatchBlockTargetCore:ConsumeReservedMessagesGreedyBounded():this (8 methods)
         120 ( 3.57% of base) : System.Data.Common.dasm - SqlMoneyStorage:Aggregate(ref,int):Object:this
          83 ( 3.01% of base) : System.Data.Common.dasm - SqlInt32Storage:Aggregate(ref,int):Object:this
          70 ( 2.05% of base) : Newtonsoft.Json.dasm - JsonTextReader:ParseReadNumber(int,ushort,int):this
          57 ( 5.47% of base) : System.Reflection.Metadata.dasm - MetadataReaderExtensions:GetTableMetadataBlock(MetadataReader,ubyte):MemoryBlock
          44 ( 2.68% of base) : Microsoft.CodeAnalysis.dasm - ChangedText:GetLinesCore():TextLineCollection:this
          42 ( 1.15% of base) : System.Private.Xml.dasm - <ParseAttributesAsync>d__531:MoveNext():this
          37 ( 8.45% of base) : xunit.performance.core.dasm - Benchmark:Iterate(Action)
          37 ( 3.00% of base) : System.Private.Xml.dasm - QilScopedVisitor:AfterVisit(QilNode):this
          37 ( 3.00% of base) : System.Private.Xml.dasm - QilScopedVisitor:BeforeVisit(QilNode):this
          33 ( 2.39% of base) : Newtonsoft.Json.dasm - JsonSerializer:SerializeInternal(JsonWriter,Object,Type):this
          26 ( 0.62% of base) : Microsoft.CodeAnalysis.dasm - MetadataWriter:SerializeTypeReference(ITypeReference,BlobBuilder,bool,bool):this
          21 ( 0.63% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindFieldAndPropertyInitializers(SourceMemberContainerTypeSymbol,ImmutableArray`1,SynthesizedInteractiveInitializerMethod,DiagnosticBag):ImmutableArray`1
          21 ( 1.60% of base) : System.Data.Common.dasm - Select:CreateIndex():this
          20 ( 1.05% of base) : Microsoft.CodeAnalysis.CSharp.dasm - <Microsoft-Cci-ITypeDefinition-GetExplicitImplementationOverrides>d__31:MoveNext():bool:this
          19 ( 0.56% of base) : System.ComponentModel.TypeConverter.dasm - ColorConverter:ConvertTo(ITypeDescriptorContext,CultureInfo,Object,Type):Object:this
          18 ( 3.31% of base) : System.Private.Xml.dasm - AllElementsContentValidator:ExpectedElements(ValidationState,bool):ArrayList:this
          18 ( 2.41% of base) : Newtonsoft.Json.dasm - DefaultContractResolver:CreatePropertyFromConstructorParameter(JsonProperty,ParameterInfo):JsonProperty:this
          17 ( 1.47% of base) : Newtonsoft.Json.dasm - ConvertUtils:ToBigInteger(Object):BigInteger
          17 (14.41% of base) : System.Private.CoreLib.dasm - Environment:GetUserName(byref)

Top method improvements (bytes):
        -690 (-15.18% of base) : System.Memory.dasm - SequenceReader`1:GetNextSpan():this (6 methods)
        -543 (-11.24% of base) : System.Memory.dasm - SequenceReader`1:TryCopyMultisegment(Span`1):bool:this (6 methods)
        -413 (-14.82% of base) : Microsoft.CodeAnalysis.dasm - SmallDictionary`2:.ctor(SmallDictionary`2,IEqualityComparer`1):this (8 methods)
        -381 (-2.35% of base) : System.Numerics.Tensors.dasm - CompressedSparseTensor`1:EnsureCapacity(int,int):this (8 methods)
        -370 (-6.86% of base) : System.Memory.dasm - SequenceReader`1:IsNextSlow(ReadOnlySpan`1,bool):bool:this (6 methods)
        -204 (-3.58% of base) : System.Security.Cryptography.X509Certificates.dasm - TbsCertificateAsn:DecodeCore(byref,Asn1Tag,ReadOnlyMemory`1,byref)
        -198 (-1.11% of base) : System.Text.Json.dasm - JsonValue`1:TryConvertJsonElement(byref):bool:this (64 methods)
        -192 (-4.58% of base) : System.Memory.dasm - SequenceReader`1:ResetReader():this (6 methods)
        -191 (-3.32% of base) : System.Memory.dasm - SequenceReader`1:TryReadTo(byref,ReadOnlySpan`1,bool):bool:this (12 methods)
        -182 (-6.40% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - <get_Entries>d__4:MoveNext():bool:this (8 methods)
        -170 (-3.90% of base) : FSharp.Core.dasm - MapTreeModule:spliceOutSuccessor(MapTree`2):Tuple`3 (8 methods)
        -165 (-4.62% of base) : FSharp.Core.dasm - callback@1546:Invoke(IAsyncResult):this (8 methods)
        -137 (-3.24% of base) : System.Collections.Immutable.dasm - Node:CopyTo(Array,int,int):this (8 methods)
        -136 (-4.25% of base) : System.Memory.dasm - <>c:<ToString>b__33_0(Span`1,ReadOnlySequence`1):this (8 methods)
        -136 (-2.93% of base) : System.Memory.dasm - SequenceReader`1:TryPeek(long,byref):bool:this (6 methods)
        -121 (-2.94% of base) : System.Security.Cryptography.Pkcs.dasm - Rfc3161TstInfo:DecodeCore(byref,Asn1Tag,ReadOnlyMemory`1,byref)
        -120 (-1.11% of base) : System.Collections.dasm - Enumerator:System.Collections.IEnumerator.get_Current():Object:this (72 methods)
        -118 (-1.88% of base) : Newtonsoft.Json.dasm - <ExecuteFilter>d__4:MoveNext():bool:this (8 methods)
        -116 (-7.30% of base) : System.Threading.Tasks.Dataflow.dasm - <>c:<ProcessMessageWithTask>b__11_0(Task`1,Object):this (16 methods)
        -112 (-8.75% of base) : FSharp.Core.dasm - Display:unpackCons(ref):Tuple`2 (8 methods)

Top method regressions (percentages):
          17 (14.41% of base) : System.Private.CoreLib.dasm - Environment:GetUserName(byref)
           6 (11.76% of base) : System.Diagnostics.Process.dasm - ProcessThread:get_PriorityLevel():int:this
           6 (11.54% of base) : System.Diagnostics.Process.dasm - ProcessThread:get_PriorityBoostEnabled():bool:this
           9 (10.84% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - KernelTraceEventParserState:get_diskEventTimeStamp():GrowableArray`1:this
          37 ( 8.45% of base) : xunit.performance.core.dasm - Benchmark:Iterate(Action)
           7 ( 8.43% of base) : System.IO.Pipelines.dasm - Pipe:AdvanceCore(int):this
          15 ( 6.38% of base) : System.Linq.Expressions.dasm - ReadOnlyCollectionBuilder`1:Contains(Nullable`1):bool:this
           4 ( 6.35% of base) : System.Speech.dasm - RecognitionResult:get_AudioDuration():TimeSpan:this
           4 ( 6.35% of base) : System.Speech.dasm - RecognitionResult:get_AudioPosition():TimeSpan:this
           4 ( 5.63% of base) : System.IO.Compression.dasm - ZipArchiveEntry:.ctor(ZipArchive,String,int):this
           2 ( 5.56% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - PENamedTypeSymbol:.ctor(PEModuleSymbol,PENamedTypeSymbol,TypeDefinitionHandle):this
          57 ( 5.47% of base) : System.Reflection.Metadata.dasm - MetadataReaderExtensions:GetTableMetadataBlock(MetadataReader,ubyte):MemoryBlock
          12 ( 4.78% of base) : System.IO.Pipelines.dasm - SequencePipeReader:AdvanceTo(SequencePosition,SequencePosition):this
          16 ( 4.42% of base) : Newtonsoft.Json.dasm - JsonObjectContract:get_HasRequiredOrDefaultValueProperties():bool:this
           8 ( 3.94% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Reader:SkipOldToken():this
          17 ( 3.79% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VisualBasicControlFlowAnalysis:get_EntryPoints():ImmutableArray`1:this
           6 ( 3.75% of base) : System.Data.Common.dasm - DbProviderFactory:get_CanCreateCommandBuilder():bool:this
           6 ( 3.73% of base) : System.Data.Common.dasm - DbProviderFactory:get_CanCreateDataAdapter():bool:this
         120 ( 3.57% of base) : System.Data.Common.dasm - SqlMoneyStorage:Aggregate(ref,int):Object:this
           4 ( 3.54% of base) : Microsoft.CSharp.dasm - AggregateSymbol:HasConversion():bool:this

Top method improvements (percentages):
          -6 (-60.00% of base) : Microsoft.Extensions.DependencyInjection.dasm - <>c:<AppendResolutionPath>b__6_0(KeyValuePair`2):int:this
         -22 (-52.38% of base) : Microsoft.CodeAnalysis.CSharp.dasm - AnonymousTypeDescriptor:AssertIsGood():this
          -3 (-37.50% of base) : Microsoft.CodeAnalysis.dasm - AdditionalTextFile:get_Path():String:this
          -3 (-37.50% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SourceLocalSymbol:GetDeclaratorSyntax():SyntaxNode:this
          -3 (-37.50% of base) : System.Drawing.Common.dasm - ValueStringBuilder:GetPinnableReference():byref:this
          -3 (-37.50% of base) : System.Console.dasm - ValueStringBuilder:GetPinnableReference():byref:this
          -3 (-37.50% of base) : System.ServiceProcess.ServiceController.dasm - ValueStringBuilder:GetPinnableReference():byref:this
          -3 (-37.50% of base) : Microsoft.Extensions.Logging.Abstractions.dasm - ValueStringBuilder:GetPinnableReference():byref:this
          -3 (-37.50% of base) : System.Private.Uri.dasm - ValueStringBuilder:GetPinnableReference():byref:this
          -6 (-31.58% of base) : Microsoft.CodeAnalysis.dasm - <>c:<GetLocalSlotDebugInfos>b__425_0(EncHoistedLocalInfo):bool:this
          -3 (-30.00% of base) : Microsoft.CodeAnalysis.dasm - SubText:get_Length():int:this
         -73 (-28.40% of base) : System.IO.Pipes.dasm - TaskAsyncResult:.ctor(Task,Object,AsyncCallback):this
         -73 (-28.40% of base) : System.Net.Quic.dasm - TaskAsyncResult:.ctor(Task,Object,AsyncCallback):this
         -73 (-28.40% of base) : System.Net.Requests.dasm - TaskAsyncResult:.ctor(Task,Object,AsyncCallback):this
         -73 (-28.40% of base) : System.Net.Security.dasm - TaskAsyncResult:.ctor(Task,Object,AsyncCallback):this
         -73 (-28.40% of base) : System.Security.Cryptography.Primitives.dasm - TaskAsyncResult:.ctor(Task,Object,AsyncCallback):this
         -73 (-28.40% of base) : System.IO.Compression.Brotli.dasm - TaskAsyncResult:.ctor(Task,Object,AsyncCallback):this
         -73 (-28.40% of base) : System.IO.Compression.dasm - TaskAsyncResult:.ctor(Task,Object,AsyncCallback):this
         -73 (-28.40% of base) : System.IO.Pipelines.dasm - TaskAsyncResult:.ctor(Task,Object,AsyncCallback):this
         -73 (-28.40% of base) : System.Net.Http.dasm - TaskAsyncResult:.ctor(Task,Object,AsyncCallback):this

3268 total methods with Code Size differences (3109 improved, 159 regressed), 256267 unchanged.
```
The reported base size of SqlMoneyStorage/SqlInt32Storage:Aggregate appears to be bogus, the actual difference is only a few bytes.

arm64 alt diff:
```
Total bytes of base: 50875252
Total bytes of diff: 50858708
Total bytes of delta: -16544 (-0.03 % of base)
    diff is an improvement.

Top file improvements (bytes):
       -2804 : System.Private.CoreLib.dasm (-0.06% of base)
       -1700 : Newtonsoft.Json.dasm (-0.19% of base)
       -1296 : System.Private.Xml.dasm (-0.03% of base)
       -1284 : Microsoft.CodeAnalysis.dasm (-0.07% of base)
       -1060 : System.Reflection.Metadata.dasm (-0.23% of base)
        -964 : System.Text.Json.dasm (-0.12% of base)
        -876 : System.Memory.dasm (-0.75% of base)
        -780 : System.Data.Common.dasm (-0.05% of base)
        -588 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.01% of base)
        -516 : System.Net.Http.dasm (-0.07% of base)
        -496 : Microsoft.CodeAnalysis.CSharp.dasm (-0.01% of base)
        -280 : System.Formats.Asn1.dasm (-0.34% of base)
        -268 : xunit.runner.utility.netcoreapp10.dasm (-0.13% of base)
        -216 : System.Security.Cryptography.Pkcs.dasm (-0.07% of base)
        -208 : System.Linq.Expressions.dasm (-0.02% of base)
        -188 : System.Linq.Parallel.dasm (-0.03% of base)
        -180 : Microsoft.VisualBasic.Core.dasm (-0.03% of base)
        -160 : System.Net.Security.dasm (-0.05% of base)
        -152 : System.Security.Cryptography.Algorithms.dasm (-0.04% of base)
        -128 : System.Security.Cryptography.Cng.dasm (-0.06% of base)

104 total files with Code Size differences (104 improved, 0 regressed), 166 unchanged.

Top method regressions (bytes):
          48 ( 1.21% of base) : Newtonsoft.Json.dasm - JsonTextReader:ParseReadNumber(int,ushort,int):this
          20 ( 4.10% of base) : System.Private.Xml.dasm - ParticleContentValidator:GetApplicableMinMaxFollowPos(BitSet,BitSet,ref):BitSet:this
          16 ( 0.72% of base) : System.Collections.Immutable.dasm - Enumerator:get_Current():KeyValuePair`2:this (12 methods)
           8 ( 2.70% of base) : Microsoft.Extensions.Logging.Abstractions.dasm - <>c__DisplayClass20_0`6:<Define>g__Log|0(ILogger,__Canon,__Canon,__Canon,__Canon,__Canon,__Canon,Exception):this
           8 ( 0.55% of base) : System.Net.Http.dasm - <DrainAsync>d__10:MoveNext():this
           4 ( 0.24% of base) : System.IO.Pipelines.dasm - <CopyToAsync>d__39:MoveNext():this
           4 ( 0.21% of base) : System.Net.Quic.dasm - <ReadAsync>d__26:MoveNext():this
           4 ( 0.40% of base) : System.Configuration.ConfigurationManager.dasm - ClientSettingsStore:ReadSettingsFromFile(String,String,bool):IDictionary
           4 ( 1.52% of base) : System.Security.Cryptography.Cng.dasm - CngProperty:GetHashCode():int:this
           4 ( 2.13% of base) : System.Data.Common.dasm - DbProviderFactory:get_CanCreateCommandBuilder():bool:this
           4 ( 2.13% of base) : System.Data.Common.dasm - DbProviderFactory:get_CanCreateDataAdapter():bool:this
           4 ( 0.41% of base) : Newtonsoft.Json.dasm - JsonTextReader:ParseConstructor():this
           4 ( 0.88% of base) : System.Linq.Expressions.dasm - LambdaCompiler:MergeBuckets(List`1)
           4 ( 4.55% of base) : System.IO.Pipelines.dasm - PipeAwaitable:ReleaseCancellationTokenRegistration(byref):CancellationTokenRegistration:this
           4 ( 0.64% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - StackSourceInterner:GetFrameName(int,bool):String:this
           4 ( 1.09% of base) : System.Net.WebSockets.dasm - WebSocketInflater:Finish(Span`1,byref):bool:this

Top method improvements (bytes):
        -572 (-8.29% of base) : System.Private.CoreLib.dasm - OpCodes:.cctor()
        -280 (-0.74% of base) : Microsoft.CodeAnalysis.dasm - AttributeDescription:.cctor() (2 methods)
        -212 (-21.81% of base) : System.Reflection.Metadata.dasm - MetadataReaderExtensions:GetTableMetadataBlock(MetadataReader,ubyte):MemoryBlock
        -156 (-1.71% of base) : Newtonsoft.Json.dasm - JToken:op_Explicit(JToken):Nullable`1 (17 methods)
        -116 (-1.67% of base) : System.Reflection.Metadata.dasm - PEBuilder:WritePEHeader(BlobBuilder,PEDirectoriesBuilder,ImmutableArray`1):this
        -104 (-8.90% of base) : Newtonsoft.Json.dasm - JsonSchemaModel:Combine(JsonSchemaModel,JsonSchema)
         -92 (-3.88% of base) : Newtonsoft.Json.dasm - JValue:WriteToAsync(JsonWriter,CancellationToken,ref):Task:this
         -88 (-4.35% of base) : Newtonsoft.Json.dasm - DefaultContractResolver:SetPropertySettingsFromAttributes(JsonProperty,Object,String,Type,int,byref):this
         -88 (-1.17% of base) : System.Private.CoreLib.dasm - Enumerator:System.Collections.IEnumerator.get_Current():Object:this (64 methods)
         -84 (-9.05% of base) : Newtonsoft.Json.dasm - DefaultContractResolver:CreatePropertyFromConstructorParameter(JsonProperty,ParameterInfo):JsonProperty:this
         -80 (-3.53% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:CanonicalizeConstant(ConstantValue):Object (2 methods)
         -80 (-0.70% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:DoUncheckedConversion(byte,ConstantValue):Object (2 methods)
         -80 (-8.93% of base) : Microsoft.CodeAnalysis.dasm - FullMetadataWriter:PopulateEventMapTableRows(List`1):this (2 methods)
         -80 (-1.90% of base) : System.Memory.dasm - SequenceReader`1:TryReadTo(byref,ReadOnlySpan`1,bool):bool:this (6 methods)
         -72 (-4.00% of base) : System.Private.CoreLib.dasm - ArraySegment`1:.cctor() (18 methods)
         -72 (-2.17% of base) : System.Private.CoreLib.dasm - ArraySegment`1:Equals(Object):bool:this (18 methods)
         -72 (-5.57% of base) : Newtonsoft.Json.dasm - JsonValidatingReader:ValidateFloat(JsonSchemaModel):this
         -64 (-3.54% of base) : System.Data.Common.dasm - SqlConvert:ConvertToSqlDouble(Object):SqlDouble
         -64 (-1.68% of base) : System.Private.CoreLib.dasm - ValueTuple`2:Equals(Object):bool:this (17 methods)
         -64 (-1.04% of base) : System.Private.CoreLib.dasm - ValueTuple`2:System.Collections.IStructuralComparable.CompareTo(Object,IComparer):int:this (17 methods)

Top method regressions (percentages):
           4 ( 4.55% of base) : System.IO.Pipelines.dasm - PipeAwaitable:ReleaseCancellationTokenRegistration(byref):CancellationTokenRegistration:this
          20 ( 4.10% of base) : System.Private.Xml.dasm - ParticleContentValidator:GetApplicableMinMaxFollowPos(BitSet,BitSet,ref):BitSet:this
           8 ( 2.70% of base) : Microsoft.Extensions.Logging.Abstractions.dasm - <>c__DisplayClass20_0`6:<Define>g__Log|0(ILogger,__Canon,__Canon,__Canon,__Canon,__Canon,__Canon,Exception):this
           4 ( 2.13% of base) : System.Data.Common.dasm - DbProviderFactory:get_CanCreateCommandBuilder():bool:this
           4 ( 2.13% of base) : System.Data.Common.dasm - DbProviderFactory:get_CanCreateDataAdapter():bool:this
           4 ( 1.52% of base) : System.Security.Cryptography.Cng.dasm - CngProperty:GetHashCode():int:this
          48 ( 1.21% of base) : Newtonsoft.Json.dasm - JsonTextReader:ParseReadNumber(int,ushort,int):this
           4 ( 1.09% of base) : System.Net.WebSockets.dasm - WebSocketInflater:Finish(Span`1,byref):bool:this
           4 ( 0.88% of base) : System.Linq.Expressions.dasm - LambdaCompiler:MergeBuckets(List`1)
          16 ( 0.72% of base) : System.Collections.Immutable.dasm - Enumerator:get_Current():KeyValuePair`2:this (12 methods)
           4 ( 0.64% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - StackSourceInterner:GetFrameName(int,bool):String:this
           8 ( 0.55% of base) : System.Net.Http.dasm - <DrainAsync>d__10:MoveNext():this
           4 ( 0.41% of base) : Newtonsoft.Json.dasm - JsonTextReader:ParseConstructor():this
           4 ( 0.40% of base) : System.Configuration.ConfigurationManager.dasm - ClientSettingsStore:ReadSettingsFromFile(String,String,bool):IDictionary
           4 ( 0.24% of base) : System.IO.Pipelines.dasm - <CopyToAsync>d__39:MoveNext():this
           4 ( 0.21% of base) : System.Net.Quic.dasm - <ReadAsync>d__26:MoveNext():this

Top method improvements (percentages):
        -212 (-21.81% of base) : System.Reflection.Metadata.dasm - MetadataReaderExtensions:GetTableMetadataBlock(MetadataReader,ubyte):MemoryBlock
         -12 (-21.43% of base) : System.IO.FileSystem.dasm - FileSystemEntry:Initialize(byref,long,ReadOnlySpan`1,ReadOnlySpan`1,ReadOnlySpan`1)
         -56 (-17.28% of base) : System.Formats.Asn1.dasm - Asn1Tag:.cctor()
          -4 (-16.67% of base) : System.Private.CoreLib.dasm - ValueStringBuilder:GetPinnableReference():byref:this
         -16 (-15.38% of base) : System.Data.Common.dasm - SqlByte:.cctor()
          -4 (-14.29% of base) : System.IO.FileSystem.dasm - FileSystemEntry:set_Directory(ReadOnlySpan`1):this
          -4 (-14.29% of base) : System.IO.FileSystem.dasm - FileSystemEntry:set_OriginalRootDirectory(ReadOnlySpan`1):this
          -4 (-14.29% of base) : System.IO.FileSystem.dasm - FileSystemEntry:set_RootDirectory(ReadOnlySpan`1):this
         -32 (-14.29% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LexicalSortKey:.cctor() (2 methods)
          -4 (-14.29% of base) : System.Memory.dasm - SequenceReader`1:set_CurrentSpan(ReadOnlySpan`1):this
         -16 (-14.29% of base) : System.Data.Common.dasm - SqlInt16:.cctor()
         -16 (-14.29% of base) : System.Data.Common.dasm - SqlInt32:.cctor()
         -16 (-14.29% of base) : System.Data.Common.dasm - SqlInt64:.cctor()
         -16 (-14.29% of base) : System.Data.Common.dasm - SqlMoney:.cctor()
          -8 (-14.29% of base) : Microsoft.CodeAnalysis.dasm - SubText:get_Length():int:this (2 methods)
          -4 (-14.29% of base) : System.Text.Json.dasm - Utf8JsonReader:set_ValueSpan(ReadOnlySpan`1):this
          -8 (-13.33% of base) : System.Linq.Expressions.dasm - ArrayByRefUpdater:.ctor(LocalDefinition,LocalDefinition,int):this
          -4 (-12.50% of base) : Microsoft.CSharp.dasm - AggregateSymbol:SetHasConversion():this
         -20 (-12.50% of base) : System.Private.CoreLib.dasm - Decimal:.cctor()
          -4 (-12.50% of base) : System.Composition.Convention.dasm - ImportConventionBuilder:AsMany():ImportConventionBuilder:this

1707 total methods with Code Size differences (1691 improved, 16 regressed), 195225 unchanged.
```
arm64 alt pmi diff:
```
Total bytes of base: 57560420
Total bytes of diff: 57516088
Total bytes of delta: -44332 (-0.08 % of base)
    diff is an improvement.


Top file improvements (bytes):
       -7740 : FSharp.Core.dasm (-0.18% of base)
       -4840 : System.Memory.dasm (-1.63% of base)
       -2968 : Microsoft.CodeAnalysis.dasm (-0.14% of base)
       -2084 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.03% of base)
       -2016 : Newtonsoft.Json.dasm (-0.20% of base)
       -1936 : System.Text.Json.dasm (-0.22% of base)
       -1784 : CommandLine.dasm (-0.32% of base)
       -1524 : Microsoft.CodeAnalysis.CSharp.dasm (-0.03% of base)
       -1456 : System.Private.Xml.dasm (-0.04% of base)
       -1176 : System.Reflection.Metadata.dasm (-0.24% of base)
        -912 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.03% of base)
        -856 : System.Net.Http.dasm (-0.12% of base)
        -848 : System.Numerics.Tensors.dasm (-0.27% of base)
        -824 : System.Linq.Parallel.dasm (-0.04% of base)
        -784 : System.Private.CoreLib.dasm (-0.03% of base)
        -772 : System.Data.Common.dasm (-0.05% of base)
        -704 : System.Security.Cryptography.Pkcs.dasm (-0.19% of base)
        -620 : System.Collections.dasm (-0.09% of base)
        -444 : System.Threading.Tasks.Dataflow.dasm (-0.04% of base)
        -400 : System.Collections.Immutable.dasm (-0.03% of base)

129 total files with Code Size differences (129 improved, 0 regressed), 141 unchanged.

Top method regressions (bytes):
         160 ( 7.16% of base) : CommandLine.dasm - UnParserExtensions:FormatCommandLine(Parser,Vector`1,Action`1):String
         100 ( 1.77% of base) : System.Threading.Tasks.Dataflow.dasm - BatchBlockTargetCore:ConsumeReservedMessagesGreedyBounded():this (8 methods)
          56 ( 2.93% of base) : System.Text.RegularExpressions.dasm - RegexCharClass:Canonicalize():this (2 methods)
          48 ( 2.70% of base) : Microsoft.CodeAnalysis.dasm - ChangedText:GetLinesCore():TextLineCollection:this
          40 ( 1.22% of base) : Newtonsoft.Json.dasm - JsonTextReader:ParseReadNumber(int,ushort,int):this
          20 ( 0.28% of base) : System.Threading.Tasks.Dataflow.dasm - BatchBlockTargetCore:ConsumeReservedMessagesNonGreedy():this (8 methods)
          20 ( 3.45% of base) : System.Linq.Expressions.dasm - BoundConstants:EmitCacheConstants(LambdaCompiler):this
          16 ( 4.71% of base) : System.Private.CoreLib.dasm - DelayPromiseWithCancellation:.ctor(int,CancellationToken):this
          16 ( 1.23% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - ProviderManifest:ComputeFieldInfo(XmlReader,Dictionary`2):TemplateInfo
          12 ( 0.94% of base) : System.IO.Compression.dasm - <ReadAsyncCore>d__27:MoveNext():this
          12 ( 2.03% of base) : System.Private.Xml.dasm - AllElementsContentValidator:ExpectedElements(ValidationState,bool):ArrayList:this
          12 ( 8.11% of base) : System.Private.CoreLib.dasm - Environment:GetUserName(byref)
          12 ( 2.54% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - ILToNativeMap:GetILOffsetForNativeAddress(long):int:this
          12 ( 7.50% of base) : Microsoft.CodeAnalysis.dasm - TypedConstant:Equals(Object):bool:this
           8 ( 0.69% of base) : System.Net.HttpListener.dasm - <CloseNetworkConnectionAsync>d__50:MoveNext():this
           8 ( 0.16% of base) : System.Collections.Immutable.dasm - ImmutableDictionary`2:AddRange(IEnumerable`1,MutationInput,int):MutationResult (8 methods)
           8 ( 4.17% of base) : System.Private.Xml.dasm - IteratorDescriptor:EnsureStack():this
           8 ( 0.95% of base) : System.Configuration.ConfigurationManager.dasm - LocalFileSettingsProvider:SetPropertyValues(SettingsContext,SettingsPropertyValueCollection):this
           8 ( 2.41% of base) : System.Linq.Expressions.dasm - ReadOnlyCollectionBuilder`1:Contains(Nullable`1):bool:this
           8 ( 1.74% of base) : Microsoft.CodeAnalysis.dasm - SourceText:GetTextChanges(SourceText):IReadOnlyList`1:this

Top method improvements (bytes):
        -360 (-2.34% of base) : System.Numerics.Tensors.dasm - CompressedSparseTensor`1:EnsureCapacity(int,int):this (8 methods)
        -312 (-6.77% of base) : System.Memory.dasm - SequenceReader`1:GetNextSpan():this (6 methods)
        -256 (-1.13% of base) : System.Text.Json.dasm - JsonValue`1:TryConvertJsonElement(byref):bool:this (64 methods)
        -244 (-9.06% of base) : Microsoft.CodeAnalysis.dasm - SmallDictionary`2:.ctor(SmallDictionary`2,IEqualityComparer`1):this (8 methods)
        -216 (-4.72% of base) : FSharp.Core.dasm - MapTreeModule:spliceOutSuccessor(MapTree`2):Tuple`3 (8 methods)
        -216 (-4.52% of base) : System.Memory.dasm - SequenceReader`1:ResetReader():this (6 methods)
        -212 (-21.81% of base) : System.Reflection.Metadata.dasm - MetadataReaderExtensions:GetTableMetadataBlock(MetadataReader,ubyte):MemoryBlock
        -188 (-2.87% of base) : System.Memory.dasm - SequenceReader`1:TryReadTo(byref,ReadOnlySpan`1,bool):bool:this (12 methods)
        -168 (-1.45% of base) : Microsoft.Extensions.Logging.Console.dasm - JsonConsoleFormatter:Write(byref,IExternalScopeProvider,TextWriter):this (8 methods)
        -168 (-2.94% of base) : System.Memory.dasm - SequenceReader`1:IsNextSlow(ReadOnlySpan`1,bool):bool:this (6 methods)
        -168 (-3.46% of base) : System.Memory.dasm - SequenceReader`1:TryReadToAnyInternal(byref,ReadOnlySpan`1,bool,int):bool:this (6 methods)
        -156 (-2.09% of base) : Newtonsoft.Json.dasm - JToken:op_Explicit(JToken):Nullable`1 (17 methods)
        -152 (-6.83% of base) : FSharp.Core.dasm - List:unzipToFreshConsTail(FSharpList`1,FSharpList`1,FSharpList`1) (8 methods)
        -148 (-0.55% of base) : System.Linq.Parallel.dasm - ContainsSearchOperator`1:WrapPartitionedStream(PartitionedStream`2,IPartitionedStreamRecipient`1,bool,QuerySettings):this (64 methods)
        -144 (-3.96% of base) : FSharp.Core.dasm - MapTreeModule:loop@380-42(MapTree`2,FSharpList`1):FSharpList`1 (8 methods)
        -140 (-2.46% of base) : System.Threading.Tasks.Dataflow.dasm - DataflowBlock:OutputAvailableAsync(ISourceBlock`1,CancellationToken):Task`1 (8 methods)
        -128 (-0.66% of base) : System.IO.Pipelines.dasm - <CopyToAsyncCore>d__16`1:MoveNext():this (8 methods)
        -128 (-8.53% of base) : Newtonsoft.Json.dasm - DefaultContractResolver:SetPropertySettingsFromAttributes(JsonProperty,Object,String,Type,int,byref):this
        -128 (-8.51% of base) : FSharp.Core.dasm - Display:unpackCons(ref):Tuple`2 (8 methods)
        -128 (-1.20% of base) : FSharp.Core.dasm - FSharpMap`2:ToString():String:this (8 methods)

Top method regressions (percentages):
          12 ( 8.11% of base) : System.Private.CoreLib.dasm - Environment:GetUserName(byref)
          12 ( 7.50% of base) : Microsoft.CodeAnalysis.dasm - TypedConstant:Equals(Object):bool:this
         160 ( 7.16% of base) : CommandLine.dasm - UnParserExtensions:FormatCommandLine(Parser,Vector`1,Action`1):String
           4 ( 5.26% of base) : System.IO.Pipelines.dasm - PipeAwaitable:ReleaseCancellationTokenRegistration(byref):CancellationTokenRegistration:this
           4 ( 5.00% of base) : FSharp.Core.dasm - NonStructuralComparison:op_GreaterThanOrEqual(__Canon,Nullable`1):bool
           4 ( 5.00% of base) : System.Diagnostics.Process.dasm - ProcessThread:get_PriorityBoostEnabled():bool:this
           4 ( 5.00% of base) : System.Diagnostics.Process.dasm - ProcessThread:get_PriorityLevel():int:this
          16 ( 4.71% of base) : System.Private.CoreLib.dasm - DelayPromiseWithCancellation:.ctor(int,CancellationToken):this
           8 ( 4.17% of base) : System.Private.Xml.dasm - IteratorDescriptor:EnsureStack():this
          20 ( 3.45% of base) : System.Linq.Expressions.dasm - BoundConstants:EmitCacheConstants(LambdaCompiler):this
          56 ( 2.93% of base) : System.Text.RegularExpressions.dasm - RegexCharClass:Canonicalize():this (2 methods)
          48 ( 2.70% of base) : Microsoft.CodeAnalysis.dasm - ChangedText:GetLinesCore():TextLineCollection:this
          12 ( 2.54% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - ILToNativeMap:GetILOffsetForNativeAddress(long):int:this
           8 ( 2.41% of base) : System.Linq.Expressions.dasm - ReadOnlyCollectionBuilder`1:Contains(Nullable`1):bool:this
           4 ( 2.08% of base) : System.Data.Common.dasm - DbProviderFactory:get_CanCreateCommandBuilder():bool:this
           4 ( 2.08% of base) : System.Data.Common.dasm - DbProviderFactory:get_CanCreateDataAdapter():bool:this
           8 ( 2.04% of base) : System.Text.Json.dasm - ThrowHelper:GetJsonReaderException(byref,int,ubyte,ReadOnlySpan`1):JsonException
          12 ( 2.03% of base) : System.Private.Xml.dasm - AllElementsContentValidator:ExpectedElements(ValidationState,bool):ArrayList:this
         100 ( 1.77% of base) : System.Threading.Tasks.Dataflow.dasm - BatchBlockTargetCore:ConsumeReservedMessagesGreedyBounded():this (8 methods)
           8 ( 1.74% of base) : Microsoft.CodeAnalysis.dasm - SourceText:GetTextChanges(SourceText):IReadOnlyList`1:this

Top method improvements (percentages):
         -28 (-36.84% of base) : Microsoft.CodeAnalysis.CSharp.dasm - AnonymousTypeDescriptor:AssertIsGood():this
          -8 (-28.57% of base) : Microsoft.Extensions.DependencyInjection.dasm - <>c:<AppendResolutionPath>b__6_0(KeyValuePair`2):int:this
          -8 (-22.22% of base) : Microsoft.CodeAnalysis.dasm - <>c:<GetLocalSlotDebugInfos>b__425_0(EncHoistedLocalInfo):bool:this
        -212 (-21.81% of base) : System.Reflection.Metadata.dasm - MetadataReaderExtensions:GetTableMetadataBlock(MetadataReader,ubyte):MemoryBlock
         -12 (-21.43% of base) : System.IO.FileSystem.dasm - FileSystemEntry:Initialize(byref,long,ReadOnlySpan`1,ReadOnlySpan`1,ReadOnlySpan`1)
         -24 (-20.69% of base) : System.Linq.Expressions.dasm - ArrayByRefUpdater:UndefineTemps(InstructionList,LocalVariables):this
         -52 (-20.31% of base) : System.IO.Pipelines.dasm - TaskAsyncResult:.ctor(Task,Object,AsyncCallback):this
         -52 (-20.31% of base) : System.Net.Http.WinHttpHandler.dasm - TaskAsyncResult:.ctor(Task,Object,AsyncCallback):this
         -52 (-20.31% of base) : System.Memory.Data.dasm - TaskAsyncResult:.ctor(Task,Object,AsyncCallback):this
         -52 (-20.31% of base) : System.Net.Connections.dasm - TaskAsyncResult:.ctor(Task,Object,AsyncCallback):this
          -8 (-20.00% of base) : FSharp.Core.dasm - callback@1554-1:.ctor(CancellationTokenRegistration):this
         -44 (-17.74% of base) : System.IO.Compression.Brotli.dasm - TaskAsyncResult:.ctor(Task,Object,AsyncCallback):this
         -44 (-17.74% of base) : System.IO.Compression.dasm - TaskAsyncResult:.ctor(Task,Object,AsyncCallback):this
         -44 (-17.74% of base) : System.Net.NameResolution.dasm - TaskAsyncResult:.ctor(Task,Object,AsyncCallback):this
         -44 (-17.74% of base) : System.Private.CoreLib.dasm - TaskAsyncResult:.ctor(Task,Object,AsyncCallback):this
         -44 (-17.74% of base) : System.Net.Http.dasm - TaskAsyncResult:.ctor(Task,Object,AsyncCallback):this
         -44 (-17.74% of base) : System.Security.Cryptography.Primitives.dasm - TaskAsyncResult:.ctor(Task,Object,AsyncCallback):this
         -44 (-17.74% of base) : System.IO.Pipes.dasm - TaskAsyncResult:.ctor(Task,Object,AsyncCallback):this
         -44 (-17.74% of base) : System.Net.NetworkInformation.dasm - TaskAsyncResult:.ctor(Task,Object,AsyncCallback):this
         -44 (-17.74% of base) : System.Net.Quic.dasm - TaskAsyncResult:.ctor(Task,Object,AsyncCallback):this

3696 total methods with Code Size differences (3648 improved, 48 regressed), 255839 unchanged.
```
