### PR TITLE
Local propagate LCL_FLD

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6209,6 +6209,7 @@ private:
     const MorphAssertion* morphAssertionFindRange(unsigned lclNum);
 
     GenTree* morphAssertionPropagateLclVar(GenTreeLclVar* lclVar);
+    GenTree* morphAssertionPropagateLclFld(GenTreeLclFld* lclFld);
     GenTree* morphAssertionPropagateIndir(GenTreeIndir* indir);
     GenTree* morphAssertionPropagateCast(GenTreeCast* cast);
     GenTree* morphAssertionPropagateCall(GenTreeCall* call);

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1233,7 +1233,7 @@ inline GenTreeIntCon* GenTree::ChangeToIntCon(ssize_t value)
 
 inline GenTreeIntCon* GenTree::ChangeToIntCon(var_types type, ssize_t value)
 {
-    SetType(type);
+    SetType(varActualType(type));
     return ChangeToIntCon(value);
 }
 


### PR DESCRIPTION
win-x64 pmi diff:
```
Total bytes of base: 60606046
Total bytes of diff: 60554985
Total bytes of delta: -51061 (-0.08 % of base)
    diff is an improvement.

Top file regressions (bytes):
          33 : System.Diagnostics.DiagnosticSource.dasm (0.02% of base)
           3 : System.Reflection.Metadata.dasm (0.00% of base)

Top file improvements (bytes):
      -13973 : System.Private.Xml.dasm (-0.36% of base)
       -5872 : System.Net.Http.dasm (-0.72% of base)
       -4243 : Newtonsoft.Json.dasm (-0.45% of base)
       -4133 : System.Collections.Immutable.dasm (-0.26% of base)
       -2860 : System.Private.CoreLib.dasm (-0.05% of base)
       -2094 : System.Net.Http.Json.dasm (-1.72% of base)
       -2045 : System.Net.WebSockets.dasm (-1.79% of base)
       -1943 : System.Collections.dasm (-0.33% of base)
       -1753 : Microsoft.CodeAnalysis.dasm (-0.09% of base)
       -1571 : System.Text.Json.dasm (-0.16% of base)
       -1526 : Newtonsoft.Json.Bson.dasm (-1.49% of base)
       -1132 : System.IO.Pipelines.dasm (-1.29% of base)
       -1093 : System.Private.Xml.Linq.dasm (-0.63% of base)
        -829 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.01% of base)
        -582 : System.Threading.Channels.dasm (-0.28% of base)
        -513 : System.Private.DataContractSerialization.dasm (-0.06% of base)
        -495 : System.Net.HttpListener.dasm (-0.20% of base)
        -476 : Microsoft.CodeAnalysis.CSharp.dasm (-0.01% of base)
        -385 : System.IO.Compression.dasm (-0.42% of base)
        -358 : System.Net.Quic.dasm (-0.36% of base)

53 total files with Code Size differences (51 improved, 2 regressed), 218 unchanged.

Top method regressions (bytes):
          23 ( 0.80% of base) : System.Net.Http.dasm - <ReadFrameEnvelopeAsync>d__44:MoveNext():this
           9 ( 0.94% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ForEachStatementInfo:Equals(ForEachStatementInfo):bool:this
           6 ( 0.56% of base) : System.Diagnostics.DiagnosticSource.dasm - ActivityCreationOptions`1:get_TraceId():ActivityTraceId:this (8 methods)
           6 ( 2.45% of base) : System.Diagnostics.DiagnosticSource.dasm - ActivityLink:Equals(ActivityLink):bool:this
           6 ( 1.24% of base) : System.Diagnostics.DiagnosticSource.dasm - ActivityLink:Equals(Object):bool:this
           6 ( 2.11% of base) : System.Diagnostics.DiagnosticSource.dasm - ActivityLink:op_Equality(ActivityLink,ActivityLink):bool
           6 ( 2.05% of base) : System.Diagnostics.DiagnosticSource.dasm - ActivityLink:op_Inequality(ActivityLink,ActivityLink):bool
           6 ( 0.44% of base) : System.Text.Json.dasm - JsonObject:InitializeIfRequired():this
           6 ( 0.75% of base) : System.Formats.Asn1.dasm - Scope:Dispose():this
           4 ( 0.29% of base) : System.Net.Quic.dasm - <AcceptStreamAsync>d__38:MoveNext():this
           4 ( 0.29% of base) : System.Net.Http.dasm - <AcceptStreamsAsync>d__40:MoveNext():this
           3 ( 0.43% of base) : System.Diagnostics.DiagnosticSource.dasm - ActivityCreationOptions`1:.ctor(ActivitySource,String,__Canon,int,IEnumerable`1,IEnumerable`1,int):this
           3 ( 0.40% of base) : Microsoft.CodeAnalysis.CSharp.dasm - AwaitExpressionSpiller:VisitAsOperator(BoundAsOperator):BoundNode:this
           3 ( 0.40% of base) : Microsoft.CodeAnalysis.CSharp.dasm - AwaitExpressionSpiller:VisitIsOperator(BoundIsOperator):BoundNode:this
           3 ( 1.26% of base) : System.Reflection.Metadata.dasm - BlobContentId:Equals(Object):bool:this
           3 ( 0.20% of base) : Microsoft.CodeAnalysis.CSharp.dasm - BoundCompoundAssignmentOperator:Update(BinaryOperatorSignature,BoundExpression,BoundExpression,Conversion,Conversion,ubyte,TypeSymbol):BoundCompoundAssignmentOperator:this
           3 ( 0.29% of base) : Microsoft.CodeAnalysis.CSharp.dasm - BoundForEachStatement:Update(ForEachEnumeratorInfo,Conversion,BoundTypeExpression,LocalSymbol,BoundExpression,BoundStatement,bool,GeneratedLabelSymbol,GeneratedLabelSymbol):BoundForEachStatement:this
           3 ( 0.25% of base) : Microsoft.CodeAnalysis.CSharp.dasm - BoundIncrementOperator:Update(int,BoundExpression,MethodSymbol,Conversion,Conversion,ubyte,TypeSymbol):BoundIncrementOperator:this
           3 ( 0.37% of base) : Microsoft.CodeAnalysis.CSharp.dasm - BoundTreeRewriter:VisitAsOperator(BoundAsOperator):BoundNode:this
           3 ( 0.37% of base) : Microsoft.CodeAnalysis.CSharp.dasm - BoundTreeRewriter:VisitIsOperator(BoundIsOperator):BoundNode:this

Top method improvements (bytes):
       -1540 (-2.67% of base) : System.Net.WebSockets.dasm - <ReceiveAsyncPrivate>d__63`1:MoveNext():this (8 methods)
       -1089 (-9.33% of base) : System.Collections.dasm - Enumerator:System.Collections.IEnumerator.get_Current():Object:this (64 methods)
        -568 (-3.56% of base) : System.Text.Json.dasm - <<DeserializeAsyncEnumerable>g__CreateAsyncEnumerableDeserializer|63_0>d`1:MoveNext():this (8 methods)
        -559 (-2.68% of base) : System.IO.Pipelines.dasm - <CopyToAsyncCore>d__16`1:MoveNext():this (8 methods)
        -448 (-1.71% of base) : System.Text.Json.dasm - <WriteStreamAsync>d__112`1:MoveNext():this (8 methods)
        -435 (-3.82% of base) : System.Collections.Immutable.dasm - Builder:ContainsValue(Nullable`1):bool:this (16 methods)
        -435 (-3.95% of base) : System.Collections.Immutable.dasm - ImmutableDictionary`2:ContainsValue(Nullable`1):bool:this (8 methods)
        -426 (-3.07% of base) : System.Collections.Immutable.dasm - Builder:System.Collections.ICollection.CopyTo(Array,int):this (32 methods)
        -426 (-3.14% of base) : System.Collections.Immutable.dasm - ImmutableDictionary`2:System.Collections.ICollection.CopyTo(Array,int):this (8 methods)
        -389 (-3.28% of base) : System.Net.Http.Json.dasm - <SerializeToStreamAsyncCore>d__5:MoveNext():this (8 methods)
        -388 (-5.64% of base) : System.Collections.Immutable.dasm - <get_Keys>d__25:MoveNext():bool:this (8 methods)
        -388 (-5.65% of base) : System.Collections.Immutable.dasm - <get_Values>d__27:MoveNext():bool:this (8 methods)
        -355 (-3.72% of base) : System.Net.Http.Json.dasm - <ReadFromJsonAsyncCore>d__4`1:MoveNext():this (8 methods)
        -350 (-2.26% of base) : System.Text.Json.dasm - <ReadAllAsync>d__65`1:MoveNext():this (8 methods)
        -349 (-2.93% of base) : System.Collections.Immutable.dasm - ImmutableDictionary`2:System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(ref,int):this (8 methods)
        -346 (-6.89% of base) : System.Private.Xml.dasm - <CallBoolTaskFuncWhenFinishCoreAsync>d__11`1:MoveNext():this (8 methods)
        -346 (-3.67% of base) : System.Net.Http.Json.dasm - <ReadFromJsonAsyncCore>d__9`1:MoveNext():this (8 methods)
        -345 (-4.73% of base) : System.Net.Http.Json.dasm - <GetFromJsonAsyncCore>d__13`1:MoveNext():this (8 methods)
        -345 (-4.73% of base) : System.Net.Http.Json.dasm - <GetFromJsonAsyncCore>d__16`1:MoveNext():this (8 methods)
        -300 (-5.39% of base) : System.Private.CoreLib.dasm - ConfiguredValueTaskAwaiter:OnCompleted(Action):this (9 methods)

Top method regressions (percentages):
           6 ( 2.45% of base) : System.Diagnostics.DiagnosticSource.dasm - ActivityLink:Equals(ActivityLink):bool:this
           6 ( 2.11% of base) : System.Diagnostics.DiagnosticSource.dasm - ActivityLink:op_Equality(ActivityLink,ActivityLink):bool
           6 ( 2.05% of base) : System.Diagnostics.DiagnosticSource.dasm - ActivityLink:op_Inequality(ActivityLink,ActivityLink):bool
           3 ( 1.26% of base) : System.Reflection.Metadata.dasm - BlobContentId:Equals(Object):bool:this
           6 ( 1.24% of base) : System.Diagnostics.DiagnosticSource.dasm - ActivityLink:Equals(Object):bool:this
           9 ( 0.94% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ForEachStatementInfo:Equals(ForEachStatementInfo):bool:this
          23 ( 0.80% of base) : System.Net.Http.dasm - <ReadFrameEnvelopeAsync>d__44:MoveNext():this
           6 ( 0.75% of base) : System.Formats.Asn1.dasm - Scope:Dispose():this
           6 ( 0.56% of base) : System.Diagnostics.DiagnosticSource.dasm - ActivityCreationOptions`1:get_TraceId():ActivityTraceId:this (8 methods)
           3 ( 0.46% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxReplacer:InsertTriviaInList(SyntaxToken,SyntaxTrivia,IEnumerable`1,bool):SyntaxToken
           3 ( 0.44% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SyntaxReplacer:InsertTriviaInList(SyntaxToken,SyntaxTrivia,IEnumerable`1,bool):SyntaxToken
           6 ( 0.44% of base) : System.Text.Json.dasm - JsonObject:InitializeIfRequired():this
           3 ( 0.43% of base) : System.Diagnostics.DiagnosticSource.dasm - ActivityCreationOptions`1:.ctor(ActivitySource,String,__Canon,int,IEnumerable`1,IEnumerable`1,int):this
           3 ( 0.40% of base) : Microsoft.CodeAnalysis.CSharp.dasm - AwaitExpressionSpiller:VisitAsOperator(BoundAsOperator):BoundNode:this
           3 ( 0.40% of base) : Microsoft.CodeAnalysis.CSharp.dasm - AwaitExpressionSpiller:VisitIsOperator(BoundIsOperator):BoundNode:this
           3 ( 0.38% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:Add(Nullable`1,MutationInput):MutationResult
           3 ( 0.37% of base) : Microsoft.CodeAnalysis.CSharp.dasm - BoundTreeRewriter:VisitNullCoalescingOperator(BoundNullCoalescingOperator):BoundNode:this
           3 ( 0.37% of base) : Microsoft.CodeAnalysis.CSharp.dasm - BoundTreeRewriter:VisitAsOperator(BoundAsOperator):BoundNode:this
           3 ( 0.37% of base) : Microsoft.CodeAnalysis.CSharp.dasm - BoundTreeRewriter:VisitIsOperator(BoundIsOperator):BoundNode:this
           3 ( 0.35% of base) : Microsoft.CodeAnalysis.CSharp.dasm - StackOptimizerPass1:VisitNullCoalescingOperator(BoundNullCoalescingOperator):BoundNode:this

Top method improvements (percentages):
        -111 (-23.57% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxRemover:AddEndOfLine():this
        -107 (-22.20% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxFactory:Token(SyntaxTrivia,ushort,SyntaxTrivia,String):SyntaxToken
         -34 (-19.43% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - _Closure$__:_Lambda$__12-0(SyntaxTrivia):bool:this
         -34 (-18.99% of base) : Microsoft.CodeAnalysis.CSharp.dasm - <>c:<HasEndOfLine>b__12_0(SyntaxTrivia):bool:this
        -138 (-18.85% of base) : System.Collections.dasm - Enumerator:get_Current():Nullable`1:this (12 methods)
         -37 (-16.16% of base) : System.Collections.dasm - Enumerator:get_Current():Vector`1:this (4 methods)
         -18 (-15.38% of base) : System.Collections.dasm - Enumerator:get_Current():int:this (4 methods)
         -18 (-14.88% of base) : System.Collections.dasm - Enumerator:get_Current():ubyte:this (4 methods)
         -18 (-14.40% of base) : System.Collections.dasm - Enumerator:get_Current():short:this (4 methods)
         -45 (-12.53% of base) : Microsoft.CodeAnalysis.CSharp.dasm - BoundTreeRewriter:VisitTypeOrValueExpression(BoundTypeOrValueExpression):BoundNode:this
         -51 (-11.31% of base) : Microsoft.CodeAnalysis.dasm - SyntaxTriviaList:Add(SyntaxTrivia):SyntaxTriviaList:this
         -47 (-10.78% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SyntaxRemover:AddEndOfLine():this
         -12 (-10.71% of base) : System.Collections.dasm - Enumerator:get_Current():long:this (4 methods)
         -38 (-10.13% of base) : Microsoft.CodeAnalysis.dasm - SyntaxTriviaList:Insert(int,SyntaxTrivia):SyntaxTriviaList:this
         -38 (-10.13% of base) : Microsoft.CodeAnalysis.dasm - SyntaxTriviaList:Replace(SyntaxTrivia,SyntaxTrivia):SyntaxTriviaList:this
         -12 (-9.45% of base) : System.Collections.dasm - Enumerator:get_Current():double:this (4 methods)
       -1089 (-9.33% of base) : System.Collections.dasm - Enumerator:System.Collections.IEnumerator.get_Current():Object:this (64 methods)
         -44 (-9.24% of base) : Microsoft.CodeAnalysis.dasm - SyntaxNode:get_HasLeadingTrivia():bool:this
        -298 (-8.10% of base) : System.Collections.dasm - Enumerator:System.Collections.IDictionaryEnumerator.get_Entry():DictionaryEntry:this (16 methods)
        -130 (-7.49% of base) : System.Net.Http.dasm - <CreateHttp11ConnectionAsync>d__101:MoveNext():this

973 total methods with Code Size differences (941 improved, 32 regressed), 275150 unchanged.
```
win-x64 crossgen diff:
```
Total bytes of base: 37503801
Total bytes of diff: 37498975
Total bytes of delta: -4826 (-0.01 % of base)
    diff is an improvement.

Top file regressions (bytes):
           3 : System.IO.Pipelines.dasm (0.01% of base)

Top file improvements (bytes):
       -2204 : System.Private.CoreLib.dasm (-0.07% of base)
        -516 : System.Reflection.Metadata.dasm (-0.16% of base)
        -376 : Microsoft.CodeAnalysis.CSharp.dasm (-0.01% of base)
        -222 : System.Security.Cryptography.X509Certificates.dasm (-0.16% of base)
        -191 : Microsoft.CodeAnalysis.dasm (-0.01% of base)
        -179 : System.Private.Xml.dasm (-0.01% of base)
        -140 : System.Formats.Cbor.dasm (-0.35% of base)
        -118 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.00% of base)
        -100 : System.Net.Http.dasm (-0.02% of base)
         -93 : Newtonsoft.Json.dasm (-0.02% of base)
         -76 : System.Linq.Parallel.dasm (-0.02% of base)
         -59 : System.Linq.dasm (-0.04% of base)
         -53 : System.Speech.dasm (-0.01% of base)
         -53 : System.Text.Json.dasm (-0.01% of base)
         -50 : System.Net.NetworkInformation.dasm (-0.18% of base)
         -42 : System.Drawing.Common.dasm (-0.01% of base)
         -37 : xunit.console.dasm (-0.05% of base)
         -35 : System.Numerics.Tensors.dasm (-0.12% of base)
         -33 : System.Net.Quic.dasm (-0.05% of base)
         -26 : Microsoft.Extensions.DependencyModel.dasm (-0.06% of base)

37 total files with Code Size differences (36 improved, 1 regressed), 234 unchanged.

Top method regressions (bytes):
          21 ( 2.17% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.OverloadResolution:GetEffectiveParametersInNormalForm(System.__Canon,int,System.Collections.Immutable.ImmutableArray`1[System.Int32],Microsoft.CodeAnalysis.ArrayBuilder`1[Microsoft.CodeAnalysis.RefKind],bool,byref):Microsoft.CodeAnalysis.CSharp.OverloadResolution+EffectiveParameters:this
           9 ( 1.07% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AsyncMethodToClassRewriter:SpillArgumentListInner(System.Collections.Immutable.ImmutableArray`1[Microsoft.CodeAnalysis.VisualBasic.BoundExpression],Microsoft.CodeAnalysis.ArrayBuilder`1[Microsoft.CodeAnalysis.VisualBasic.AsyncRewriter+SpillBuilder],bool,byref):System.Collections.Immutable.ImmutableArray`1[Microsoft.CodeAnalysis.VisualBasic.BoundExpression]:this
           9 ( 3.05% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SpillBuilder:AddSpill(Microsoft.CodeAnalysis.VisualBasic.BoundSpillSequence):this
           7 ( 0.32% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SourceNamedTypeSymbol:MakeDeclaredBases(Roslyn.Utilities.ConsList`1[Microsoft.CodeAnalysis.CSharp.Symbol],Microsoft.CodeAnalysis.DiagnosticBag):System.Tuple`2[Microsoft.CodeAnalysis.CSharp.Symbols.NamedTypeSymbol, System.Collections.Immutable.ImmutableArray`1[Microsoft.CodeAnalysis.CSharp.Symbols.NamedTypeSymbol]]:this
           6 ( 0.71% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.ForEachStatementInfo:Equals(Microsoft.CodeAnalysis.CSharp.ForEachStatementInfo):bool:this
           3 ( 0.46% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.BoundAsOperator:Update(Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.CSharp.BoundTypeExpression,Microsoft.CodeAnalysis.CSharp.Conversion,Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol):Microsoft.CodeAnalysis.CSharp.BoundAsOperator:this
           3 ( 0.47% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.BoundFixedLocalCollectionInitializer:Update(Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol,Microsoft.CodeAnalysis.CSharp.Conversion,Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol):Microsoft.CodeAnalysis.CSharp.BoundFixedLocalCollectionInitializer:this
           3 ( 0.27% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.BoundIncrementOperator:Update(int,Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.CSharp.Symbols.MethodSymbol,Microsoft.CodeAnalysis.CSharp.Conversion,Microsoft.CodeAnalysis.CSharp.Conversion,ubyte,Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol):Microsoft.CodeAnalysis.CSharp.BoundIncrementOperator:this
           3 ( 0.46% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.BoundIsOperator:Update(Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.CSharp.BoundTypeExpression,Microsoft.CodeAnalysis.CSharp.Conversion,Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol):Microsoft.CodeAnalysis.CSharp.BoundIsOperator:this
           3 ( 0.46% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.BoundNullCoalescingOperator:Update(Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.CSharp.Conversion,Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol):Microsoft.CodeAnalysis.CSharp.BoundNullCoalescingOperator:this
           3 ( 0.06% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.LocalRewriter:TransformCompoundAssignmentLHS(Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.ArrayBuilder`1[Microsoft.CodeAnalysis.CSharp.BoundExpression],Microsoft.CodeAnalysis.ArrayBuilder`1[Microsoft.CodeAnalysis.CSharp.Symbols.LocalSymbol],bool):Microsoft.CodeAnalysis.CSharp.BoundExpression:this
           3 ( 0.82% of base) : System.IO.Pipelines.dasm - System.IO.Pipelines.StreamPipeReader:AllocateSegment(System.Nullable`1[System.Int32]):System.IO.Pipelines.BufferSegment:this
           1 ( 0.82% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.MarshalPseudoCustomAttributeData:SetMarshalAsArray(System.Nullable`1[System.Runtime.InteropServices.UnmanagedType],System.Nullable`1[System.Int32],System.Nullable`1[System.Int16]):this
           1 ( 2.33% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.MarshalPseudoCustomAttributeData:SetMarshalAsComInterface(int,System.Nullable`1[System.Int32]):this
           1 ( 1.64% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.MarshalPseudoCustomAttributeData:SetMarshalAsSafeArray(System.Nullable`1[System.Runtime.InteropServices.VarEnum],Microsoft.CodeAnalysis.ITypeSymbol):this

Top method improvements (bytes):
         -89 (-3.62% of base) : System.Private.CoreLib.dasm - <ReadFromUnderlyingStreamAsync>d__49:MoveNext():this
         -85 (-5.31% of base) : System.Private.CoreLib.dasm - <FlushAsyncInternal>d__36:MoveNext():this
         -81 (-2.54% of base) : System.Private.CoreLib.dasm - <WriteToUnderlyingStreamAsync>d__60:MoveNext():this
         -77 (-2.86% of base) : System.Private.CoreLib.dasm - <ReadAsyncSlowPath>d__39:MoveNext():this
         -70 (-7.90% of base) : System.Private.CoreLib.dasm - ConfiguredValueTaskAwaiter:OnCompleted(System.Action):this (3 methods)
         -70 (-8.17% of base) : System.Private.CoreLib.dasm - ConfiguredValueTaskAwaiter:UnsafeOnCompleted(System.Action):this (3 methods)
         -67 (-3.66% of base) : System.Private.CoreLib.dasm - <CopyToAsyncCore>d__59:MoveNext():this
         -67 (-3.84% of base) : System.Private.CoreLib.dasm - <CopyToAsyncCore>d__69:MoveNext():this
         -60 (-5.51% of base) : System.Security.Cryptography.X509Certificates.dasm - System.Security.Cryptography.X509Certificates.X509Certificate2:ExtractKeyFromEncryptedPem(System.ReadOnlySpan`1[System.Char],System.ReadOnlySpan`1[System.Char],System.Func`1[System.__Canon],System.Func`2[System.__Canon, System.Security.Cryptography.X509Certificates.X509Certificate2]):System.Security.Cryptography.X509Certificates.X509Certificate2
         -60 (-4.83% of base) : System.Security.Cryptography.X509Certificates.dasm - System.Security.Cryptography.X509Certificates.X509Certificate2Collection:ImportFromPem(System.ReadOnlySpan`1[System.Char]):this
         -59 (-3.95% of base) : System.Private.CoreLib.dasm - <<FlushAsyncInternal>g__Core|76_0>d:MoveNext():this
         -58 (-1.93% of base) : System.Private.CoreLib.dasm - <ReadAsyncInternal>d__68:MoveNext():this
         -58 (-2.92% of base) : System.Private.CoreLib.dasm - <ReadLineAsyncInternal>d__63:MoveNext():this
         -57 (-4.39% of base) : System.Security.Cryptography.X509Certificates.dasm - System.Security.Cryptography.X509Certificates.X509Certificate2:CreateFromPem(System.ReadOnlySpan`1[System.Char]):System.Security.Cryptography.X509Certificates.X509Certificate2
         -54 (-5.67% of base) : System.Private.CoreLib.dasm - <WriteToNonSeekableAsync>d__49:MoveNext():this
         -53 (-3.75% of base) : System.Private.CoreLib.dasm - <AsyncModeCopyToAsync>d__94:MoveNext():this
         -53 (-2.37% of base) : System.Private.CoreLib.dasm - <WriteAsyncSlowPath>d__50:MoveNext():this
         -51 (-5.36% of base) : System.Private.CoreLib.dasm - <<WriteLineAsync>g__WriteLineAsyncCore|66_0>d:MoveNext():this
         -51 (-4.96% of base) : System.Private.CoreLib.dasm - <DisposeAsync>d__28:MoveNext():this
         -51 (-4.95% of base) : System.Private.CoreLib.dasm - <DisposeAsync>d__33:MoveNext():this

Top method regressions (percentages):
           9 ( 3.05% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SpillBuilder:AddSpill(Microsoft.CodeAnalysis.VisualBasic.BoundSpillSequence):this
           1 ( 2.33% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.MarshalPseudoCustomAttributeData:SetMarshalAsComInterface(int,System.Nullable`1[System.Int32]):this
          21 ( 2.17% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.OverloadResolution:GetEffectiveParametersInNormalForm(System.__Canon,int,System.Collections.Immutable.ImmutableArray`1[System.Int32],Microsoft.CodeAnalysis.ArrayBuilder`1[Microsoft.CodeAnalysis.RefKind],bool,byref):Microsoft.CodeAnalysis.CSharp.OverloadResolution+EffectiveParameters:this
           1 ( 1.64% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.MarshalPseudoCustomAttributeData:SetMarshalAsSafeArray(System.Nullable`1[System.Runtime.InteropServices.VarEnum],Microsoft.CodeAnalysis.ITypeSymbol):this
           9 ( 1.07% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AsyncMethodToClassRewriter:SpillArgumentListInner(System.Collections.Immutable.ImmutableArray`1[Microsoft.CodeAnalysis.VisualBasic.BoundExpression],Microsoft.CodeAnalysis.ArrayBuilder`1[Microsoft.CodeAnalysis.VisualBasic.AsyncRewriter+SpillBuilder],bool,byref):System.Collections.Immutable.ImmutableArray`1[Microsoft.CodeAnalysis.VisualBasic.BoundExpression]:this
           1 ( 0.82% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.MarshalPseudoCustomAttributeData:SetMarshalAsArray(System.Nullable`1[System.Runtime.InteropServices.UnmanagedType],System.Nullable`1[System.Int32],System.Nullable`1[System.Int16]):this
           3 ( 0.82% of base) : System.IO.Pipelines.dasm - System.IO.Pipelines.StreamPipeReader:AllocateSegment(System.Nullable`1[System.Int32]):System.IO.Pipelines.BufferSegment:this
           6 ( 0.71% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.ForEachStatementInfo:Equals(Microsoft.CodeAnalysis.CSharp.ForEachStatementInfo):bool:this
           3 ( 0.47% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.BoundFixedLocalCollectionInitializer:Update(Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol,Microsoft.CodeAnalysis.CSharp.Conversion,Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol):Microsoft.CodeAnalysis.CSharp.BoundFixedLocalCollectionInitializer:this
           3 ( 0.46% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.BoundAsOperator:Update(Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.CSharp.BoundTypeExpression,Microsoft.CodeAnalysis.CSharp.Conversion,Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol):Microsoft.CodeAnalysis.CSharp.BoundAsOperator:this
           3 ( 0.46% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.BoundIsOperator:Update(Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.CSharp.BoundTypeExpression,Microsoft.CodeAnalysis.CSharp.Conversion,Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol):Microsoft.CodeAnalysis.CSharp.BoundIsOperator:this
           3 ( 0.46% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.BoundNullCoalescingOperator:Update(Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.CSharp.Conversion,Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol):Microsoft.CodeAnalysis.CSharp.BoundNullCoalescingOperator:this
           7 ( 0.32% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SourceNamedTypeSymbol:MakeDeclaredBases(Roslyn.Utilities.ConsList`1[Microsoft.CodeAnalysis.CSharp.Symbol],Microsoft.CodeAnalysis.DiagnosticBag):System.Tuple`2[Microsoft.CodeAnalysis.CSharp.Symbols.NamedTypeSymbol, System.Collections.Immutable.ImmutableArray`1[Microsoft.CodeAnalysis.CSharp.Symbols.NamedTypeSymbol]]:this
           3 ( 0.27% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.BoundIncrementOperator:Update(int,Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.CSharp.Symbols.MethodSymbol,Microsoft.CodeAnalysis.CSharp.Conversion,Microsoft.CodeAnalysis.CSharp.Conversion,ubyte,Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol):Microsoft.CodeAnalysis.CSharp.BoundIncrementOperator:this
           3 ( 0.06% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.LocalRewriter:TransformCompoundAssignmentLHS(Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.ArrayBuilder`1[Microsoft.CodeAnalysis.CSharp.BoundExpression],Microsoft.CodeAnalysis.ArrayBuilder`1[Microsoft.CodeAnalysis.CSharp.Symbols.LocalSymbol],bool):Microsoft.CodeAnalysis.CSharp.BoundExpression:this

Top method improvements (percentages):
         -10 (-18.52% of base) : System.Formats.Cbor.dasm - System.Formats.Cbor.HalfHelpers:WriteHalfBigEndian(System.Span`1[System.Byte],System.Half)
         -10 (-16.39% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.NamedTypeSymbol:get_DefaultMarshallingCharSet():int:this
         -10 (-16.39% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.SourceAssemblySymbol:get_AssemblyHashAlgorithm():int:this
         -10 (-14.49% of base) : xunit.execution.dotnet.dasm - TestFrameworkOptionsReadExtensions:MaxParallelThreadsOrDefault(Xunit.Abstractions.ITestFrameworkExecutionOptions):int
         -10 (-14.49% of base) : xunit.runner.utility.netcoreapp10.dasm - TestFrameworkOptionsReadWriteExtensions:GetMaxParallelThreadsOrDefault(Xunit.Abstractions.ITestFrameworkExecutionOptions):int
         -27 (-11.59% of base) : System.Drawing.Common.dasm - System.Drawing.Drawing2D.Matrix:get_Offset():System.Drawing.PointF:this
         -21 (-11.54% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.DeclarationComputer:GetDeclarationInfo(Microsoft.CodeAnalysis.SemanticModel,Microsoft.CodeAnalysis.SyntaxNode,bool,Microsoft.CodeAnalysis.SyntaxNode,System.Threading.CancellationToken):Microsoft.CodeAnalysis.DeclarationInfo
         -22 (-11.46% of base) : Newtonsoft.Json.dasm - Newtonsoft.Json.Schema.JsonSchemaGenerator:HasFlag(System.Nullable`1[Newtonsoft.Json.Schema.JsonSchemaType],int):bool
         -26 (-11.21% of base) : System.Reflection.Metadata.dasm - System.Reflection.Metadata.StandaloneSignature:GetKind():int:this
         -21 (-11.17% of base) : System.Reflection.Metadata.dasm - System.Reflection.Internal.DecimalUtilities:GetScale(System.Decimal):int
         -10 (-11.11% of base) : System.Net.Http.dasm - System.Net.Http.Headers.HttpHeadersNonValidated:get_Count():int:this
         -35 (-10.61% of base) : System.Numerics.Tensors.dasm - System.Numerics.Tensors.Tensor:CreateIdentity(int,bool,System.__Canon):System.Numerics.Tensors.Tensor`1[System.__Canon]
         -10 (-10.31% of base) : System.Net.Http.dasm - System.Net.Http.Headers.HttpGeneralHeaders:set_ConnectionClose(System.Nullable`1[System.Boolean]):this
         -10 (-10.31% of base) : System.Net.Http.dasm - System.Net.Http.Headers.HttpGeneralHeaders:set_TransferEncodingChunked(System.Nullable`1[System.Boolean]):this
         -10 (-10.31% of base) : System.Net.Http.dasm - System.Net.Http.Headers.HttpRequestHeaders:set_ExpectContinue(System.Nullable`1[System.Boolean]):this
         -10 (-10.10% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.BoundExpressionExtensions:IsNegativeIntegerConstant(Microsoft.CodeAnalysis.VisualBasic.BoundExpression):bool
         -21 (-9.81% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.ExtendedErrorTypeSymbol:.ctor(Microsoft.CodeAnalysis.CSharp.Symbols.NamespaceOrTypeSymbol,Microsoft.CodeAnalysis.CSharp.Symbol,ubyte,Microsoft.CodeAnalysis.DiagnosticInfo,bool):this
         -10 (-9.71% of base) : Newtonsoft.Json.dasm - Newtonsoft.Json.JsonReader:set_MaxDepth(System.Nullable`1[System.Int32]):this
         -27 (-9.25% of base) : System.Formats.Cbor.dasm - DecimalHelpers:ReconstructFromNegativeScale(System.Decimal,ubyte):System.Decimal
         -10 (-9.09% of base) : Newtonsoft.Json.dasm - Newtonsoft.Json.JsonSerializerSettings:set_MaxDepth(System.Nullable`1[System.Int32]):this

230 total methods with Code Size differences (215 improved, 15 regressed), 249281 unchanged.
```
Regressions due to changes in frame offsets that lead to use of 32 bit displacement encoding or changes in prolog local zeroing.