### PR TITLE
Delete GTF_MUL_64RSLT crap

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -3912,10 +3912,6 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
 
     DoPhase(this, PHASE_STR_ADRLCL, &Compiler::fgMarkAddressExposedLocals);
 
-#ifndef TARGET_64BIT
-    INDEBUG(fgStress64RsltMul();)
-#endif
-
     // Morph the trees in all the blocks of the method
     //
     auto morphGlobalPhase = [this]() {
@@ -7805,15 +7801,6 @@ void cTreeFlags(Compiler* comp, GenTree* tree)
                     chars += printf("[BLK_UNALIGNED]");
                 }
                 break;
-
-#ifndef TARGET_64BIT
-            case GT_MUL_LONG:
-                if ((tree->gtFlags & GTF_MUL_64RSLT) != 0)
-                {
-                    chars += printf("[64RSLT]");
-                }
-                break;
-#endif
 
             case GT_ADD:
             case GT_LSH:

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4731,10 +4731,14 @@ private:
     GenTree* fgMorphQmark(GenTreeQmark* qmark, MorphAddrContext* mac = nullptr);
     GenTree* fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac = nullptr);
     GenTree* fgMorphModToSubMulDiv(GenTreeOp* tree);
-    GenTree* fgMorphMulLongCandidate(GenTreeOp* mul);
     GenTree* fgMorphSmpOpOptional(GenTreeOp* tree);
     GenTree* fgMorphConst(GenTree* tree);
     GenTree* fgMorphAssociative(GenTreeOp* tree);
+
+#ifndef TARGET_64BIT
+    bool fgMorphIsMulLongCandidate(GenTreeOp* mul);
+    GenTree* fgMorphMulLongCandidate(GenTreeOp* mul);
+#endif
 
 #ifdef FEATURE_HW_INTRINSICS
     GenTree* fgMorphHWIntrinsic(GenTreeHWIntrinsic* tree);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4731,6 +4731,7 @@ private:
     GenTree* fgMorphQmark(GenTreeQmark* qmark, MorphAddrContext* mac = nullptr);
     GenTree* fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac = nullptr);
     GenTree* fgMorphModToSubMulDiv(GenTreeOp* tree);
+    GenTree* fgMorphMulLongCandidate(GenTreeOp* mul);
     GenTree* fgMorphSmpOpOptional(GenTreeOp* tree);
     GenTree* fgMorphConst(GenTree* tree);
     GenTree* fgMorphAssociative(GenTreeOp* tree);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4736,8 +4736,16 @@ private:
     GenTree* fgMorphAssociative(GenTreeOp* tree);
 
 #ifndef TARGET_64BIT
-    bool fgMorphIsMulLongCandidate(GenTreeOp* mul);
-    GenTree* fgMorphMulLongCandidate(GenTreeOp* mul);
+    enum class MulLongCandidateKind
+    {
+        None,
+        Const,
+        Signed,
+        Unsigned
+    };
+
+    MulLongCandidateKind fgMorphIsMulLongCandidate(GenTreeOp* mul);
+    GenTree* fgMorphMulLongCandidate(GenTreeOp* mul, MulLongCandidateKind kind);
 #endif
 
 #ifdef FEATURE_HW_INTRINSICS

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4740,6 +4740,7 @@ private:
     {
         None,
         Const,
+        Shift,
         Signed,
         Unsigned
     };

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4349,9 +4349,7 @@ public:
     void fgDumpBlock(BasicBlock* block);
     void fgDumpTrees(BasicBlock* firstBlock, BasicBlock* lastBlock);
 
-    static fgWalkPreFn fgStress64RsltMulCB;
-    void               fgStress64RsltMul();
-    void               fgDebugCheckUpdate();
+    void fgDebugCheckUpdate();
     void fgDebugCheckBBlist(bool checkBBNum = false, bool checkBBRefs = true);
     void fgDebugCheckBlockLinks();
     void fgDebugCheckLinks(bool morphTrees = false);
@@ -7487,7 +7485,6 @@ public:
         STRESS_MODE(BB_PROFILE)                                                                 \
         STRESS_MODE(OPT_BOOLS_GC)                                                               \
         STRESS_MODE(REMORPH_TREES)                                                              \
-        STRESS_MODE(64RSLT_MUL)                                                                 \
         STRESS_MODE(DO_WHILE_LOOPS)                                                             \
         STRESS_MODE(MIN_OPTS)                                                                   \
         STRESS_MODE(REVERSE_FLAG)     /* Will set GTF_REVERSE_OPS whenever we can */            \

--- a/src/coreclr/jit/decomposelongs.cpp
+++ b/src/coreclr/jit/decomposelongs.cpp
@@ -1540,6 +1540,7 @@ GenTree* DecomposeLongs::DecomposeMul(LIR::Use& use)
     GenTreeCast* op2 = tree->GetOp(1)->AsCast();
     assert(op1->TypeIs(TYP_LONG));
     assert(op2->TypeIs(TYP_LONG));
+    assert(op1->IsUnsigned() == op2->IsUnsigned());
 
     Range().Remove(op1);
     Range().Remove(op2);
@@ -1547,6 +1548,15 @@ GenTree* DecomposeLongs::DecomposeMul(LIR::Use& use)
     tree->SetOp(0, op1->GetOp(0));
     tree->SetOp(1, op2->GetOp(0));
     tree->SetOper(GT_MUL_LONG);
+
+    if (op1->IsUnsigned())
+    {
+        tree->gtFlags |= GTF_UNSIGNED;
+    }
+    else
+    {
+        tree->gtFlags &= ~GTF_UNSIGNED;
+    }
 
     return StoreNodeToVar(use);
 }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2204,9 +2204,7 @@ bool IsMulLongCandidate(GenTreeOp* mul)
             else
                 return false;
 
-            if (((unsigned)(constOp->AsCast()->CastOp()->AsIntCon()->gtIconVal) < (unsigned)(0x80000000)))
-                constOp->gtFlags ^= GTF_UNSIGNED;
-            else
+            if (((unsigned)(constOp->AsCast()->CastOp()->AsIntCon()->gtIconVal) >= (unsigned)(0x80000000)))
                 return false;
         }
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2180,64 +2180,6 @@ GenTree* Compiler::gtReverseCond(GenTree* tree)
     return tree;
 }
 
-#ifndef TARGET_64BIT
-bool IsMulLongCandidate(GenTreeOp* mul)
-{
-    assert(mul->OperIs(GT_MUL) && mul->TypeIs(TYP_LONG));
-
-    // Both operands must be INT to LONG casts, without overflow checks.
-    GenTreeCast* op1 = mul->GetOp(0)->IsCast();
-
-    if ((op1 == nullptr) || (varActualType(op1->GetOp(0)->GetType()) != TYP_INT) || op1->gtOverflow())
-    {
-        return false;
-    }
-
-    GenTreeCast* op2 = mul->GetOp(1)->IsCast();
-
-    if ((op2 == nullptr) || (varActualType(op2->GetOp(0)->GetType()) != TYP_INT) || op2->gtOverflow())
-    {
-        return false;
-    }
-
-    // Both casts must have the same signedness, except when the cast operand
-    // is a positive constant.
-    // TODO-MIKE-CQ: There are other values that could be easily recognized as
-    // always positive: ARR_LENGTH, relops...
-
-    unsigned op1Sign = 0;
-    unsigned op2Sign = 0;
-
-    GenTreeIntCon* const1 = op1->GetOp(0)->IsIntCon();
-
-    if ((const1 == nullptr) || (const1->GetInt32Value() < 0))
-    {
-        op1Sign = op1->IsUnsigned() ? 1 : 2;
-    }
-
-    GenTreeIntCon* const2 = op2->GetOp(0)->IsIntCon();
-
-    if ((const2 == nullptr) || (const2->GetInt32Value() < 0))
-    {
-        op2Sign = op2->IsUnsigned() ? 1 : 2;
-    }
-
-    if ((op1Sign | op2Sign) == 3)
-    {
-        return false;
-    }
-
-    // Overflow multiply with operands of different signedness may still overflow.
-
-    if (mul->gtOverflow())
-    {
-        return (op1Sign | op2Sign) == (mul->IsUnsigned() ? 1u : 2u);
-    }
-
-    return true;
-}
-#endif // TARGET_64BIT
-
 unsigned Compiler::gtSetCallArgsOrder(const GenTreeCall::UseList& args, bool lateArgs, int* callCostEx, int* callCostSz)
 {
     unsigned level  = 0;

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2238,56 +2238,6 @@ bool IsMulLongCandidate(GenTreeOp* mul)
 }
 #endif // TARGET_64BIT
 
-#ifdef DEBUG
-#ifndef TARGET_64BIT
-
-bool GenTree::gtIsValid64RsltMul()
-{
-    assert((gtOper == GT_MUL) && (gtType == TYP_LONG));
-
-    GenTree* op1 = AsOp()->gtOp1;
-    GenTree* op2 = AsOp()->gtOp2;
-
-    if (TypeGet() != TYP_LONG || op1->TypeGet() != TYP_LONG || op2->TypeGet() != TYP_LONG)
-    {
-        return false;
-    }
-
-    if (gtOverflow())
-    {
-        return false;
-    }
-
-    // op1 has to be conv.i8(i4Expr)
-    if ((op1->gtOper != GT_CAST) || (genActualType(op1->CastFromType()) != TYP_INT))
-    {
-        return false;
-    }
-
-    // op2 has to be conv.i8(i4Expr)
-    if ((op2->gtOper != GT_CAST) || (genActualType(op2->CastFromType()) != TYP_INT))
-    {
-        return false;
-    }
-
-    // The signedness of both casts must be the same
-    if (((op1->gtFlags & GTF_UNSIGNED) != 0) != ((op2->gtFlags & GTF_UNSIGNED) != 0))
-    {
-        return false;
-    }
-
-    // Do unsigned mul iff both the casts are unsigned
-    if (((op1->gtFlags & GTF_UNSIGNED) != 0) != ((gtFlags & GTF_UNSIGNED) != 0))
-    {
-        return false;
-    }
-
-    return true;
-}
-
-#endif // !TARGET_64BIT
-#endif // DEBUG
-
 unsigned Compiler::gtSetCallArgsOrder(const GenTreeCall::UseList& args, bool lateArgs, int* callCostEx, int* callCostSz)
 {
     unsigned level  = 0;

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2187,10 +2187,7 @@ GenTree* Compiler::gtReverseCond(GenTree* tree)
 
 bool GenTree::gtIsValid64RsltMul()
 {
-    if ((gtOper != GT_MUL) || !(gtFlags & GTF_MUL_64RSLT))
-    {
-        return false;
-    }
+    assert((gtOper == GT_MUL) && (gtType == TYP_LONG));
 
     GenTree* op1 = AsOp()->gtOp1;
     GenTree* op2 = AsOp()->gtOp2;
@@ -7490,18 +7487,6 @@ int Compiler::gtDispNodeHeader(GenTree* tree, IndentStack* indentStack, int msgL
                     break;
                 }
 
-                goto DASH;
-
-            case GT_MUL:
-#ifndef TARGET_64BIT
-            case GT_MUL_LONG:
-                if ((tree->gtFlags & GTF_MUL_64RSLT) != 0)
-                {
-                    printf("L");
-                    --msgLength;
-                    break;
-                }
-#endif
                 goto DASH;
 
             case GT_DIV:

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -2721,6 +2721,10 @@ public:
 #endif
 };
 
+#ifndef TARGET_64BIT
+bool IsMulLongCandidate(GenTreeOp* mul);
+#endif
+
 struct GenTreeOp : public GenTreeUnOp
 {
     GenTree* gtOp2;

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1945,10 +1945,7 @@ public:
     bool gtOverflow() const;
     bool gtOverflowEx() const;
 
-#ifdef DEBUG
-    bool       gtIsValid64RsltMul();
-    static int gtDispFlags(GenTreeFlags flags, GenTreeDebugFlags debugFlags);
-#endif
+    INDEBUG(static int gtDispFlags(GenTreeFlags flags, GenTreeDebugFlags debugFlags);)
 
     // cast operations
     inline var_types  CastFromType();

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -3058,6 +3058,11 @@ struct GenTreeLngCon : public GenTreeIntConCommon
         return gtLconVal;
     }
 
+    uint64_t GetUInt64Value() const
+    {
+        return static_cast<uint64_t>(gtLconVal);
+    }
+
     void SetValue(int64_t value)
     {
         gtLconVal = value;

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -547,10 +547,6 @@ enum GenTreeFlags : unsigned int
     GTF_ADDRMODE_NO_CSE         = 0x80000000, // ADD/MUL/LSH/COMMA -- Node is part of addressing mode, do not CSE.
                                               // Unlike GTF_DONT_CSE this does not block constant propagation.
 
-#ifndef TARGET_64BIT
-    GTF_MUL_64RSLT              = 0x40000000, // GT_MUL     -- produce 64-bit result
-#endif
-
     GTF_RELOP_NAN_UN            = 0x80000000, // GT_<relop> -- Is branch taken if ops are NaN?
     GTF_RELOP_JMP_USED          = 0x40000000, // GT_<relop> -- result of compare used for jump or ?:
     GTF_RELOP_ZTT               = 0x08000000, // GT_<relop> -- Loop test cloned for converting while-loops into do-while

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -2718,10 +2718,6 @@ public:
 #endif
 };
 
-#ifndef TARGET_64BIT
-bool IsMulLongCandidate(GenTreeOp* mul);
-#endif
-
 struct GenTreeOp : public GenTreeUnOp
 {
     GenTree* gtOp2;

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -2440,17 +2440,6 @@ int LinearScan::BuildMul(GenTree* tree)
     // two-op form:     reg *= r/m
     // three-op form:   reg = r/m * imm
 
-    // This special widening 32x32->64 MUL is not used on x64
-    CLANG_FORMAT_COMMENT_ANCHOR;
-#if defined(TARGET_X86)
-    if (tree->OperGet() != GT_MUL_LONG)
-#endif
-    {
-#ifndef TARGET_64BIT
-        assert((tree->gtFlags & GTF_MUL_64RSLT) == 0);
-#endif
-    }
-
     BuildKills(tree, getKillSetForMul(tree->AsOp()));
 
     // We do use the widening multiply to implement

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12422,7 +12422,12 @@ GenTree* Compiler::fgMorphMulLongCandidate(GenTreeOp* tree, MulLongCandidateKind
     if (kind == MulLongCandidateKind::Const)
     {
         GenTree* con = gtFoldExprConst(tree);
-        noway_assert(con->OperIsConst());
+
+        if (!con->IsLngCon())
+        {
+            noway_assert(fgIsCommaThrow(con));
+            con = fgMorphTree(con);
+        }
 
         return con;
     }
@@ -12483,7 +12488,7 @@ GenTree* Compiler::fgMorphMulLongCandidate(GenTreeOp* tree, MulLongCandidateKind
         tree->SetOp(1, const2);
 
         GenTree* con = gtFoldExprConst(tree);
-        noway_assert(con->OperIsConst());
+        noway_assert(con->IsLngCon());
 
         return con;
     }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12358,6 +12358,12 @@ Compiler::MulLongCandidateKind Compiler::fgMorphIsMulLongCandidate(GenTreeOp* mu
         // TODO-MIKE-CQ: There are other values that could be easily recognized
         // as always positive: ARR_LENGTH, relops, small unsigned int casts...
 
+        // TODO-MIKE-CQ: Microsoft.VisualBasic.Core's Operators:MultiplyUInt16(ushort,ushort)
+        // has a signed multiply with overflow and unsigned cast operands that is currently
+        // rejected due to signedness mismatch.
+        // However, those are casts from USHORT so overflow checking is not actually required.
+        // Old code managed to accept that due to incorrect overflow signedness checks.
+
         if ((intConst1 == nullptr) || (intConst1->GetInt32Value() < 0))
         {
             op1Sign = cast1->IsUnsigned() ? 1 : 2;

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -10992,7 +10992,7 @@ DONE_MORPHING_CHILDREN:
 #ifndef TARGET_64BIT
             if (typ == TYP_LONG)
             {
-                assert(tree->gtIsValid64RsltMul());
+                assert(IsMulLongCandidate(tree->AsOp()));
                 return tree;
             }
 #endif

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -5133,13 +5133,26 @@ bool Compiler::optNarrowTree(GenTree* tree, var_types srct, var_types dstt, Valu
                 if (doit)
                 {
 #ifndef TARGET_64BIT
-                    if (tree->OperIs(GT_MUL) && ((tree->gtFlags & GTF_MUL_64RSLT) != 0))
+                    if (tree->OperIs(GT_MUL) && tree->TypeIs(TYP_LONG))
                     {
-                        tree->gtFlags &= ~GTF_MUL_64RSLT;
+                        assert(dstt == TYP_INT);
+
+                        GenTreeCast* op1 = tree->AsOp()->GetOp(0)->IsCast();
+                        GenTreeCast* op2 = tree->AsOp()->GetOp(1)->IsCast();
+
+                        if (op1 != nullptr)
+                        {
+                            op1->ClearDoNotCSE();
+                        }
+
+                        if (op2 != nullptr)
+                        {
+                            op1->ClearDoNotCSE();
+                        }
                     }
 #endif
 
-                    tree->gtType = genActualType(dstt);
+                    tree->SetType(varActualType(dstt));
                     tree->SetVNs(vnpNarrow);
                 }
 


### PR DESCRIPTION
win-x86 pmi diff:
```
Total bytes of base: 39251604
Total bytes of diff: 39248788
Total bytes of delta: -2816 (-0.01 % of base)
Total relative delta: NaN
    diff is an improvement.
    relative diff is a regression.


Top file improvements (bytes):
       -1062 : System.Private.CoreLib.dasm (-0.05% of base)
        -268 : System.Private.Xml.dasm (-0.01% of base)
        -176 : Newtonsoft.Json.dasm (-0.03% of base)
        -145 : Newtonsoft.Json.Bson.dasm (-0.20% of base)
        -107 : System.Data.Common.dasm (-0.01% of base)
         -88 : System.Formats.Asn1.dasm (-0.12% of base)
         -86 : System.Net.Http.dasm (-0.02% of base)
         -78 : System.Data.Odbc.dasm (-0.05% of base)
         -72 : System.Security.Cryptography.Algorithms.dasm (-0.03% of base)
         -70 : Microsoft.Diagnostics.FastSerialization.dasm (-0.07% of base)
         -62 : System.Data.OleDb.dasm (-0.03% of base)
         -54 : System.ServiceModel.Syndication.dasm (-0.05% of base)
         -50 : System.Private.DataContractSerialization.dasm (-0.01% of base)
         -50 : System.Diagnostics.EventLog.dasm (-0.07% of base)
         -42 : System.DirectoryServices.Protocols.dasm (-0.06% of base)
         -38 : System.Threading.Tasks.Parallel.dasm (-0.02% of base)
         -38 : System.Speech.dasm (-0.01% of base)
         -38 : System.Text.Encoding.CodePages.dasm (-0.07% of base)
         -31 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
         -29 : System.Net.Mail.dasm (-0.02% of base)

36 total files with Code Size differences (36 improved, 0 regressed), 234 unchanged.

Top method regressions (bytes):
          26 ( 1.81% of base) : System.Net.Http.dasm - <ReadHeadersAsync>d__43:MoveNext():this
           9 ( 0.71% of base) : Newtonsoft.Json.dasm - <DoWriteValueAsync>d__63:MoveNext():this
           9 ( 5.70% of base) : Microsoft.VisualBasic.Core.dasm - Operators:MultiplyUInt16(ushort,ushort):Object

Top method improvements (bytes):
         -94 (-4.47% of base) : System.Private.CoreLib.dasm - Number:Dragon4(long,int,int,bool,int,bool,Span`1,byref):int
         -86 (-13.48% of base) : System.Private.CoreLib.dasm - Number:TryParseUInt64HexNumberStyle(ReadOnlySpan`1,int,byref):int
         -70 (-10.74% of base) : Newtonsoft.Json.Bson.dasm - DateTimeUtils:TryParseDateTimeOffsetIso(String,byref):bool
         -70 (-10.62% of base) : Newtonsoft.Json.dasm - DateTimeUtils:TryParseDateTimeOffsetIso(StringReference,byref):bool
         -70 (-3.80% of base) : Microsoft.Diagnostics.FastSerialization.dasm - GrowableArray`1:Realloc(int):this (8 methods)
         -70 (-4.45% of base) : System.Private.Xml.dasm - XsdDateTime:op_Implicit(XsdDateTime):DateTimeOffset
         -62 (-3.00% of base) : System.Private.Xml.dasm - XsdDateTime:op_Implicit(XsdDateTime):DateTime
         -59 (-1.61% of base) : System.Formats.Asn1.dasm - AsnDecoder:ParseGeneralizedTime(int,ReadOnlySpan`1):DateTimeOffset
         -58 (-4.39% of base) : Newtonsoft.Json.Bson.dasm - DateTimeUtils:TryParseDateTimeIso(String,int,byref):bool
         -53 (-4.01% of base) : Newtonsoft.Json.dasm - DateTimeUtils:TryParseDateTimeIso(StringReference,int,byref):bool
         -45 (-11.84% of base) : System.Private.CoreLib.dasm - TimeSpanParse:TryTimeToTicks(bool,TimeSpanToken,TimeSpanToken,TimeSpanToken,TimeSpanToken,TimeSpanToken,byref):bool
         -44 (-7.07% of base) : System.Private.Xml.dasm - XsdDateTime:ToZulu():DateTime:this
         -41 (-0.83% of base) : System.Data.Common.dasm - FunctionNode:EvalFunction(int,ref,DataRow,int):Object:this
         -33 (-10.89% of base) : System.Private.CoreLib.dasm - TimeSpan:.ctor(int,int,int,int,int):this
         -30 (-9.46% of base) : System.Private.CoreLib.dasm - Grisu3:TryRoundWeedCounted(Span`1,int,long,long,long,byref):bool
         -29 (-2.93% of base) : System.Formats.Asn1.dasm - AsnDecoder:ParseUtcTime(ReadOnlySpan`1,int,int):DateTimeOffset
         -29 (-4.74% of base) : System.Private.CoreLib.dasm - DateTimeParse:ParseTimeZone(byref,byref):bool
         -29 (-6.67% of base) : System.Private.CoreLib.dasm - DateTimeParse:ParseTimeZoneOffset(byref,int,byref):bool
         -29 (-8.33% of base) : System.Net.Mail.dasm - SmtpDateTime:TryParseTimeZoneString(String,byref):bool:this
         -28 (-14.43% of base) : System.Net.Http.dasm - AltSvcHeaderParser:TryReadQuotedInt32Value(ReadOnlySpan`1,byref):bool

Top method regressions (percentages):
           9 ( 5.70% of base) : Microsoft.VisualBasic.Core.dasm - Operators:MultiplyUInt16(ushort,ushort):Object
          26 ( 1.81% of base) : System.Net.Http.dasm - <ReadHeadersAsync>d__43:MoveNext():this
           9 ( 0.71% of base) : Newtonsoft.Json.dasm - <DoWriteValueAsync>d__63:MoveNext():this

Top method improvements (percentages):
         -13 (-31.71% of base) : System.Data.OleDb.dasm - ADP:TimerFromSeconds(int):long
         -13 (-31.71% of base) : System.Data.Odbc.dasm - ADP:TimerFromSeconds(int):long
         -18 (-31.58% of base) : System.Data.Common.dasm - SqlMoney:.ctor(int):this
         -26 (-23.85% of base) : System.Security.Cryptography.Pkcs.dasm - Rfc3161Accuracy:get_TotalMicros():long:this
         -14 (-22.95% of base) : System.DirectoryServices.Protocols.dasm - LdapSessionOptions:get_PingKeepAliveTimeout():TimeSpan:this
         -14 (-22.95% of base) : System.DirectoryServices.Protocols.dasm - LdapSessionOptions:get_PingWaitTimeout():TimeSpan:this
         -14 (-22.95% of base) : System.DirectoryServices.Protocols.dasm - LdapSessionOptions:get_SendTimeout():TimeSpan:this
         -14 (-16.67% of base) : System.Private.Xml.dasm - BinXmlDateTime:GetKatmaiTimeZoneTicks(ref,int):long
         -13 (-16.46% of base) : System.Private.CoreLib.dasm - TimeOnly:.ctor(int,int):this
         -23 (-14.74% of base) : System.Private.CoreLib.dasm - TimeSpan:TimeToTicks(int,int,int):long
         -28 (-14.43% of base) : System.Net.Http.dasm - AltSvcHeaderParser:TryReadQuotedInt32Value(ReadOnlySpan`1,byref):bool
         -14 (-13.86% of base) : System.Threading.Tasks.Parallel.dasm - RangeWorker:.ctor(ref,int,long,bool):this
         -23 (-13.53% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - FastStream:ReadLongHex():long:this
         -86 (-13.48% of base) : System.Private.CoreLib.dasm - Number:TryParseUInt64HexNumberStyle(ReadOnlySpan`1,int,byref):int
         -14 (-12.17% of base) : Microsoft.VisualBasic.Core.dasm - DateAndTime:TimeSerial(int,int,int):DateTime
         -16 (-11.94% of base) : System.Data.Odbc.dasm - TimeoutTimer:SetTimeoutSeconds(int):this
         -45 (-11.84% of base) : System.Private.CoreLib.dasm - TimeSpanParse:TryTimeToTicks(bool,TimeSpanToken,TimeSpanToken,TimeSpanToken,TimeSpanToken,TimeSpanToken,byref):bool
         -19 (-11.73% of base) : System.Private.CoreLib.dasm - TimeSpan:.ctor(int,int,int):this
         -12 (-11.43% of base) : System.Speech.dasm - AudioDeviceOut:get_Duration():TimeSpan:this
         -12 (-11.43% of base) : System.Speech.dasm - AudioFileOut:get_Duration():TimeSpan:this

163 total methods with Code Size differences (160 improved, 3 regressed), 258736 unchanged.
```