### PR TITLE
Recognize CLS_VAR_ADDR for struct static fields

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5742,29 +5742,9 @@ public:
     void optVnCopyProp();
     INDEBUG(void optDumpCopyPropStack(LclNumToGenTreePtrStack* curSsaName));
 
-    /**************************************************************************
-     *               Early value propagation
-     *************************************************************************/
-    struct SSAName
-    {
-        unsigned m_lvNum;
-        unsigned m_ssaNum;
-
-        SSAName(unsigned lvNum, unsigned ssaNum) : m_lvNum(lvNum), m_ssaNum(ssaNum)
-        {
-        }
-
-        static unsigned GetHashCode(SSAName ssaNm)
-        {
-            return (ssaNm.m_lvNum << 16) | (ssaNm.m_ssaNum);
-        }
-
-        static bool Equals(SSAName ssaNm1, SSAName ssaNm2)
-        {
-            return (ssaNm1.m_lvNum == ssaNm2.m_lvNum) && (ssaNm1.m_ssaNum == ssaNm2.m_ssaNum);
-        }
-    };
-
+/**************************************************************************
+ *               Early value propagation
+ *************************************************************************/
 #define OMF_HAS_NEWARRAY 0x00000001         // Method contains 'new' of an array
 #define OMF_HAS_NEWOBJ 0x00000002           // Method contains 'new' of an object type.
 #define OMF_HAS_ARRAYREF 0x00000004         // Method contains array element loads or stores.
@@ -5879,18 +5859,11 @@ public:
     // No throughput diff was found with backward walk bound between 3-8.
     static const int optEarlyPropRecurBound = 5;
 
-    enum class optPropKind
-    {
-        OPK_INVALID,
-        OPK_ARRAYLEN,
-        OPK_NULLCHECK
-    };
-
     typedef JitHashTable<unsigned, JitSmallPrimitiveKeyFuncs<unsigned>, GenTree*> LocalNumberToNullCheckTreeMap;
 
     GenTree* getArrayLengthFromAllocation(GenTree* tree DEBUGARG(BasicBlock* block));
-    GenTree* optPropGetValueRec(unsigned lclNum, unsigned ssaNum, optPropKind valueKind, int walkDepth);
-    GenTree* optPropGetValue(unsigned lclNum, unsigned ssaNum, optPropKind valueKind);
+    GenTree* optPropGetValueRec(GenTreeLclVar* lclVar, int walkDepth);
+    GenTree* optPropGetValue(GenTreeLclVar* lclVar);
     GenTree* optEarlyPropRewriteTree(GenTree* tree, LocalNumberToNullCheckTreeMap* nullCheckMap);
     bool optDoEarlyPropForBlock(BasicBlock* block);
     bool optDoEarlyPropForFunc();

--- a/src/coreclr/jit/ssabuilder.h
+++ b/src/coreclr/jit/ssabuilder.h
@@ -7,11 +7,6 @@
 #include "compiler.h"
 #include "ssarenamestate.h"
 
-typedef int LclVarNum;
-
-// Pair of a local var name eg: V01 and Ssa number; eg: V01_01
-typedef std::pair<LclVarNum, int> SsaVarName;
-
 class SsaBuilder
 {
 private:

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -3850,9 +3850,11 @@ FieldSeqNode* Compiler::vnIsStaticStructFieldAddr(GenTree* addr)
 {
     FieldSeqNode* fieldSeq = nullptr;
 
-    // TODO-MIKE-CQ: This doesn't check for CLS_VAR_ADDR.
-
-    if (GenTreeIntCon* intCon = addr->IsIntCon())
+    if (GenTreeClsVar* clsVarAddr = addr->IsClsVar())
+    {
+        fieldSeq = clsVarAddr->GetFieldSeq();
+    }
+    else if (GenTreeIntCon* intCon = addr->IsIntCon())
     {
         fieldSeq = intCon->GetFieldSeq();
     }


### PR DESCRIPTION
win-x86 pmi diff:
```
Total bytes of base: 47289725
Total bytes of diff: 47288975
Total bytes of delta: -750 (-0.00 % of base)
    diff is an improvement.

Top file regressions (bytes):
           9 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (0.00% of base)

Top file improvements (bytes):
        -222 : System.Data.Common.dasm (-0.02% of base)
        -157 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00% of base)
        -108 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.00% of base)
         -72 : System.Reflection.Metadata.dasm (-0.01% of base)
         -54 : ILCompiler.TypeSystem.ReadyToRun.dasm (-0.02% of base)
         -31 : System.Private.CoreLib.dasm (-0.00% of base)
         -28 : System.Management.dasm (-0.01% of base)
         -26 : Newtonsoft.Json.Bson.dasm (-0.03% of base)
         -26 : Newtonsoft.Json.dasm (-0.00% of base)
         -14 : System.Configuration.ConfigurationManager.dasm (-0.01% of base)
         -14 : System.Net.Http.dasm (-0.00% of base)
          -7 : Microsoft.CodeAnalysis.dasm (-0.00% of base)

13 total files with Code Size differences (12 improved, 1 regressed), 258 unchanged.

Top method regressions (bytes):
           9 ( 1.35% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - BPerfEventSource:.ctor(String,TraceEventDispatcherOptions,ref,ref,bool):this

Top method improvements (bytes):
        -173 (-26.09% of base) : System.Data.Common.dasm - DateTimeOffsetStorage:Compare(int,int):int:this
         -91 (-3.92% of base) : Microsoft.CodeAnalysis.CSharp.dasm - BuiltInOperators:GetSimpleBuiltInOperators(int,ArrayBuilder`1):this (2 methods)
         -47 (-24.61% of base) : ILCompiler.TypeSystem.ReadyToRun.dasm - UniversalCanonLayoutAlgorithm:ComputeStaticFieldLayout(DefType,int):ComputedStaticFieldLayout:this
         -40 (-12.54% of base) : System.Data.Common.dasm - DateTimeStorage:Compare(int,int):int:this
         -39 (-4.73% of base) : Microsoft.CodeAnalysis.CSharp.dasm - MethodBodySynthesizer:ConstructDestructorBody(MethodSymbol,BoundBlock):BoundBlock
         -29 (-8.48% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxFactory:Literal(String,String):SyntaxToken
         -29 (-8.58% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxFactory:Literal(String,ushort):SyntaxToken
         -26 (-1.18% of base) : Newtonsoft.Json.Bson.dasm - DateTimeUtils:TryParseDateTimeIso(String,int,byref):bool
         -26 (-1.16% of base) : Newtonsoft.Json.dasm - DateTimeUtils:TryParseDateTimeIso(StringReference,int,byref):bool
         -14 (-3.28% of base) : System.Private.CoreLib.dasm - CurrentSystemTimeZone:CreateDaylightChanges(int):DaylightTime
         -14 (-1.25% of base) : System.Net.Http.dasm - HttpConnectionPoolManager:.ctor(HttpConnectionSettings):this
         -14 (-3.41% of base) : System.Configuration.ConfigurationManager.dasm - InternalConfigHost:StaticGetStreamVersion(String):FileVersion
         -14 (-6.90% of base) : System.Management.dasm - WqlEventQuery:.ctor():this
         -14 (-6.48% of base) : System.Management.dasm - WqlEventQuery:.ctor(String,String):this
         -13 (-3.78% of base) : System.Private.CoreLib.dasm - TimeZoneInfo:ConvertUtcToTimeZone(long,TimeZoneInfo,byref):DateTime
          -9 (-0.68% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindAttributeArguments(NamedTypeSymbol,ArgumentListSyntax,DiagnosticBag):AnalyzedAttributeArguments:this
          -9 (-1.37% of base) : Microsoft.CodeAnalysis.CSharp.dasm - OverriddenOrHiddenMembersHelpers:MakeEventAccessorOverriddenOrHiddenMembers(MethodSymbol,EventSymbol):OverriddenOrHiddenMembersResult
          -9 (-0.70% of base) : Microsoft.CodeAnalysis.CSharp.dasm - OverriddenOrHiddenMembersHelpers:MakeInterfaceOverriddenOrHiddenMembers(Symbol,bool):OverriddenOrHiddenMembersResult
          -9 (-1.36% of base) : Microsoft.CodeAnalysis.CSharp.dasm - OverriddenOrHiddenMembersHelpers:MakePropertyAccessorOverriddenOrHiddenMembers(MethodSymbol,PropertySymbol):OverriddenOrHiddenMembersResult
          -9 (-1.19% of base) : System.Reflection.Metadata.dasm - SignatureDecoder`2:DecodeArrayType(byref):__Canon:this

Top method regressions (percentages):
           9 ( 1.35% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - BPerfEventSource:.ctor(String,TraceEventDispatcherOptions,ref,ref,bool):this

Top method improvements (percentages):
        -173 (-26.09% of base) : System.Data.Common.dasm - DateTimeOffsetStorage:Compare(int,int):int:this
         -47 (-24.61% of base) : ILCompiler.TypeSystem.ReadyToRun.dasm - UniversalCanonLayoutAlgorithm:ComputeStaticFieldLayout(DefType,int):ComputedStaticFieldLayout:this
         -40 (-12.54% of base) : System.Data.Common.dasm - DateTimeStorage:Compare(int,int):int:this
         -29 (-8.58% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxFactory:Literal(String,ushort):SyntaxToken
         -29 (-8.48% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxFactory:Literal(String,String):SyntaxToken
         -14 (-6.90% of base) : System.Management.dasm - WqlEventQuery:.ctor():this
         -14 (-6.48% of base) : System.Management.dasm - WqlEventQuery:.ctor(String,String):this
         -39 (-4.73% of base) : Microsoft.CodeAnalysis.CSharp.dasm - MethodBodySynthesizer:ConstructDestructorBody(MethodSymbol,BoundBlock):BoundBlock
         -91 (-3.92% of base) : Microsoft.CodeAnalysis.CSharp.dasm - BuiltInOperators:GetSimpleBuiltInOperators(int,ArrayBuilder`1):this (2 methods)
         -13 (-3.78% of base) : System.Private.CoreLib.dasm - TimeZoneInfo:ConvertUtcToTimeZone(long,TimeZoneInfo,byref):DateTime
          -9 (-3.73% of base) : System.Data.Common.dasm - TimeSpanStorage:Compare(int,int):int:this
         -14 (-3.41% of base) : System.Configuration.ConfigurationManager.dasm - InternalConfigHost:StaticGetStreamVersion(String):FileVersion
         -14 (-3.28% of base) : System.Private.CoreLib.dasm - CurrentSystemTimeZone:CreateDaylightChanges(int):DaylightTime
          -6 (-2.29% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxFactory:Literal(String,double):SyntaxToken
          -6 (-2.29% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxFactory:Literal(String,float):SyntaxToken
          -7 (-1.94% of base) : Microsoft.CodeAnalysis.dasm - LocalScopeManager:GetAllScopesWithLocals():ImmutableArray`1:this
          -7 (-1.93% of base) : ILCompiler.TypeSystem.ReadyToRun.dasm - DefType:ComputeStaticFieldLayout(int):this
          -9 (-1.37% of base) : Microsoft.CodeAnalysis.CSharp.dasm - OverriddenOrHiddenMembersHelpers:MakeEventAccessorOverriddenOrHiddenMembers(MethodSymbol,EventSymbol):OverriddenOrHiddenMembersResult
          -9 (-1.36% of base) : Microsoft.CodeAnalysis.CSharp.dasm - OverriddenOrHiddenMembersHelpers:MakePropertyAccessorOverriddenOrHiddenMembers(MethodSymbol,PropertySymbol):OverriddenOrHiddenMembersResult
          -9 (-1.36% of base) : System.Reflection.Metadata.dasm - SignatureDecoder`2:DecodeArrayType(byref):int:this

40 total methods with Code Size differences (39 improved, 1 regressed), 275256 unchanged.
```
