### PR TITLE
Improve 32 bit LONG returns

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -1066,8 +1066,6 @@ protected:
 
     void genUpdateLife(GenTreeLclVarCommon* tree);
     void genUpdateRegLife(const LclVarDsc* varDsc, bool isBorn, bool isDying DEBUGARG(GenTree* tree));
-    void genUpdateVarReg(LclVarDsc* varDsc, GenTree* tree, int regIndex);
-    void genUpdateVarReg(LclVarDsc* varDsc, GenTree* tree);
     regMaskTP genGetRegMask(const LclVarDsc* varDsc);
     regMaskTP genGetRegMask(GenTree* tree);
 

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -900,6 +900,12 @@ void CodeGen::GenStoreLclVar(GenTreeLclVar* store)
 {
     assert(store->OperIs(GT_STORE_LCL_VAR));
 
+    if (store->TypeIs(TYP_LONG))
+    {
+        GenStoreLclVarLong(store);
+        return;
+    }
+
     GenTree* src = store->GetOp(0);
 
     if (src->IsMultiRegNode())
@@ -920,13 +926,6 @@ void CodeGen::GenStoreLclVar(GenTreeLclVar* store)
     }
 
     var_types lclRegType = lcl->GetRegisterType(store);
-
-    if (lclRegType == TYP_LONG)
-    {
-        GenStoreLclVarLong(store);
-        // TODO-MIKE-Review: Doesn't this need a genUpdateLife call?
-        return;
-    }
 
     regNumber srcReg = genConsumeReg(src);
     regNumber dstReg = store->GetRegNum();

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2996,7 +2996,6 @@ void CodeGen::genCodeForSwap(GenTreeOp* tree)
     regNumber oldOp2Reg     = lcl2->GetRegNum();
     regMaskTP oldOp2RegMask = genRegMask(oldOp2Reg);
 
-    // We don't call genUpdateVarReg because we don't have a tree node with the new register.
     varDsc1->SetRegNum(oldOp2Reg);
     varDsc2->SetRegNum(oldOp1Reg);
 

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -10816,40 +10816,6 @@ void CodeGenInterface::VariableLiveKeeper::siStartOrCloseVariableLiveRange(const
 }
 
 //------------------------------------------------------------------------
-// siStartOrCloseVariableLiveRanges: Iterates the given set of variables
-//  calling "siStartOrCloseVariableLiveRange" with each one.
-//
-// Arguments:
-//    varsIndexSet    - the set of variables to report start/end "VariableLiveRange"
-//    isBorn    - whether the set is being born from where the emitter is located.
-//    isDying   - whether the set is dying from where the emitter is located.
-//
-// Assumptions:
-//    The emitter should be located on the first instruction from where is true that
-//    the variable becoming valid (when isBorn is true) or invalid (when isDying is true).
-//
-// Notes:
-//    This method is being called when a set of variables
-//    is being born, becoming dead, or both.
-//
-void CodeGenInterface::VariableLiveKeeper::siStartOrCloseVariableLiveRanges(VARSET_VALARG_TP varsIndexSet,
-                                                                            bool             isBorn,
-                                                                            bool             isDying)
-{
-    if (m_Compiler->opts.compDbgInfo)
-    {
-        VarSetOps::Iter iter(m_Compiler, varsIndexSet);
-        unsigned        varIndex = 0;
-        while (iter.NextElem(&varIndex))
-        {
-            unsigned int     varNum = m_Compiler->lvaTrackedIndexToLclNum(varIndex);
-            const LclVarDsc* varDsc = m_Compiler->lvaGetDesc(varNum);
-            siStartOrCloseVariableLiveRange(varDsc, varNum, isBorn, isDying);
-        }
-    }
-}
-
-//------------------------------------------------------------------------
 // siStartVariableLiveRange: Reports the given variable as being born.
 //
 // Arguments:

--- a/src/coreclr/jit/codegeninterface.h
+++ b/src/coreclr/jit/codegeninterface.h
@@ -677,7 +677,6 @@ public:
 
         // For tracking locations during code generation
         void siStartOrCloseVariableLiveRange(const LclVarDsc* varDsc, unsigned int varNum, bool isBorn, bool isDying);
-        void siStartOrCloseVariableLiveRanges(VARSET_VALARG_TP varsIndexSet, bool isBorn, bool isDying);
         void siStartVariableLiveRange(const LclVarDsc* varDsc, unsigned int varNum);
         void siEndVariableLiveRange(unsigned int varNum);
         void siUpdateVariableLiveRange(const LclVarDsc* varDsc, unsigned int varNum);

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -919,38 +919,6 @@ void CodeGen::SpillRegCandidateLclVar(GenTreeLclVar* lclVar)
 }
 
 //------------------------------------------------------------------------
-// genUpdateVarReg: Update the current register location for a multi-reg lclVar
-//
-// Arguments:
-//    varDsc   - the LclVarDsc for the lclVar
-//    tree     - the lclVar node
-//    regIndex - the index of the register in the node
-//
-// inline
-void CodeGen::genUpdateVarReg(LclVarDsc* varDsc, GenTree* tree, int regIndex)
-{
-    // This should only be called for multireg lclVars.
-    assert(compiler->lvaEnregMultiRegVars);
-    assert(tree->IsMultiRegLclVar() || (tree->gtOper == GT_COPY));
-    varDsc->SetRegNum(tree->GetRegNum(regIndex));
-}
-
-//------------------------------------------------------------------------
-// genUpdateVarReg: Update the current register location for a lclVar
-//
-// Arguments:
-//    varDsc - the LclVarDsc for the lclVar
-//    tree   - the lclVar node
-//
-// inline
-void CodeGen::genUpdateVarReg(LclVarDsc* varDsc, GenTree* tree)
-{
-    // This should not be called for multireg lclVars.
-    assert((tree->OperIs(GT_LCL_VAR, GT_STORE_LCL_VAR) && !tree->IsMultiRegLclVar()) || tree->OperIs(GT_COPY));
-    varDsc->SetRegNum(tree->GetRegNum());
-}
-
-//------------------------------------------------------------------------
 // genCopyRegIfNeeded: Copy the given node into the specified register
 //
 // Arguments:
@@ -1140,7 +1108,7 @@ void CodeGen::CopyReg(GenTreeCopyOrReload* copy)
             {
                 genUpdateRegLife(lcl, /*isBorn*/ false, /*isDying*/ true DEBUGARG(src));
                 gcInfo.gcMarkRegSetNpt(genRegMask(src->GetRegNum()));
-                genUpdateVarReg(lcl, copy);
+                lcl->SetRegNum(copy->GetRegNum());
 #ifdef USING_VARIABLE_LIVE_RANGE
                 varLiveKeeper->siUpdateVariableLiveRange(lcl, src->AsLclVar()->GetLclNum());
 #endif

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -2273,27 +2273,6 @@ CodeGen::GenIntCastDesc::GenIntCastDesc(GenTreeCast* cast)
     }
 }
 
-#ifndef TARGET_64BIT
-
-void CodeGen::GenStoreLclVarLong(GenTreeLclVar* store)
-{
-    LclVarDsc* lcl = compiler->lvaGetDesc(store);
-    assert(lcl->TypeIs(TYP_LONG));
-    assert(!lcl->IsPromoted());
-
-    GenTreeOp* src = store->GetOp(0)->AsOp();
-    assert(src->OperIs(GT_LONG));
-    assert(src->isContained());
-
-    regNumber loSrcReg = genConsumeReg(src->GetOp(0));
-    regNumber hiSrcReg = genConsumeReg(src->GetOp(1));
-
-    GetEmitter()->emitIns_S_R(ins_Store(TYP_INT), EA_4BYTE, loSrcReg, store->GetLclNum(), 0);
-    GetEmitter()->emitIns_S_R(ins_Store(TYP_INT), EA_4BYTE, hiSrcReg, store->GetLclNum(), 4);
-}
-
-#endif
-
 //------------------------------------------------------------------------
 // genCodeForJumpTrue: Generate code for a GT_JTRUE node.
 //

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -4675,7 +4675,6 @@ void CodeGen::genCodeForSwap(GenTreeOp* tree)
     regNumber oldOp2Reg     = lcl2->GetRegNum();
     regMaskTP oldOp2RegMask = genRegMask(oldOp2Reg);
 
-    // We don't call genUpdateVarReg because we don't have a tree node with the new register.
     varDsc1->SetRegNum(oldOp2Reg);
     varDsc2->SetRegNum(oldOp1Reg);
 

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -4149,6 +4149,14 @@ void CodeGen::GenStoreLclVar(GenTreeLclVar* store)
 {
     assert(store->OperIs(GT_STORE_LCL_VAR));
 
+#ifndef TARGET_64BIT
+    if (store->TypeIs(TYP_LONG))
+    {
+        GenStoreLclVarLong(store);
+        return;
+    }
+#endif
+
     GenTree* src = store->GetOp(0);
 
     if (src->IsMultiRegNode())
@@ -4183,15 +4191,6 @@ void CodeGen::GenStoreLclVar(GenTreeLclVar* store)
 
         assert(varTypeUsesFloatReg(lclRegType) == varTypeUsesFloatReg(srcRegType));
         assert(!varTypeUsesFloatReg(lclRegType) || (emitTypeSize(lclRegType) == emitTypeSize(srcRegType)));
-    }
-#endif
-
-#ifndef TARGET_64BIT
-    if (lclRegType == TYP_LONG)
-    {
-        GenStoreLclVarLong(store);
-        // TODO-MIKE-Review: Doesn't this need a genUpdateLife call?
-        return;
     }
 #endif
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6889,48 +6889,6 @@ public:
     // not all JIT Helper calls follow the standard ABI on the target architecture.
     regMaskTP compHelperCallKillSet(CorInfoHelpFunc helper);
 
-    // This map is indexed by GT_OBJ nodes that are address of promoted struct variables, which
-    // have been annotated with the GTF_VAR_DEATH flag.  If such a node is *not* mapped in this
-    // table, one may assume that all the (tracked) field vars die at this GT_OBJ.  Otherwise,
-    // the node maps to a pointer to a VARSET_TP, containing set bits for each of the tracked field
-    // vars of the promoted struct local that go dead at the given node (the set bits are the bits
-    // for the tracked var indices of the field vars, as in a live var set).
-    //
-    // The map is allocated on demand so all map operations should use one of the following three
-    // wrapper methods.
-
-    NodeToVarsetPtrMap* m_promotedStructDeathVars;
-
-    NodeToVarsetPtrMap* GetPromotedStructDeathVars()
-    {
-        if (m_promotedStructDeathVars == nullptr)
-        {
-            m_promotedStructDeathVars = new (getAllocator()) NodeToVarsetPtrMap(getAllocator());
-        }
-        return m_promotedStructDeathVars;
-    }
-
-    void ClearPromotedStructDeathVars()
-    {
-        if (m_promotedStructDeathVars != nullptr)
-        {
-            m_promotedStructDeathVars->RemoveAll();
-        }
-    }
-
-    bool LookupPromotedStructDeathVars(GenTree* tree, VARSET_TP** bits)
-    {
-        *bits       = nullptr;
-        bool result = false;
-
-        if (m_promotedStructDeathVars != nullptr)
-        {
-            result = m_promotedStructDeathVars->Lookup(tree, bits);
-        }
-
-        return result;
-    }
-
 /*
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/src/coreclr/jit/decomposelongs.cpp
+++ b/src/coreclr/jit/decomposelongs.cpp
@@ -318,11 +318,15 @@ GenTree* DecomposeLongs::FinalizeDecomposition(LIR::Use& use,
     assert(Range().Contains(loResult));
     assert(Range().Contains(hiResult));
 
-    GenTree* gtLong = new (m_compiler, GT_LONG) GenTreeOp(GT_LONG, TYP_LONG, loResult, hiResult);
     if (use.IsDummyUse())
     {
-        gtLong->SetUnusedValue();
+        loResult->SetUnusedValue();
+        hiResult->SetUnusedValue();
+
+        return insertResultAfter->gtNext;
     }
+
+    GenTree* gtLong = new (m_compiler, GT_LONG) GenTreeOp(GT_LONG, TYP_LONG, loResult, hiResult);
 
     loResult->ClearUnusedValue();
     hiResult->ClearUnusedValue();

--- a/src/coreclr/jit/decomposelongs.cpp
+++ b/src/coreclr/jit/decomposelongs.cpp
@@ -327,6 +327,7 @@ GenTree* DecomposeLongs::FinalizeDecomposition(LIR::Use& use,
     }
 
     GenTree* gtLong = new (m_compiler, GT_LONG) GenTreeOp(GT_LONG, TYP_LONG, loResult, hiResult);
+    gtLong->SetSideEffects(GTF_EMPTY);
 
     loResult->ClearUnusedValue();
     hiResult->ClearUnusedValue();

--- a/src/coreclr/jit/decomposelongs.h
+++ b/src/coreclr/jit/decomposelongs.h
@@ -70,7 +70,7 @@ private:
     GenTree* RepresentOpAsLocalVar(GenTree* op, GenTree* user, GenTree** edge);
     GenTree* EnsureIntSized(GenTree* node, bool signExtend);
 
-    GenTree* StoreNodeToVar(LIR::Use& use);
+    GenTree* StoreMultiRegNodeToLcl(LIR::Use& use);
     static genTreeOps GetHiOper(genTreeOps oper);
     static genTreeOps GetLoOper(genTreeOps oper);
 

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -157,11 +157,6 @@ void Compiler::fgInit()
     }
 #endif // DEBUG
 
-    if (!compIsForInlining())
-    {
-        m_promotedStructDeathVars = nullptr;
-    }
-
     fgHasSwitch                  = false;
     fgPgoDisabled                = false;
     fgPgoSchema                  = nullptr;

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -8113,7 +8113,7 @@ void Compiler::dmpLclVarCommon(GenTreeLclVarCommon* node, IndentStack* indentSta
         }
     }
 
-    if (!lcl->IsPromoted() && lcl->lvTracked && fgLocalVarLivenessDone && ((node->gtFlags & GTF_VAR_DEATH) != 0))
+    if (fgLocalVarLivenessDone && node->HasLastUse())
     {
         printf("%slast-use", prefix);
     }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -8113,7 +8113,7 @@ void Compiler::dmpLclVarCommon(GenTreeLclVarCommon* node, IndentStack* indentSta
         }
     }
 
-    if (fgLocalVarLivenessDone && node->HasLastUse())
+    if (fgLocalVarLivenessDone && node->OperIs(GT_LCL_VAR, GT_LCL_FLD, GT_STORE_LCL_VAR, GT_STORE_LCL_FLD) && node->HasLastUse())
     {
         printf("%slast-use", prefix);
     }

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1740,8 +1740,7 @@ public:
     // Last-use information for either GenTreeLclVar or GenTreeCopyOrReload nodes.
     bool IsLastUse(unsigned regIndex);
     bool HasLastUse();
-    void SetLastUse(unsigned regIndex);
-    void ClearLastUse(unsigned regIndex);
+    void SetLastUse(unsigned regIndex, bool lastUse);
 
     // Returns true if it is a GT_COPY or GT_RELOAD of a multi-reg call node
     inline bool IsCopyOrReloadOfMultiRegCall() const;
@@ -7786,30 +7785,30 @@ constexpr GenTreeFlags GetLastUseFlag(unsigned regIndex)
 
 inline bool GenTree::IsLastUse(unsigned regIndex)
 {
-    assert(OperIs(GT_LCL_VAR, GT_STORE_LCL_VAR, GT_COPY, GT_RELOAD));
+    assert(OperIs(GT_LCL_VAR, GT_STORE_LCL_VAR, GT_LCL_FLD, GT_STORE_LCL_FLD, GT_COPY, GT_RELOAD));
 
     return (gtFlags & GetLastUseFlag(regIndex)) != 0;
 }
 
 inline bool GenTree::HasLastUse()
 {
-    assert(OperIs(GT_LCL_VAR, GT_STORE_LCL_VAR, GT_COPY, GT_RELOAD));
+    assert(OperIs(GT_LCL_VAR, GT_STORE_LCL_VAR, GT_LCL_FLD, GT_STORE_LCL_FLD, GT_COPY, GT_RELOAD));
 
     return (gtFlags & (GTF_VAR_DEATH_MASK)) != 0;
 }
 
-inline void GenTree::SetLastUse(unsigned regIndex)
+inline void GenTree::SetLastUse(unsigned regIndex, bool lastUse)
 {
-    assert(OperIs(GT_LCL_VAR, GT_STORE_LCL_VAR, GT_COPY, GT_RELOAD));
+    assert(OperIs(GT_LCL_VAR, GT_STORE_LCL_VAR, GT_LCL_FLD, GT_STORE_LCL_FLD, GT_COPY, GT_RELOAD));
 
-    gtFlags |= GetLastUseFlag(regIndex);
-}
-
-inline void GenTree::ClearLastUse(unsigned regIndex)
-{
-    assert(OperIs(GT_LCL_VAR, GT_STORE_LCL_VAR, GT_COPY, GT_RELOAD));
-
-    gtFlags &= ~GetLastUseFlag(regIndex);
+    if (lastUse)
+    {
+        gtFlags |= GetLastUseFlag(regIndex);
+    }
+    else
+    {
+        gtFlags &= ~GetLastUseFlag(regIndex);
+    }
 }
 
 //-----------------------------------------------------------------------------------

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -43,7 +43,7 @@ void Compiler::fgMarkUseDef(GenTreeLclVarCommon* node)
         return;
     }
 
-    if (varTypeIsStruct(lcl->GetType()) && lcl->IsPromoted())
+    if (lcl->IsPromoted())
     {
         // TODO-MIKE-Cleanup: This is kind of strange because it doesn't bother to
         // check which fields actually overlap a LCL_FLD access. Since a LCL_FLD
@@ -1513,20 +1513,16 @@ bool Compiler::fgComputeLifeUntrackedLocal(VARSET_TP&           liveOut,
                 return true;
             }
         }
-        else if (varTypeIsStruct(lcl->GetType()))
+        else
         {
             if (!lcl->IsIndependentPromoted())
             {
                 return true;
             }
         }
-        else
-        {
-            return true;
-        }
     }
 
-    if (lcl->IsAddressExposed() || !varTypeIsStruct(lcl->GetType()) || !lcl->IsPromoted())
+    if (lcl->IsAddressExposed() || !lcl->IsPromoted())
     {
         return false;
     }

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -16,7 +16,8 @@ void Compiler::fgMarkUseDef(GenTreeLclVarCommon* node)
     assert(!lcl->IsAddressExposed());
 
     // We should never encounter a reference to a local that has a zero ref count.
-    if ((lcl->lvRefCnt() == 0) && (!varTypeIsPromotable(lcl->GetType()) || !lcl->IsPromoted()))
+    // TODO-MIKE-Review: It's not clear why promotion makes a difference.
+    if ((lcl->lvRefCnt() == 0) && !lcl->IsPromoted())
     {
         JITDUMP("Found reference to V%02u with zero refCnt.\n", node->GetLclNum());
         assert(!"We should never encounter a reference to a lclVar that has a zero refCnt.");

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -352,7 +352,7 @@ private:
 
     void WidenSIMD12IfNecessary(GenTreeLclVarCommon* node);
 #if FEATURE_MULTIREG_RET
-    void MakeMultiRegStoreLclVar(GenTreeLclVar* lclVar, const ReturnTypeDesc* retTypeDesc);
+    void MakeMultiRegStoreLclVar(GenTreeLclVar* store, GenTree* value);
 #endif
     GenTree* LowerArrElem(GenTree* node);
     void LowerRotate(GenTree* tree);

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -2136,7 +2136,7 @@ void LinearScan::checkLastUses(BasicBlock* block)
                     // Checked or Debug builds, for which this method will be executed.
                     if (tree != nullptr)
                     {
-                        tree->AsLclVar()->SetLastUse(currentRefPosition->multiRegIdx);
+                        tree->SetLastUse(currentRefPosition->multiRegIdx, true);
                     }
                 }
                 else if (!currentRefPosition->lastUse)
@@ -2155,7 +2155,7 @@ void LinearScan::checkLastUses(BasicBlock* block)
             else if (extendLifetimes() && tree != nullptr)
             {
                 // NOTE: see the comment above re: the extendLifetimes hack.
-                tree->AsLclVar()->ClearLastUse(currentRefPosition->multiRegIdx);
+                tree->SetLastUse(currentRefPosition->multiRegIdx, false);
             }
 
             if (currentRefPosition->refType == RefTypeDef || currentRefPosition->refType == RefTypeDummyDef)
@@ -5729,14 +5729,7 @@ void LinearScan::resolveLocalRef(BasicBlock* block, GenTreeLclVar* treeNode, Ref
     // lifetimes. See also the comments in checkLastUses.
     if ((treeNode != nullptr) && !extendLifetimes())
     {
-        if (currentRefPosition->lastUse)
-        {
-            treeNode->SetLastUse(currentRefPosition->getMultiRegIdx());
-        }
-        else
-        {
-            treeNode->ClearLastUse(currentRefPosition->getMultiRegIdx());
-        }
+        treeNode->SetLastUse(currentRefPosition->getMultiRegIdx(), currentRefPosition->lastUse);
 
         if ((currentRefPosition->registerAssignment != RBM_NONE) && (interval->physReg == REG_NA) &&
             currentRefPosition->RegOptional() && currentRefPosition->lastUse &&
@@ -6122,7 +6115,7 @@ void LinearScan::insertCopyOrReload(BasicBlock* block, GenTree* tree, unsigned m
         {
             // This is a TEMPORARY copy
             assert(isCandidateLclVar(tree) || tree->IsMultiRegLclVar());
-            newNode->SetLastUse(multiRegIdx);
+            newNode->SetLastUse(multiRegIdx, true);
         }
 
         // Insert the copy/reload after the spilled node and replace the use of the original node with a use

--- a/src/coreclr/jit/treelifeupdater.cpp
+++ b/src/coreclr/jit/treelifeupdater.cpp
@@ -286,8 +286,6 @@ void CodeGenLivenessUpdater::UpdateLifePromoted(CodeGen* codeGen, GenTreeLclVarC
         isDying = (lclNode->gtFlags & GTF_VAR_DEATH) != 0;
     }
 
-    bool spill = lclNode->IsAnyRegSpill();
-
     if (isBorn || isDying)
     {
         VarSetOps::Assign(compiler, newLife, currentLife);
@@ -309,8 +307,8 @@ void CodeGenLivenessUpdater::UpdateLifePromoted(CodeGen* codeGen, GenTreeLclVarC
 
                 bool isInReg        = fieldLcl->lvIsInReg() && (lclNode->GetRegNum(i) != REG_NA);
                 bool isInMemory     = !isInReg || fieldLcl->IsAlwaysAliveInMemory();
-                bool isFieldDying   = lclNode->AsLclVar()->IsLastUse(i);
-                bool isFieldSpilled = spill && lclNode->IsRegSpill(i);
+                bool isFieldDying   = lclNode->IsLastUse(i);
+                bool isFieldSpilled = lclNode->IsRegSpill(i);
 
                 if ((isBorn && !isFieldDying) || (!isBorn && isFieldDying))
                 {
@@ -335,11 +333,11 @@ void CodeGenLivenessUpdater::UpdateLifePromoted(CodeGen* codeGen, GenTreeLclVarC
                     assert(!isFieldSpilled);
                 }
             }
-
-            spill = false;
         }
         else
         {
+            assert(!lclNode->IsAnyRegSpill());
+
             bool hasDeadTrackedFields = false;
 
             if (isDying)
@@ -436,6 +434,4 @@ void CodeGenLivenessUpdater::UpdateLifePromoted(CodeGen* codeGen, GenTreeLclVarC
 #endif
         }
     }
-
-    assert(!spill);
 }

--- a/src/coreclr/jit/treelifeupdater.cpp
+++ b/src/coreclr/jit/treelifeupdater.cpp
@@ -249,8 +249,6 @@ void CodeGenLivenessUpdater::UpdateLife(CodeGen* codeGen, GenTreeLclVarCommon* l
 
             if (isDying)
             {
-                assert(!isBorn);
-
                 VARSET_TP* deadTrackedFields = nullptr;
                 hasDeadTrackedFields         = compiler->LookupPromotedStructDeathVars(lclNode, &deadTrackedFields);
                 if (hasDeadTrackedFields)

--- a/src/coreclr/jit/treelifeupdater.cpp
+++ b/src/coreclr/jit/treelifeupdater.cpp
@@ -413,14 +413,6 @@ void CodeGenLivenessUpdater::UpdateLifePromoted(CodeGen* codeGen, GenTreeLclVarC
                 DBEXEC(compiler->verbose,
                        compiler->dmpVarSetDiff("GC stack vars: ", scratchSet, codeGen->gcInfo.gcVarPtrSetCur);)
             }
-
-#ifdef USING_VARIABLE_LIVE_RANGE
-            codeGen->getVariableLiveKeeper()->siStartOrCloseVariableLiveRanges(varDeltaSet, isBorn, isDying);
-#endif
-
-#ifdef USING_SCOPE_INFO
-            codeGen->siUpdate();
-#endif
         }
     }
 }

--- a/src/coreclr/jit/treelifeupdater.cpp
+++ b/src/coreclr/jit/treelifeupdater.cpp
@@ -5,7 +5,6 @@
 void CodeGenLivenessUpdater::Begin()
 {
     currentLife           = VarSetOps::MakeEmpty(compiler);
-    newLife               = VarSetOps::MakeEmpty(compiler);
     varDeltaSet           = VarSetOps::MakeEmpty(compiler);
     varStackGCPtrDeltaSet = VarSetOps::MakeEmpty(compiler);
 

--- a/src/coreclr/jit/treelifeupdater.cpp
+++ b/src/coreclr/jit/treelifeupdater.cpp
@@ -168,11 +168,9 @@ void CodeGenLivenessUpdater::UpdateLife(CodeGen* codeGen, GenTreeLclVarCommon* l
 
     if (isBorn || isDying)
     {
-        VarSetOps::Assign(compiler, newLife, currentLife);
-
         if (isBorn && lcl->IsRegCandidate() && (lclNode->GetRegNum() != REG_NA))
         {
-            codeGen->genUpdateVarReg(lcl, lclNode);
+            lcl->SetRegNum(lclNode->GetRegNum());
         }
 
         bool isInReg    = lcl->lvIsInReg() && (lclNode->GetRegNum() != REG_NA);
@@ -182,6 +180,8 @@ void CodeGenLivenessUpdater::UpdateLife(CodeGen* codeGen, GenTreeLclVarCommon* l
         {
             codeGen->genUpdateRegLife(lcl, isBorn, isDying DEBUGARG(lclNode));
         }
+
+        VarSetOps::Assign(compiler, newLife, currentLife);
 
         if (isDying)
         {
@@ -313,7 +313,7 @@ void CodeGenLivenessUpdater::UpdateLifePromoted(CodeGen* codeGen, GenTreeLclVarC
                 {
                     if (isBorn)
                     {
-                        codeGen->genUpdateVarReg(fieldLcl, lclNode, i);
+                        fieldLcl->SetRegNum(lclNode->GetRegNum(i));
                     }
 
                     codeGen->genUpdateRegLife(fieldLcl, isBorn, isFieldDying DEBUGARG(lclNode));

--- a/src/coreclr/jit/treelifeupdater.h
+++ b/src/coreclr/jit/treelifeupdater.h
@@ -18,6 +18,7 @@ class CodeGenLivenessUpdater
     INDEBUG(VARSET_TP scratchSet;)
     INDEBUG(unsigned epoch;)
 
+    void UpdateLifeMultiReg(class CodeGen* codeGen, GenTreeLclVar* lclNode);
     void UpdateLifePromoted(class CodeGen* codeGen, GenTreeLclVarCommon* lclNode);
 
 public:

--- a/src/coreclr/jit/treelifeupdater.h
+++ b/src/coreclr/jit/treelifeupdater.h
@@ -12,7 +12,6 @@ class CodeGenLivenessUpdater
     Compiler* compiler;
     GenTree*  currentNode;
     VARSET_TP currentLife;
-    VARSET_TP newLife;
     VARSET_TP varDeltaSet;
     VARSET_TP varStackGCPtrDeltaSet;
 #ifdef DEBUG

--- a/src/coreclr/jit/treelifeupdater.h
+++ b/src/coreclr/jit/treelifeupdater.h
@@ -18,6 +18,8 @@ class CodeGenLivenessUpdater
     INDEBUG(VARSET_TP scratchSet;)
     INDEBUG(unsigned epoch;)
 
+    void UpdateLifePromoted(class CodeGen* codeGen, GenTreeLclVarCommon* lclNode);
+
 public:
     CodeGenLivenessUpdater(Compiler* compiler) : compiler(compiler)
     {

--- a/src/coreclr/jit/treelifeupdater.h
+++ b/src/coreclr/jit/treelifeupdater.h
@@ -15,8 +15,11 @@ class CodeGenLivenessUpdater
     VARSET_TP newLife;
     VARSET_TP varDeltaSet;
     VARSET_TP varStackGCPtrDeltaSet;
-    INDEBUG(VARSET_TP scratchSet;)
-    INDEBUG(unsigned epoch;)
+#ifdef DEBUG
+    VARSET_TP scratchSet1;
+    VARSET_TP scratchSet2;
+    unsigned  epoch;
+#endif
 
     void UpdateLifeMultiReg(class CodeGen* codeGen, GenTreeLclVar* lclNode);
     void UpdateLifePromoted(class CodeGen* codeGen, GenTreeLclVarCommon* lclNode);

--- a/src/coreclr/jit/treelifeupdater.h
+++ b/src/coreclr/jit/treelifeupdater.h
@@ -22,6 +22,7 @@ class CodeGenLivenessUpdater
 
     void UpdateLifeMultiReg(class CodeGen* codeGen, GenTreeLclVar* lclNode);
     void UpdateLifePromoted(class CodeGen* codeGen, GenTreeLclVarCommon* lclNode);
+    INDEBUG(void DumpDiff(class CodeGen* codeGen);)
 
 public:
     CodeGenLivenessUpdater(Compiler* compiler) : compiler(compiler)

--- a/src/coreclr/jit/vartype.h
+++ b/src/coreclr/jit/vartype.h
@@ -292,23 +292,6 @@ inline bool varTypeIsComposite(T vt)
     return (!varTypeIsArithmetic(TypeGet(vt)) && TypeGet(vt) != TYP_VOID);
 }
 
-// Is this type promotable?
-// In general only structs are promotable.
-// However, a SIMD type, e.g. TYP_SIMD may be handled as either a struct, OR a
-// fully-promoted register type.
-// On 32-bit systems longs are split into an upper and lower half, and they are
-// handled as if they are structs with two integer fields.
-
-template <class T>
-inline bool varTypeIsPromotable(T vt)
-{
-    return varTypeIsStruct(vt)
-#ifndef TARGET_64BIT
-           || varTypeIsLong(vt)
-#endif
-        ;
-}
-
 template <class T>
 inline bool varTypeIsStruct(T vt)
 {


### PR DESCRIPTION
win-x86 pmi diff:
```
Total bytes of base: 47348270
Total bytes of diff: 47251881
Total bytes of delta: -96389 (-0.20 % of base)
Total relative delta: -715.48
    diff is an improvement.
    relative diff is an improvement.


Top file improvements (bytes):
      -14301 : System.Private.CoreLib.dasm (-0.32% of base)
      -11542 : Microsoft.CodeAnalysis.CSharp.dasm (-0.29% of base)
       -9981 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.35% of base)
       -7740 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.15% of base)
       -6463 : System.Private.Xml.dasm (-0.21% of base)
       -5791 : Microsoft.VisualBasic.Core.dasm (-1.41% of base)
       -3934 : FSharp.Core.dasm (-0.13% of base)
       -3458 : System.Linq.dasm (-0.39% of base)
       -3417 : System.Reflection.Metadata.dasm (-0.69% of base)
       -3066 : System.Data.Common.dasm (-0.23% of base)
       -1863 : Microsoft.CodeAnalysis.dasm (-0.12% of base)
       -1434 : Newtonsoft.Json.dasm (-0.20% of base)
       -1259 : System.Linq.Parallel.dasm (-0.08% of base)
       -1221 : System.Net.Http.dasm (-0.19% of base)
       -1213 : System.Text.Json.dasm (-0.15% of base)
       -1177 : System.Private.DataContractSerialization.dasm (-0.18% of base)
        -973 : System.Threading.Tasks.Dataflow.dasm (-0.11% of base)
        -937 : System.Collections.Immutable.dasm (-0.08% of base)
        -802 : System.Linq.Queryable.dasm (-0.29% of base)
        -735 : Microsoft.Diagnostics.FastSerialization.dasm (-0.73% of base)

124 total files with Code Size differences (124 improved, 0 regressed), 147 unchanged.

Top method regressions (bytes):
          99 (11.69% of base) : System.Private.CoreLib.dasm - TimerQueue:FireNextTimers():this
          49 ( 8.29% of base) : System.IO.Compression.dasm - ZipArchiveEntry:WriteCrcAndSizesInLocalHeader(bool):this
          41 ( 3.40% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - <>c__DisplayClass32_0:<SetupCallbacks>b__33(GCHeapStatsTraceData):this
          38 ( 1.69% of base) : System.Diagnostics.PerformanceCounter.dasm - CategorySample:.ctor(ref,CategoryEntry,PerformanceCounterLib):this
          31 ( 0.12% of base) : Microsoft.CodeAnalysis.dasm - ArrayBuilder`1:SelectDistinct(Func`2):ImmutableArray`1:this (64 methods)
          31 ( 2.13% of base) : System.Private.CoreLib.dasm - Variant:MarshalHelperConvertObjectToVariant(Object,byref)
          23 ( 5.62% of base) : System.Text.Encoding.CodePages.dasm - ISO2022Encoding:GetMaxByteCount(int):int:this
          18 ( 0.37% of base) : System.Numerics.Tensors.dasm - Tensor`1:GetTriangle(int,bool):Tensor`1:this (8 methods)
          16 ( 1.33% of base) : System.Private.CoreLib.dasm - DateTimeFormat:TryFormatO(DateTime,TimeSpan,Span`1,byref):bool
          16 ( 2.66% of base) : System.Private.CoreLib.dasm - HijriCalendar:GetDatePart(long,int):int:this
           9 ( 0.61% of base) : FSharp.Core.dasm - QueryModule:TransFor@1294(int,bool,Type,FSharpVar,Type,ConversionDescription,TransInnerResult,FSharpExpr):Tuple`2
           8 ( 2.84% of base) : FSharp.Core.dasm - ArrayModule:Average$W(FSharpFunc`2,FSharpFunc`2,FSharpFunc`2,ref):long
           8 ( 2.92% of base) : FSharp.Core.dasm - ListModule:ReduceBack(FSharpFunc`2,FSharpList`1):long
           8 ( 3.07% of base) : FSharp.Core.dasm - SeqModule:ReduceBack(FSharpFunc`2,IEnumerable`1):long
           7 ( 0.82% of base) : Newtonsoft.Json.dasm - BooleanQueryExpression:EqualsWithStringCoercion(JValue,JValue):bool
           6 ( 7.23% of base) : System.Runtime.Numerics.dasm - BigIntegerCalculator:Remainder(ref,int):int
           6 ( 1.30% of base) : Microsoft.CodeAnalysis.dasm - ManagedResource:WriteData(BlobBuilder):this
           6 ( 0.88% of base) : System.Reflection.Metadata.dasm - SignatureDecoder`2:DecodeArrayType(byref):long:this
           4 ( 0.17% of base) : CommandLine.dasm - EnumerableExtensions:ToDelimitedStringImpl(IEnumerable`1,String,Func`3):String (8 methods)
           4 ( 1.07% of base) : Newtonsoft.Json.dasm - JsonConvert:ToString(DateTimeOffset,int):String

Top method improvements (bytes):
       -1627 (-26.15% of base) : System.Reflection.Metadata.dasm - PEHeader:.ctor(byref):this
       -1024 (-13.22% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:FoldNeverOverflowBinaryOperators(int,ConstantValue,ConstantValue):Object
        -638 (-19.39% of base) : Microsoft.VisualBasic.Core.dasm - Operators:IntDivideObject(Object,Object):Object
        -620 (-46.90% of base) : System.Private.Xml.dasm - XslVisitor`1:Visit(XslNode):long:this
        -546 (-3.59% of base) : System.Data.Common.dasm - BinaryNode:EvalBinaryOp(int,ExpressionNode,ExpressionNode,DataRow,int,ref):Object:this
        -446 (-32.89% of base) : System.Reflection.Metadata.dasm - SignatureDecoder`2:DecodeType(byref,bool,int):long:this
        -365 (-11.45% of base) : Microsoft.VisualBasic.Core.dasm - Operators:XorObject(Object,Object):Object
        -345 (-11.81% of base) : Microsoft.VisualBasic.Core.dasm - ObjectType:IDivObj(Object,Object):Object
        -337 (-24.24% of base) : System.Private.CoreLib.dasm - DecCalc:VarDecMul(byref,byref)
        -324 (-21.41% of base) : System.Reflection.Metadata.dasm - CorHeader:.ctor(byref):this
        -279 (-13.13% of base) : Microsoft.VisualBasic.Core.dasm - Operators:OrObject(Object,Object):Object
        -271 (-4.83% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - ExpressionEvaluator:PerformCompileTimeBinaryOperation(ushort,byte,CConst,CConst,ExpressionSyntax):CConst
        -254 (-5.63% of base) : Microsoft.VisualBasic.Core.dasm - Operators:ModObject(Object,Object):Object
        -223 (-11.13% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - OverloadResolution:FoldIntegralCharOrDateTimeBinaryOperator(int,ConstantValue,ConstantValue,TypeSymbol,TypeSymbol,byref,byref):ConstantValue
        -222 (-0.79% of base) : System.Linq.dasm - Enumerable:Max(IEnumerable`1,Func`2):Nullable`1 (48 methods)
        -213 (-15.96% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:FoldUncheckedIntegralBinaryOperator(int,ConstantValue,ConstantValue):Object
        -208 (-6.05% of base) : System.Private.CoreLib.dasm - TimeSpanFormat:FormatCustomized(TimeSpan,ReadOnlySpan`1,DateTimeFormatInfo,StringBuilder):StringBuilder
        -202 (-6.74% of base) : Microsoft.VisualBasic.Core.dasm - Operators:SubtractObject(Object,Object):Object
        -198 (-7.76% of base) : System.ComponentModel.TypeConverter.dasm - DateTimeOffsetConverter:ConvertTo(ITypeDescriptorContext,CultureInfo,Object,Type):Object:this
        -195 (-6.04% of base) : Microsoft.VisualBasic.Core.dasm - Operators:AddObject(Object,Object):Object

Top method regressions (percentages):
          99 (11.69% of base) : System.Private.CoreLib.dasm - TimerQueue:FireNextTimers():this
          49 ( 8.29% of base) : System.IO.Compression.dasm - ZipArchiveEntry:WriteCrcAndSizesInLocalHeader(bool):this
           6 ( 7.23% of base) : System.Runtime.Numerics.dasm - BigIntegerCalculator:Remainder(ref,int):int
          23 ( 5.62% of base) : System.Text.Encoding.CodePages.dasm - ISO2022Encoding:GetMaxByteCount(int):int:this
           3 ( 4.55% of base) : System.Private.CoreLib.dasm - DateTime:get_Hour():int:this
           3 ( 4.00% of base) : System.Private.CoreLib.dasm - DateTimeOffset:get_Hour():int:this
          41 ( 3.40% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - <>c__DisplayClass32_0:<SetupCallbacks>b__33(GCHeapStatsTraceData):this
           8 ( 3.07% of base) : FSharp.Core.dasm - SeqModule:ReduceBack(FSharpFunc`2,IEnumerable`1):long
           8 ( 2.92% of base) : FSharp.Core.dasm - ListModule:ReduceBack(FSharpFunc`2,FSharpList`1):long
           8 ( 2.84% of base) : FSharp.Core.dasm - ArrayModule:Average$W(FSharpFunc`2,FSharpFunc`2,FSharpFunc`2,ref):long
          16 ( 2.66% of base) : System.Private.CoreLib.dasm - HijriCalendar:GetDatePart(long,int):int:this
          31 ( 2.13% of base) : System.Private.CoreLib.dasm - Variant:MarshalHelperConvertObjectToVariant(Object,byref)
          38 ( 1.69% of base) : System.Diagnostics.PerformanceCounter.dasm - CategorySample:.ctor(ref,CategoryEntry,PerformanceCounterLib):this
           1 ( 1.64% of base) : Microsoft.Diagnostics.FastSerialization.dasm - Deserializer:ReadDouble():double:this
           3 ( 1.36% of base) : FSharp.Core.dasm - ListModule:Average$W(FSharpFunc`2,FSharpFunc`2,FSharpFunc`2,FSharpList`1):long
          16 ( 1.33% of base) : System.Private.CoreLib.dasm - DateTimeFormat:TryFormatO(DateTime,TimeSpan,Span`1,byref):bool
           6 ( 1.30% of base) : Microsoft.CodeAnalysis.dasm - ManagedResource:WriteData(BlobBuilder):this
           2 ( 1.30% of base) : FSharp.Core.dasm - ArrayModule:Sum$W(FSharpFunc`2,FSharpFunc`2,ref):long
           4 ( 1.07% of base) : Newtonsoft.Json.dasm - JsonConvert:ToString(DateTimeOffset,int):String
           6 ( 0.88% of base) : System.Reflection.Metadata.dasm - SignatureDecoder`2:DecodeArrayType(byref):long:this

Top method improvements (percentages):
         -14 (-56.00% of base) : System.Private.CoreLib.dasm - DecCalc:UInt32x32To64(int,int):long
         -14 (-56.00% of base) : System.Private.CoreLib.dasm - Math:BigMul(int,int):long
         -14 (-53.85% of base) : System.Private.CoreLib.dasm - AppDomain:get_MonitoringSurvivedMemorySize():long:this
         -14 (-53.85% of base) : System.Private.CoreLib.dasm - BitConverter:ToUInt64(ref,int):long
         -14 (-53.85% of base) : System.Reflection.Metadata.dasm - BlobReader:ReadUInt64():long:this
         -14 (-53.85% of base) : FSharp.Core.dasm - ExtraTopLevelOperators:PrintFormatToString(PrintfFormat`4):long
         -14 (-53.85% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - FastStream:ReadULong():long:this
         -14 (-53.85% of base) : FSharp.Core.dasm - FSharpList`1:get_Item(int):long:this
         -14 (-53.85% of base) : FSharp.Core.dasm - FSharpList`1:System.Collections.Generic.IReadOnlyList<'T>.get_Item(int):long:this
         -14 (-53.85% of base) : Newtonsoft.Json.dasm - JsonFormatterConverter:ToInt64(Object):long:this
         -14 (-53.85% of base) : Newtonsoft.Json.dasm - JsonFormatterConverter:ToUInt64(Object):long:this
         -14 (-53.85% of base) : Newtonsoft.Json.dasm - JValue:System.IConvertible.ToInt64(IFormatProvider):long:this
         -14 (-53.85% of base) : Newtonsoft.Json.dasm - JValue:System.IConvertible.ToUInt64(IFormatProvider):long:this
         -14 (-53.85% of base) : System.Private.CoreLib.dasm - Lazy`1:CreateViaDefaultConstructor():long
         -14 (-53.85% of base) : FSharp.Core.dasm - Operators:Unbox(Object):long
         -14 (-53.85% of base) : FSharp.Core.dasm - SeqModule:Get(int,IEnumerable`1):long
         -14 (-53.85% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - TraceEvent:GetAddressAt(int):long:this
         -14 (-53.85% of base) : System.Private.DataContractSerialization.dasm - XmlBufferReader:GetUInt64(int):long:this
         -14 (-51.85% of base) : CommandLine.dasm - <>c__0`1:<Build>b__0_16(Func`1):long:this
         -14 (-51.85% of base) : CommandLine.dasm - <>c__0`1:<Build>b__0_4(Func`1):long:this

4824 total methods with Code Size differences (4795 improved, 29 regressed), 270472 unchanged.
```
Regressions caused by changes in reg/frame alloc.