### PR TITLE
Static field indirs cannot fault

### DIFF
--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -905,33 +905,6 @@ bool Compiler::fgAddrCouldBeNull(GenTree* addr)
             }
         }
 
-        // TODO-MIKE-Review: The whole fgIsBigOffset/IsIconHandle mess is dubious.
-        // Adding "big offset" obviously doesn't imply that the result is null.
-        // This is obviously a mix up with field morphing attempting to elide an
-        // explicit null check, relying on the indir to fault if the field offset
-        // is sufficiently small. But attempting to use this do determine if an
-        // indir may throw an exception or not does not make a lot of sense.
-
-        if (GenTreeIntCon* const1 = op1->IsIntCon())
-        {
-            if (!const1->IsIconHandle())
-            {
-                return fgIsBigOffset(const1->GetValue()) || fgAddrCouldBeNull(op2);
-            }
-
-            if (GenTreeIntCon* const2 = op2->IsIntCon())
-            {
-                return const2->IsIconHandle() || fgIsBigOffset(const2->GetValue());
-            }
-
-            return true;
-        }
-
-        if (GenTreeIntCon* const2 = op2->IsIntCon())
-        {
-            return const2->IsIconHandle() || fgIsBigOffset(const2->GetValue()) || fgAddrCouldBeNull(op1);
-        }
-
         return true;
     }
 

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -895,6 +895,16 @@ bool Compiler::fgAddrCouldBeNull(GenTree* addr)
         GenTree* op1 = addr->AsOp()->GetOp(0);
         GenTree* op2 = addr->AsOp()->GetOp(1);
 
+        if (GenTreeIntCon* const2 = op2->IsIntCon())
+        {
+            // Static struct field boxed instances cannot be null.
+            if (const2->GetFieldSeq() == GetFieldSeqStore()->GetBoxedValuePseudoField())
+            {
+                assert(const2->GetValue() == TARGET_POINTER_SIZE);
+                return !op1->TypeIs(TYP_REF);
+            }
+        }
+
         // TODO-MIKE-Review: The whole fgIsBigOffset/IsIconHandle mess is dubious.
         // Adding "big offset" obviously doesn't imply that the result is null.
         // This is obviously a mix up with field morphing attempting to elide an

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5992,7 +5992,8 @@ GenTree* Compiler::impImportStaticFieldAddressHelper(CORINFO_RESOLVED_TOKEN*   r
 
     if ((fieldInfo.fieldFlags & CORINFO_FLG_FIELD_STATIC_IN_HEAP) != 0)
     {
-        addr     = gtNewOperNode(GT_IND, TYP_REF, addr);
+        addr = gtNewOperNode(GT_IND, TYP_REF, addr);
+        addr->gtFlags |= GTF_IND_NONFAULTING;
         fieldSeq = GetFieldSeqStore()->GetBoxedValuePseudoField();
         addr     = gtNewOperNode(GT_ADD, TYP_BYREF, addr, gtNewIconNode(TARGET_POINTER_SIZE, fieldSeq));
     }
@@ -6027,7 +6028,7 @@ GenTree* Compiler::impImportStaticFieldAccess(CORINFO_RESOLVED_TOKEN*   resolved
             indir = gtNewOperNode(GT_IND, type, addr);
         }
 
-        indir->gtFlags |= GTF_GLOB_REF;
+        indir->gtFlags |= GTF_GLOB_REF | GTF_IND_NONFAULTING;
 
         if (indir->TypeIs(TYP_REF) && addr->TypeIs(TYP_BYREF))
         {
@@ -6115,6 +6116,7 @@ GenTree* Compiler::impImportStaticFieldAccess(CORINFO_RESOLVED_TOKEN*   resolved
         if ((fieldInfo.fieldFlags & CORINFO_FLG_FIELD_STATIC_IN_HEAP) != 0)
         {
             addr = gtNewOperNode(GT_IND, TYP_REF, addr);
+            addr->gtFlags |= GTF_IND_NONFAULTING;
 
 #ifdef TARGET_64BIT
             if (isStaticReadOnlyInited)
@@ -6174,8 +6176,9 @@ GenTree* Compiler::impImportStaticFieldAccess(CORINFO_RESOLVED_TOKEN*   resolved
         else
         {
             indir = gtNewOperNode(GT_IND, type, addr);
-            indir->gtFlags |= GTF_GLOB_REF | GTF_IND_NONFAULTING;
         }
+
+        indir->gtFlags |= GTF_GLOB_REF | GTF_IND_NONFAULTING;
     }
 
     return indir;


### PR DESCRIPTION
win-x64 diff:

```
Total bytes of base: 31490083
Total bytes of diff: 31489826
Total bytes of delta: -257 (-0.00 % of base)
Total relative delta: NaN
    diff is an improvement.
    relative diff is a regression.


Top file regressions (bytes):
          24 : System.Private.Xml.dasm (0.00% of base)

Top file improvements (bytes):
        -143 : Microsoft.CodeAnalysis.dasm (-0.02% of base)
         -19 : System.Data.OleDb.dasm (-0.01% of base)
         -18 : FSharp.Core.dasm (-0.00% of base)
         -16 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00% of base)
         -15 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
         -13 : System.Data.Common.dasm (-0.00% of base)
         -12 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.00% of base)
         -12 : System.Private.CoreLib.dasm (-0.00% of base)
          -9 : System.Security.AccessControl.dasm (-0.01% of base)
          -6 : System.Data.Odbc.dasm (-0.00% of base)
          -6 : System.Reflection.Metadata.dasm (-0.00% of base)
          -3 : Microsoft.Diagnostics.FastSerialization.dasm (-0.01% of base)
          -3 : Microsoft.VisualBasic.Core.dasm (-0.00% of base)
          -3 : System.Net.Http.dasm (-0.00% of base)
          -3 : System.Speech.dasm (-0.00% of base)

16 total files with Code Size differences (15 improved, 1 regressed), 254 unchanged.

Top method regressions (bytes):
          41 ( 0.77% of base) : System.Private.Xml.dasm - XsltLoader:.ctor():this

Top method improvements (bytes):
        -143 (-48.15% of base) : Microsoft.CodeAnalysis.dasm - PortableShim:Initialize()
         -12 (-2.14% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - TdhEventParser:ParseEventMetaData():DynamicTraceEventData:this
         -10 (-1.29% of base) : System.Data.Common.dasm - SqlDateTime:.cctor()
          -7 (-1.35% of base) : System.Data.OleDb.dasm - OleDbConnectionInternal:GetLiteralInfo(int):String:this
          -6 (-0.75% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindAttributeArguments(NamedTypeSymbol,ArgumentListSyntax,DiagnosticBag):AnalyzedAttributeArguments:this
          -6 (-19.35% of base) : FSharp.Core.dasm - LayoutTag:GetHashCode():int:this
          -6 (-0.20% of base) : System.Data.Odbc.dasm - OdbcMetaDataFactory:DataTableFromDataReaderDataTypes(DataTable,OdbcDataReader,OdbcConnection):this
          -6 (-0.41% of base) : System.Data.OleDb.dasm - OleDbConnectionInternal:BuildInfoLiterals():DataTable:this
          -6 (-2.00% of base) : System.Data.OleDb.dasm - RowBinding:SetVariantValue(int,Object):this
          -6 (-0.23% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Scanner:ScanDateLiteral(SyntaxList`1):SyntaxToken:this
          -6 (-19.35% of base) : FSharp.Core.dasm - ShowMode:GetHashCode():int:this
          -6 (-19.35% of base) : FSharp.Core.dasm - TupleType:GetHashCode():int:this
          -6 (-0.85% of base) : System.Private.Xml.dasm - XmlSchemaImporter:ImportAny(XmlSchemaAny,bool,String):ref:this
          -6 (-0.84% of base) : System.Private.Xml.dasm - XmlSchemaImporter:ImportAnyMapping(XmlSchemaType,String,String,bool):SpecialMapping:this
          -4 (-0.43% of base) : System.Private.CoreLib.dasm - GateThread:GateThreadStart()
          -4 (-7.41% of base) : System.Private.CoreLib.dasm - HillClimbing:ForceChange(int,int):this
          -4 (-4.82% of base) : System.Reflection.Metadata.dasm - MetadataTokens:TryGetTableIndex(ubyte,byref):bool
          -4 (-0.38% of base) : Microsoft.CodeAnalysis.CSharp.dasm - MethodCompiler:GetStateMachineSlotDebugInfo(PEModuleBuilder,IEnumerable`1,VariableSlotAllocator,DiagnosticBag,byref,byref)
          -4 (-1.65% of base) : Microsoft.CodeAnalysis.CSharp.dasm - MethodToStateMachineRewriter:FreeReusableHoistedField(StateMachineFieldSymbol):this
          -4 (-0.44% of base) : System.Private.CoreLib.dasm - WorkerThread:WorkerThreadStart()

Top method regressions (percentages):
          41 ( 0.77% of base) : System.Private.Xml.dasm - XsltLoader:.ctor():this

Top method improvements (percentages):
        -143 (-48.15% of base) : Microsoft.CodeAnalysis.dasm - PortableShim:Initialize()
          -6 (-19.35% of base) : FSharp.Core.dasm - LayoutTag:GetHashCode():int:this
          -6 (-19.35% of base) : FSharp.Core.dasm - ShowMode:GetHashCode():int:this
          -6 (-19.35% of base) : FSharp.Core.dasm - TupleType:GetHashCode():int:this
          -4 (-7.41% of base) : System.Private.CoreLib.dasm - HillClimbing:ForceChange(int,int):this
          -4 (-4.82% of base) : System.Reflection.Metadata.dasm - MetadataTokens:TryGetTableIndex(ubyte,byref):bool
          -3 (-3.30% of base) : Microsoft.VisualBasic.Core.dasm - VB6File:LengthCheck(int):this
          -2 (-2.30% of base) : System.Reflection.Metadata.dasm - MetadataReaderExtensions:GetTableRowCount(MetadataReader,ubyte):int
         -12 (-2.14% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - TdhEventParser:ParseEventMetaData():DynamicTraceEventData:this
          -6 (-2.00% of base) : System.Data.OleDb.dasm - RowBinding:SetVariantValue(int,Object):this
          -4 (-1.65% of base) : Microsoft.CodeAnalysis.CSharp.dasm - MethodToStateMachineRewriter:FreeReusableHoistedField(StateMachineFieldSymbol):this
          -2 (-1.57% of base) : Microsoft.CodeAnalysis.CSharp.dasm - PEFieldSymbol:FilterOutDecimalConstantAttribute():bool:this
          -7 (-1.35% of base) : System.Data.OleDb.dasm - OleDbConnectionInternal:GetLiteralInfo(int):String:this
         -10 (-1.29% of base) : System.Data.Common.dasm - SqlDateTime:.cctor()
          -3 (-1.04% of base) : System.Net.Http.dasm - IntegerDecoder:TryDecode(ubyte,byref):bool:this
          -6 (-0.85% of base) : System.Private.Xml.dasm - XmlSchemaImporter:ImportAny(XmlSchemaAny,bool,String):ref:this
          -6 (-0.84% of base) : System.Private.Xml.dasm - XmlSchemaImporter:ImportAnyMapping(XmlSchemaType,String,String,bool):SpecialMapping:this
          -6 (-0.75% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindAttributeArguments(NamedTypeSymbol,ArgumentListSyntax,DiagnosticBag):AnalyzedAttributeArguments:this
          -2 (-0.68% of base) : Microsoft.CodeAnalysis.CSharp.dasm - PEFieldSymbol:GetConstantValue(ConstantFieldsInProgress,bool):ConstantValue:this
          -3 (-0.47% of base) : System.Speech.dasm - RecognizerBase:FireSignalProblemOccurredEvent(int):this

38 total methods with Code Size differences (37 improved, 1 regressed), 192779 unchanged.
```

`XsltLoader:.ctor():this` regression due to changes in register allocation - using `r12` instead of `r15` in address modes requires SIB byte.