### PR TITLE
Value number AX LCL_FLD loads

### DIFF
--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1113,6 +1113,11 @@ public:
         gtVNPair.SetLiberal(vn);
     }
 
+    void SetConservativeVN(ValueNum vn)
+    {
+        gtVNPair.SetConservative(vn);
+    }
+
     ValueNum GetConservativeVN() const
     {
         return gtVNPair.GetConservative();

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -1510,16 +1510,6 @@ bool ValueNumStore::IsKnownNonNull(ValueNum vn)
     return GetVNFunc(vn, &funcAttr) && ((VNFuncAttribs(funcAttr.m_func) & VNFOA_KnownNonNull) != 0);
 }
 
-bool ValueNumStore::IsSharedStatic(ValueNum vn)
-{
-    if (vn == NoVN)
-    {
-        return false;
-    }
-    VNFuncApp funcAttr;
-    return GetVNFunc(vn, &funcAttr) && ((VNFuncAttribs(funcAttr.m_func) & VNFOA_SharedStatic) != 0);
-}
-
 ValueNumStore::Chunk::Chunk(CompAllocator alloc, ValueNum* pNextBaseVN, var_types typ, ChunkExtraAttribs attribs)
     : m_defs(nullptr), m_numUsed(0), m_baseVN(*pNextBaseVN), m_typ(typ), m_attribs(attribs)
 {
@@ -7055,8 +7045,6 @@ void ValueNumStore::InitValueNumStoreStatics()
         vnfOpAttribs[vnfNum] |= VNFOA_Commutative;                                                                     \
     if (knownNonNull)                                                                                                  \
         vnfOpAttribs[vnfNum] |= VNFOA_KnownNonNull;                                                                    \
-    if (sharedStatic)                                                                                                  \
-        vnfOpAttribs[vnfNum] |= VNFOA_SharedStatic;                                                                    \
     vnfOpAttribs[vnfNum] |= ((arity << VNFOA_ArityShift) & VNFOA_ArityMask);                                           \
     vnfNum++;
 

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -166,7 +166,6 @@ private:
         VNFOA_Arity2           = 0x8,  // Bits 2,3,4 encode the arity.
         VNFOA_Arity4           = 0x10, // Bits 2,3,4 encode the arity.
         VNFOA_KnownNonNull     = 0x20, // 1 iff the result is known to be non-null.
-        VNFOA_SharedStatic     = 0x40, // 1 iff this VNF is represent one of the shared static jit helpers
     };
 
     static const unsigned VNFOA_ArityShift = 2;
@@ -511,9 +510,6 @@ public:
 
     // True "iff" vn is a value known to be non-null.  (For example, the result of an allocation...)
     bool IsKnownNonNull(ValueNum vn);
-
-    // True "iff" vn is a value returned by a call to a shared static helper.
-    bool IsSharedStatic(ValueNum vn);
 
     // VNForFunc: We have five overloads, for arities 0, 1, 2, 3 and 4
     ValueNum VNForFunc(var_types typ, VNFunc func);


### PR DESCRIPTION
win-x64 pmi diff:
```
Total bytes of base: 60619211
Total bytes of diff: 60605998
Total bytes of delta: -13213 (-0.02 % of base)
    diff is an improvement.

Top file regressions (bytes):
          54 : System.Diagnostics.EventLog.dasm (0.05% of base)
          13 : System.Text.RegularExpressions.dasm (0.00% of base)
          11 : System.Private.Uri.dasm (0.01% of base)
          10 : Microsoft.Extensions.Logging.Abstractions.dasm (0.01% of base)
           6 : System.CodeDom.dasm (0.00% of base)
           6 : System.Private.DataContractSerialization.dasm (0.00% of base)
           6 : System.Security.Cryptography.Xml.dasm (0.00% of base)
           5 : System.Transactions.Local.dasm (0.00% of base)

Top file improvements (bytes):
       -5355 : System.Collections.Immutable.dasm (-0.33% of base)
       -1585 : System.Threading.Tasks.Dataflow.dasm (-0.14% of base)
       -1176 : System.Private.CoreLib.dasm (-0.02% of base)
        -798 : Microsoft.CodeAnalysis.CSharp.dasm (-0.02% of base)
        -701 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.01% of base)
        -644 : System.Security.Cryptography.Pkcs.dasm (-0.15% of base)
        -583 : System.Collections.dasm (-0.10% of base)
        -349 : Microsoft.CodeAnalysis.dasm (-0.02% of base)
        -307 : System.Linq.dasm (-0.03% of base)
        -211 : System.Text.Json.dasm (-0.02% of base)
        -165 : System.Security.Cryptography.Algorithms.dasm (-0.04% of base)
        -157 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
        -152 : System.Net.Http.dasm (-0.02% of base)
        -124 : System.Security.Cryptography.Cng.dasm (-0.06% of base)
        -117 : ILCompiler.TypeSystem.ReadyToRun.dasm (-0.04% of base)
        -105 : System.Security.Cryptography.X509Certificates.dasm (-0.06% of base)
         -93 : System.Private.Xml.dasm (-0.00% of base)
         -80 : System.Drawing.Primitives.dasm (-0.19% of base)
         -68 : System.Linq.Expressions.dasm (-0.01% of base)
         -62 : System.Drawing.Common.dasm (-0.01% of base)

70 total files with Code Size differences (62 improved, 8 regressed), 201 unchanged.

Top method regressions (bytes):
         192 ( 1.68% of base) : System.Linq.dasm - SelectManySingleSelectorIterator`2:ToArray():ref:this (8 methods)
          69 ( 0.95% of base) : System.Private.CoreLib.dasm - String:JoinCore(ReadOnlySpan`1,IEnumerable`1):String (8 methods)
          54 ( 2.16% of base) : System.Diagnostics.EventLog.dasm - NativeWrapper:EvtRenderBufferWithContextSystem(EventLogHandle,EventLogHandle,int,SystemProperties,int)
          34 ( 0.95% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:InitializeFixedStatementArrayLocal(LocalSymbol,BoundFixedLocalCollectionInitializer,SyntheticBoundNodeFactory,byref):BoundStatement:this
          26 ( 3.57% of base) : System.Private.CoreLib.dasm - FileSystemName:TranslateWin32Expression(String):String
          26 ( 3.20% of base) : System.Private.CoreLib.dasm - Path:Join(ref):String
          16 ( 1.70% of base) : System.Private.CoreLib.dasm - Path:Combine(ref):String
          13 ( 0.38% of base) : Microsoft.CodeAnalysis.CSharp.dasm - AnonymousTypeEqualsMethodSymbol:GenerateMethodBody(TypeCompilationState,DiagnosticBag):this
          13 ( 0.41% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - QueryLambdaBinder:BindJoinKeys(Binder,JoinClauseSyntax,BoundQueryClauseBase,BoundQueryClauseBase,ImmutableArray`1,byref,byref,byref,byref,DiagnosticBag)
          10 ( 2.43% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CustomModifierUtils:CopyTypeCustomModifiers(TypeSymbol,TypeSymbol,ubyte,AssemblySymbol):TypeSymbol
          10 ( 1.38% of base) : Microsoft.Extensions.Logging.Abstractions.dasm - LogValuesFormatter:FormatArgument(Object):Object:this
          10 ( 1.66% of base) : System.Private.Uri.dasm - UriHelper:UnescapeString(long,int,int,ref,byref,ushort,ushort,ushort,int,UriParser,bool):ref
           8 ( 1.13% of base) : System.Net.Http.dasm - AltSvcHeaderParser:TryReadQuotedValue(ReadOnlySpan`1,byref):bool
           8 ( 2.76% of base) : System.Console.dasm - ConsolePal:get_Title():String
           8 ( 1.08% of base) : System.Text.RegularExpressions.dasm - RegexParser:EscapeImpl(String,int):String
           8 ( 0.96% of base) : System.Text.RegularExpressions.dasm - RegexParser:UnescapeImpl(String,int):String
           7 ( 0.78% of base) : System.Private.CoreLib.dasm - String:ReplaceLineEndings(String):String:this
           7 ( 1.41% of base) : System.Private.CoreLib.dasm - WebUtility:HtmlDecode(String):String
           7 ( 1.40% of base) : System.Private.CoreLib.dasm - WebUtility:HtmlEncode(String):String
           6 ( 1.82% of base) : System.Private.CoreLib.dasm - ActivityInfo:Path(ActivityInfo):String

Top method improvements (bytes):
        -368 (-3.04% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:IsProperSupersetOf(IEnumerable`1,MutationInput):bool (8 methods)
        -350 (-3.04% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:IsSupersetOf(IEnumerable`1,MutationInput):bool (8 methods)
        -350 (-2.99% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:Overlaps(IEnumerable`1,MutationInput):bool (8 methods)
        -279 (-1.92% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:Intersect(IEnumerable`1,MutationInput):MutationResult (8 methods)
        -276 (-1.91% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:Except(IEnumerable`1,IEqualityComparer`1,IEqualityComparer`1,SortedInt32KeyNode`1):MutationResult (8 methods)
        -226 (-3.23% of base) : System.Linq.dasm - AppendPrependN`1:LazyToArray():ref:this (8 methods)
        -220 (-1.96% of base) : System.Collections.Immutable.dasm - ImmutableDictionary`2:ContainsValue(Nullable`1):bool:this (8 methods)
        -203 (-2.55% of base) : System.Linq.dasm - Concat2Iterator`1:ToArray():ref:this (8 methods)
        -172 (-34.47% of base) : System.Private.CoreLib.dasm - AppendInterpolatedStringHandler:AppendFormatted(Nullable`1,String):this
        -168 (-1.45% of base) : System.Collections.Immutable.dasm - Builder:System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(ref,int):this (16 methods)
        -168 (-1.51% of base) : System.Collections.Immutable.dasm - Builder:System.Collections.Generic.ICollection<T>.CopyTo(ref,int):this (16 methods)
        -168 (-1.20% of base) : System.Collections.Immutable.dasm - Builder:System.Collections.ICollection.CopyTo(Array,int):this (32 methods)
        -168 (-1.39% of base) : System.Collections.Immutable.dasm - ImmutableDictionary`2:System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(ref,int):this (8 methods)
        -168 (-1.22% of base) : System.Collections.Immutable.dasm - ImmutableDictionary`2:System.Collections.ICollection.CopyTo(Array,int):this (8 methods)
        -168 (-1.53% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:System.Collections.Generic.ICollection<T>.CopyTo(ref,int):this (8 methods)
        -156 (-34.51% of base) : System.Private.CoreLib.dasm - AppendInterpolatedStringHandler:AppendFormatted(Nullable`1):this
        -150 (-1.30% of base) : System.Collections.Immutable.dasm - Builder:ContainsValue(Nullable`1):bool:this (16 methods)
        -149 (-1.25% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:System.Collections.ICollection.CopyTo(Array,int):this (8 methods)
        -142 (-1.57% of base) : System.Collections.dasm - SortedSet`1:IntersectWith(IEnumerable`1):this (8 methods)
        -130 (-0.83% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:Union(IEnumerable`1,MutationInput):MutationResult (8 methods)

Top method regressions (percentages):
          26 ( 3.57% of base) : System.Private.CoreLib.dasm - FileSystemName:TranslateWin32Expression(String):String
          26 ( 3.20% of base) : System.Private.CoreLib.dasm - Path:Join(ref):String
           8 ( 2.76% of base) : System.Console.dasm - ConsolePal:get_Title():String
          10 ( 2.43% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CustomModifierUtils:CopyTypeCustomModifiers(TypeSymbol,TypeSymbol,ubyte,AssemblySymbol):TypeSymbol
          54 ( 2.16% of base) : System.Diagnostics.EventLog.dasm - NativeWrapper:EvtRenderBufferWithContextSystem(EventLogHandle,EventLogHandle,int,SystemProperties,int)
           4 ( 1.97% of base) : System.Private.CoreLib.dasm - FileSystem:CreateSymbolicLink(String,String,bool)
           6 ( 1.85% of base) : System.Net.Http.dasm - HttpAuthority:ToString():String:this
           6 ( 1.82% of base) : System.Private.CoreLib.dasm - ActivityInfo:Path(ActivityInfo):String
           6 ( 1.82% of base) : System.Security.Cryptography.Xml.dasm - SignedXmlDebugLog:GetObjectId(Object):String
          16 ( 1.70% of base) : System.Private.CoreLib.dasm - Path:Combine(ref):String
         192 ( 1.68% of base) : System.Linq.dasm - SelectManySingleSelectorIterator`2:ToArray():ref:this (8 methods)
          10 ( 1.66% of base) : System.Private.Uri.dasm - UriHelper:UnescapeString(long,int,int,ref,byref,ushort,ushort,ushort,int,UriParser,bool):ref
           6 ( 1.61% of base) : System.Linq.Expressions.dasm - ContractUtils:GetParamName(String,int):String
           6 ( 1.60% of base) : System.Linq.Expressions.dasm - Error:GetParamName(String,int):String
           7 ( 1.41% of base) : System.Private.CoreLib.dasm - WebUtility:HtmlDecode(String):String
           7 ( 1.40% of base) : System.Private.CoreLib.dasm - WebUtility:HtmlEncode(String):String
           6 ( 1.38% of base) : System.CodeDom.dasm - CodeTypeReference:get_BaseType():String:this
           6 ( 1.38% of base) : System.Private.DataContractSerialization.dasm - CodeTypeReference:get_BaseType():String:this
          10 ( 1.38% of base) : Microsoft.Extensions.Logging.Abstractions.dasm - LogValuesFormatter:FormatArgument(Object):Object:this
           4 ( 1.18% of base) : Microsoft.CodeAnalysis.CSharp.dasm - DynamicTypeDecoder:TransformTypeInternal(TypeSymbol,AssemblySymbol,int,ubyte,ImmutableArray`1,bool,bool):TypeSymbol

Top method improvements (percentages):
        -156 (-34.51% of base) : System.Private.CoreLib.dasm - AppendInterpolatedStringHandler:AppendFormatted(Nullable`1):this
        -172 (-34.47% of base) : System.Private.CoreLib.dasm - AppendInterpolatedStringHandler:AppendFormatted(Nullable`1,String):this
         -97 (-21.41% of base) : System.Private.CoreLib.dasm - TryWriteInterpolatedStringHandler:AppendFormatted(Nullable`1):bool:this
         -89 (-18.78% of base) : System.Private.CoreLib.dasm - TryWriteInterpolatedStringHandler:AppendFormatted(Nullable`1,String):bool:this
         -22 (-13.58% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - TraceCodeAddresses:MethodIndex(int):int:this
         -13 (-8.84% of base) : System.Net.HttpListener.dasm - SendOperation:Initialize(Nullable`1,CancellationToken):this
         -13 (-8.07% of base) : Microsoft.CodeAnalysis.CSharp.dasm - VariableIdentifier:Equals(Object):bool:this
         -31 (-7.45% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxNormalizer:EndsWithColonSeparator(SyntaxToken):bool:this
         -35 (-7.01% of base) : Microsoft.CodeAnalysis.dasm - TargetSymbolResolver:ParseType(ISymbol):Nullable`1:this
         -11 (-5.73% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - TraceCodeAddress:get_Method():TraceMethod:this
         -25 (-5.62% of base) : System.Private.CoreLib.dasm - DefaultInterpolatedStringHandler:AppendFormatted(Nullable`1):this
         -23 (-5.28% of base) : System.Private.Xml.Linq.dasm - XStreamingElement:WriteTo(XmlWriter):this
         -16 (-5.25% of base) : System.Net.Security.dasm - NegotiateStream:GetOutgoingBlob(ref,byref):ref:this
         -18 (-5.16% of base) : Microsoft.CodeAnalysis.dasm - SyntaxNodeOrTokenList:IndexOf(SyntaxNodeOrToken):int:this
         -11 (-4.95% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - TraceCodeAddress:get_FullMethodName():String:this
         -31 (-4.78% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxNormalizer:IsLastTokenOnLine(SyntaxToken):bool:this
         -14 (-4.67% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - TraceCodeAddresses:ModuleFileIndex(int):int:this
         -17 (-4.43% of base) : Microsoft.CodeAnalysis.CSharp.dasm - OverloadResolution:GetAllBuiltInOperators(int,BoundExpression,ArrayBuilder`1,byref):this
          -5 (-4.42% of base) : Microsoft.CodeAnalysis.dasm - SyntaxToken:get_HasLeadingTrivia():bool:this
          -5 (-4.42% of base) : Microsoft.CodeAnalysis.dasm - SyntaxToken:get_HasTrailingTrivia():bool:this

603 total methods with Code Size differences (548 improved, 55 regressed), 275520 unchanged.
```

alt-arm64 pmi diff:
```
Total bytes of base: 68115724
Total bytes of diff: 68099564
Total bytes of delta: -16160 (-0.02 % of base)
    diff is an improvement.

Top file regressions (bytes):
          40 : CommandLine.dasm (0.01% of base)
           8 : Microsoft.Extensions.Hosting.dasm (0.02% of base)
           4 : System.Net.Primitives.dasm (0.01% of base)
           4 : System.Security.Cryptography.Xml.dasm (0.00% of base)
           4 : System.Transactions.Local.dasm (0.00% of base)
           4 : Microsoft.Extensions.Logging.Abstractions.dasm (0.00% of base)
           4 : System.CodeDom.dasm (0.00% of base)
           4 : System.Data.OleDb.dasm (0.00% of base)
           4 : System.Private.DataContractSerialization.dasm (0.00% of base)

Top file improvements (bytes):
       -7536 : System.Collections.Immutable.dasm (-0.44% of base)
       -2400 : System.Private.CoreLib.dasm (-0.04% of base)
       -1184 : Microsoft.CodeAnalysis.CSharp.dasm (-0.02% of base)
        -708 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.01% of base)
        -644 : System.Threading.Tasks.Dataflow.dasm (-0.05% of base)
        -592 : System.Collections.dasm (-0.09% of base)
        -452 : System.Security.Cryptography.Pkcs.dasm (-0.11% of base)
        -368 : Microsoft.CodeAnalysis.dasm (-0.02% of base)
        -296 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.01% of base)
        -264 : System.Net.Http.dasm (-0.03% of base)
        -220 : System.Text.Json.dasm (-0.02% of base)
        -200 : System.Security.Cryptography.Algorithms.dasm (-0.05% of base)
        -124 : System.Security.Cryptography.Cng.dasm (-0.06% of base)
        -104 : ILCompiler.TypeSystem.ReadyToRun.dasm (-0.03% of base)
        -104 : System.Private.Uri.dasm (-0.11% of base)
         -92 : System.Drawing.Primitives.dasm (-0.20% of base)
         -88 : System.Drawing.Common.dasm (-0.02% of base)
         -80 : System.Security.Cryptography.X509Certificates.dasm (-0.04% of base)
         -68 : System.IO.Compression.dasm (-0.06% of base)
         -64 : System.Net.HttpListener.dasm (-0.02% of base)

70 total files with Code Size differences (61 improved, 9 regressed), 201 unchanged.

Top method regressions (bytes):
          56 ( 0.80% of base) : System.Linq.dasm - AppendPrependN`1:LazyToArray():ref:this (8 methods)
          40 ( 1.59% of base) : CommandLine.dasm - UnParserExtensions:FormatCommandLine(Parser,ubyte,Action`1):String
          12 ( 3.19% of base) : System.Reflection.MetadataLoadContext.dasm - EcmaAssembly:GetManifestResourceStream(String):Stream:this
          12 ( 1.25% of base) : System.Text.RegularExpressions.dasm - RegexParser:UnescapeImpl(String,int):String
           8 ( 0.83% of base) : Microsoft.Extensions.Hosting.dasm - HostBuilder:CreateServiceProvider():this
           8 ( 0.93% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalScopeBinder:MakeLocal(VariableDeclarationSyntax,VariableDeclaratorSyntax,ubyte):SourceLocalSymbol:this
           8 ( 0.14% of base) : System.Private.Xml.dasm - XmlSerializationReaderILGen:GenerateLiteralMembersElement(XmlMembersMapping):String:this
           4 ( 1.05% of base) : System.Private.CoreLib.dasm - ActivityInfo:Path(ActivityInfo):String
           4 ( 0.44% of base) : System.Net.Http.dasm - AltSvcHeaderParser:TryReadUnknownPercentEncodedAlpnProtocolName(ReadOnlySpan`1,byref):bool
           4 ( 0.68% of base) : Microsoft.CSharp.dasm - BinderHelper:ValidateBindArgument(ref,String)
           4 ( 0.75% of base) : System.CodeDom.dasm - CodeTypeReference:get_BaseType():String:this
           4 ( 0.75% of base) : System.Private.DataContractSerialization.dasm - CodeTypeReference:get_BaseType():String:this
           4 ( 0.58% of base) : Microsoft.CSharp.dasm - ComTypeEnumDesc:.ctor(ITypeInfo,ComTypeLibDesc):this
           4 ( 0.90% of base) : System.Linq.Expressions.dasm - ContractUtils:GetParamName(String,int):String
           4 ( 0.71% of base) : System.Net.Primitives.dasm - CredentialKey:ToString():String:this
           4 ( 0.48% of base) : System.Data.OleDb.dasm - DbConnectionPoolCounters:GetInstanceName():String:this
           4 ( 0.90% of base) : System.Linq.Expressions.dasm - Error:GetParamName(String,int):String
           4 ( 0.25% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ForLoopBinder:BuildLocals():ImmutableArray`1:this
           4 ( 0.60% of base) : System.Net.Http.dasm - Http3Connection:.ctor(HttpConnectionPool,HttpAuthority,HttpAuthority,QuicConnection):this
           4 ( 1.06% of base) : System.Net.Http.dasm - HttpAuthority:ToString():String:this

Top method improvements (bytes):
        -428 (-4.46% of base) : System.Private.CoreLib.dasm - TextSegmentationUtility:GetLengthOfFirstExtendedGraphemeCluster(ReadOnlySpan`1,DecodeFirstRune`1):int (8 methods)
        -332 (-3.00% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:IsProperSupersetOf(IEnumerable`1,MutationInput):bool (8 methods)
        -332 (-3.12% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:IsSupersetOf(IEnumerable`1,MutationInput):bool (8 methods)
        -332 (-3.02% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:Overlaps(IEnumerable`1,MutationInput):bool (8 methods)
        -252 (-2.02% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:Except(IEnumerable`1,IEqualityComparer`1,IEqualityComparer`1,SortedInt32KeyNode`1):MutationResult (8 methods)
        -252 (-1.98% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:Intersect(IEnumerable`1,MutationInput):MutationResult (8 methods)
        -224 (-2.22% of base) : System.Collections.Immutable.dasm - Builder:ContainsValue(Nullable`1):bool:this (16 methods)
        -224 (-2.30% of base) : System.Collections.Immutable.dasm - ImmutableDictionary`2:ContainsValue(Nullable`1):bool:this (8 methods)
        -220 (-1.14% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:SymmetricExcept(IEnumerable`1,MutationInput):MutationResult (8 methods)
        -220 (-1.63% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:Union(IEnumerable`1,MutationInput):MutationResult (8 methods)
        -200 (-4.22% of base) : System.Private.CoreLib.dasm - Vector128`1:ToString():String:this (6 methods)
        -200 (-4.00% of base) : System.Private.CoreLib.dasm - Vector256`1:ToString():String:this (6 methods)
        -196 (-1.87% of base) : System.Collections.Immutable.dasm - Builder:set_KeyComparer(IComparer`1):this (16 methods)
        -196 (-1.99% of base) : System.Collections.Immutable.dasm - Builder:System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(ref,int):this (16 methods)
        -196 (-1.94% of base) : System.Collections.Immutable.dasm - ImmutableDictionary`2:System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(ref,int):this (8 methods)
        -196 (-2.80% of base) : System.Collections.Immutable.dasm - ImmutableList`1:RemoveRange(IEnumerable`1,IEqualityComparer`1):ImmutableList`1:this (8 methods)
        -192 (-1.90% of base) : System.Collections.Immutable.dasm - Builder:System.Collections.Generic.ICollection<T>.CopyTo(ref,int):this (16 methods)
        -192 (-1.95% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:System.Collections.Generic.ICollection<T>.CopyTo(ref,int):this (8 methods)
        -168 (-34.71% of base) : System.Private.CoreLib.dasm - AppendInterpolatedStringHandler:AppendFormatted(Nullable`1,String):this
        -168 (-36.21% of base) : System.Private.CoreLib.dasm - AppendInterpolatedStringHandler:AppendFormatted(Nullable`1):this

Top method regressions (percentages):
           4 ( 4.55% of base) : System.Private.CoreLib.dasm - WriteIfInterpolatedStringHandler:AppendFormatted(__Canon):this
          12 ( 3.19% of base) : System.Reflection.MetadataLoadContext.dasm - EcmaAssembly:GetManifestResourceStream(String):Stream:this
           4 ( 1.96% of base) : Microsoft.CodeAnalysis.dasm - SyntaxTree:GetDisplayPath(TextSpan,SourceReferenceResolver):String:this
          40 ( 1.59% of base) : CommandLine.dasm - UnParserExtensions:FormatCommandLine(Parser,ubyte,Action`1):String
          12 ( 1.25% of base) : System.Text.RegularExpressions.dasm - RegexParser:UnescapeImpl(String,int):String
           4 ( 1.06% of base) : System.Net.Http.dasm - HttpAuthority:ToString():String:this
           4 ( 1.05% of base) : System.Private.CoreLib.dasm - ActivityInfo:Path(ActivityInfo):String
           4 ( 1.03% of base) : System.Security.Cryptography.Xml.dasm - SignedXmlDebugLog:GetObjectId(Object):String
           8 ( 0.93% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalScopeBinder:MakeLocal(VariableDeclarationSyntax,VariableDeclaratorSyntax,ubyte):SourceLocalSymbol:this
           4 ( 0.90% of base) : System.Linq.Expressions.dasm - ContractUtils:GetParamName(String,int):String
           4 ( 0.90% of base) : System.Linq.Expressions.dasm - Error:GetParamName(String,int):String
           4 ( 0.88% of base) : System.Private.Xml.dasm - XmlQueryRuntime:GenerateId(XPathNavigator):String:this
           8 ( 0.83% of base) : Microsoft.Extensions.Hosting.dasm - HostBuilder:CreateServiceProvider():this
           4 ( 0.80% of base) : System.Private.Xml.dasm - XmlSerializationReaderCodeGen:NextIdName(String):String:this
           4 ( 0.80% of base) : System.Private.Xml.dasm - XmlSerializationReaderILGen:NextIdName(String):String:this
          56 ( 0.80% of base) : System.Linq.dasm - AppendPrependN`1:LazyToArray():ref:this (8 methods)
           4 ( 0.76% of base) : System.Transactions.Local.dasm - InternalTransaction:get_TransactionTraceId():TransactionTraceIdentifier:this
           4 ( 0.75% of base) : System.CodeDom.dasm - CodeTypeReference:get_BaseType():String:this
           4 ( 0.75% of base) : System.Private.DataContractSerialization.dasm - CodeTypeReference:get_BaseType():String:this
           4 ( 0.71% of base) : System.Net.Primitives.dasm - CredentialKey:ToString():String:this

Top method improvements (percentages):
        -168 (-36.21% of base) : System.Private.CoreLib.dasm - AppendInterpolatedStringHandler:AppendFormatted(Nullable`1):this
        -168 (-34.71% of base) : System.Private.CoreLib.dasm - AppendInterpolatedStringHandler:AppendFormatted(Nullable`1,String):this
        -108 (-21.60% of base) : System.Private.CoreLib.dasm - TryWriteInterpolatedStringHandler:AppendFormatted(Nullable`1):bool:this
        -108 (-20.77% of base) : System.Private.CoreLib.dasm - TryWriteInterpolatedStringHandler:AppendFormatted(Nullable`1,String):bool:this
         -16 (-10.53% of base) : System.Net.HttpListener.dasm - SendOperation:Initialize(Nullable`1,CancellationToken):this
         -24 (-9.38% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - TraceCodeAddress:get_Method():TraceMethod:this
         -16 (-8.70% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DataFlowsInWalker:ResetState(LocalState):LocalState:this
         -16 (-8.16% of base) : Microsoft.CodeAnalysis.CSharp.dasm - VariableIdentifier:Equals(Object):bool:this
         -24 (-8.11% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - TraceCodeAddress:get_FullMethodName():String:this
         -16 (-8.00% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - TraceCodeAddresses:MethodIndex(int):int:this
         -36 (-7.38% of base) : System.Private.CoreLib.dasm - DefaultInterpolatedStringHandler:AppendFormatted(Nullable`1):this
         -32 (-6.61% of base) : System.Private.CoreLib.dasm - TypeNameParser:EscapeTypeName(String):String
         -24 (-6.45% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxNormalizer:EndsWithColonSeparator(SyntaxToken):bool:this
         -24 (-6.45% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - TraceCodeAddresses:ModuleFileIndex(int):int:this
         -92 (-5.90% of base) : System.Private.Uri.dasm - IriHelper:EscapeUnescapeIri(long,int,int,int):String
          -4 (-5.26% of base) : System.IO.FileSystem.AccessControl.dasm - FileSystem:DirectoryExists(String):bool
          -4 (-5.26% of base) : System.Private.CoreLib.dasm - FileSystem:DirectoryExists(String):bool
         -16 (-5.19% of base) : System.Formats.Asn1.dasm - AsnWriter:WriteTag(Asn1Tag):this
         -24 (-5.04% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - ActivityComputer:TrimETWFrames(int):int:this
          -4 (-5.00% of base) : System.IO.FileSystem.AccessControl.dasm - FileSystem:FileExists(String):bool

677 total methods with Code Size differences (640 improved, 37 regressed), 275446 unchanged.
```
