### PR TITLE
Cleanup VN copy propagation

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5061,11 +5061,6 @@ private:
 
 void Compiler::optVNAssertionProp()
 {
-    if (fgSsaPassesCompleted == 0)
-    {
-        return;
-    }
-
 #ifdef DEBUG
     if (verbose)
     {
@@ -5074,6 +5069,8 @@ void Compiler::optVNAssertionProp()
         fgDispBasicBlocks(true);
     }
 #endif
+
+    assert(ssaForm && (vnStore != nullptr));
 
     optAssertionInit();
 

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -114,6 +114,9 @@ void Compiler::optAddCopies()
         //
         // On all other platforms we will never need to make a copy
         // for an incoming double parameter
+        //
+        // TODO-MIKE-CQ: So if this is done in order to get around DOUBLE parameter
+        // alignment then why the crap it's also checking for FLOAT?!?
 
         bool isFloatParam = false;
 

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -1126,7 +1126,7 @@ void Compiler::compInit(ArenaAllocator*       pAlloc,
 
     ssaForm                    = false;
     vnStore                    = nullptr;
-    m_opAsgnVarDefSsaNums      = nullptr;
+    m_partialSsaDefMap         = nullptr;
     m_nodeToLoopMemoryBlockMap = nullptr;
 
     // check that HelperCallProperties are initialized
@@ -4157,10 +4157,10 @@ void Compiler::ResetOptAnnotations()
 
     fgResetForSsa();
 
-    ssaForm               = false;
-    vnStore               = nullptr;
-    m_opAsgnVarDefSsaNums = nullptr;
-    m_blockToEHPreds      = nullptr;
+    ssaForm            = false;
+    vnStore            = nullptr;
+    m_partialSsaDefMap = nullptr;
+    m_blockToEHPreds   = nullptr;
 
     for (BasicBlock* const block : Blocks())
     {

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5710,7 +5710,6 @@ public:
     class CopyPropDomTreeVisitor;
 
     void optCopyProp(GenTreeLclVar* use, CopyPropDomTreeVisitor& visitor);
-    void optBlockCopyPropPopStacks(BasicBlock* block, CopyPropDomTreeVisitor& visitor);
     void optBlockCopyProp(BasicBlock* block, CopyPropDomTreeVisitor& visitor);
     GenTreeLclVarCommon* optIsSsaLocal(GenTree* node);
     int optCopyProp_LclVarScore(LclVarDsc* lclVarDsc, LclVarDsc* copyVarDsc, bool preferOp2);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -991,6 +991,11 @@ public:
         return lvPerSsaData.GetSsaDef(ssaNum);
     }
 
+    bool HasSingleSsaDef() const
+    {
+        return lvPerSsaData.GetCount() == 1;
+    }
+
     bool HasImplicitSsaDef() const
     {
         return (lvPerSsaData.GetCount() != 0) &&

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3915,7 +3915,7 @@ public:
     // Reset any data structures to the state expected by "fgSsaBuild", so it can be run again.
     void fgResetForSsa();
 
-    unsigned fgSsaPassesCompleted; // Number of times fgSsaBuild has been run.
+    bool ssaForm;
 
     // Returns "true" if this is a special variable that is never zero initialized in the prolog.
     inline bool fgVarIsNeverZeroInitializedInProlog(unsigned varNum);
@@ -3979,8 +3979,6 @@ public:
     FieldSeqNode* vnIsFieldAddr(GenTree* addr, GenTree** obj);
     FieldSeqNode* vnIsStaticStructFieldAddr(GenTree* addr);
     bool vnIsArrayElemAddr(GenTree* addr, ArrayInfo* arrayInfo);
-
-    unsigned fgVNPassesCompleted; // Number of times fgValueNumber has been run.
 
     struct VNLoop
     {

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3958,6 +3958,7 @@ public:
     ValueNum vnCoerceLoadValue(GenTree* load, ValueNum valueVN, var_types fieldType, ClassLayout* fieldLayout);
     void vnLocalStore(GenTreeLclVar* store, GenTreeOp* asg, GenTree* value);
     void vnLocalLoad(GenTreeLclVar* load);
+    ValueNumPair vnLocalLoad(GenTreeLclVar* load, LclVarDsc* lcl, unsigned ssaNum);
     void vnLocalFieldStore(GenTreeLclFld* store, GenTreeOp* asg, GenTree* value);
     void vnLocalFieldLoad(GenTreeLclFld* load);
     ValueNum vnAddField(GenTreeOp* add);
@@ -5708,7 +5709,7 @@ protected:
 public:
     class CopyPropDomTreeVisitor;
 
-    void optCopyProp(GenTreeLclVar* tree, CopyPropDomTreeVisitor& visitor);
+    void optCopyProp(GenTreeLclVar* use, CopyPropDomTreeVisitor& visitor);
     void optBlockCopyPropPopStacks(BasicBlock* block, CopyPropDomTreeVisitor& visitor);
     void optBlockCopyProp(BasicBlock* block, CopyPropDomTreeVisitor& visitor);
     GenTreeLclVarCommon* optIsSsaLocal(GenTree* node);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5695,8 +5695,6 @@ protected:
 public:
     class CopyPropDomTreeVisitor;
 
-    void optCopyProp(GenTreeLclVar* use, CopyPropDomTreeVisitor& visitor);
-    int optCopyProp_LclVarScore(LclVarDsc* lclVarDsc, LclVarDsc* copyVarDsc);
     void optVnCopyProp();
 
 /**************************************************************************

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5723,17 +5723,12 @@ public:
     typedef JitHashTable<unsigned, JitSmallPrimitiveKeyFuncs<unsigned>, ArrayStack<GenTree*>*> LclNumToGenTreePtrStack;
 
     // Copy propagation functions.
-    void optCopyProp(BasicBlock*                    block,
-                     Statement*                     stmt,
-                     GenTreeLclVar*                 tree,
-                     unsigned                       lclNum,
-                     LclNumToGenTreePtrStack*       curSsaName,
-                     class CopyPropLivenessUpdater& liveness);
+    void optCopyProp(GenTreeLclVar* tree, LclNumToGenTreePtrStack* curSsaName, class CopyPropLivenessUpdater& liveness);
     void optBlockCopyPropPopStacks(BasicBlock* block, LclNumToGenTreePtrStack* curSsaName);
     void optBlockCopyProp(BasicBlock*                    block,
                           LclNumToGenTreePtrStack*       curSsaName,
                           class CopyPropLivenessUpdater& liveness);
-    unsigned optIsSsaLocal(GenTree* tree);
+    GenTreeLclVarCommon* optIsSsaLocal(GenTree* node);
     int optCopyProp_LclVarScore(LclVarDsc* lclVarDsc, LclVarDsc* copyVarDsc, bool preferOp2);
     void optVnCopyProp();
     INDEBUG(void optDumpCopyPropStack(LclNumToGenTreePtrStack* curSsaName));

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5714,7 +5714,6 @@ public:
     GenTreeLclVarCommon* optIsSsaLocal(GenTree* node);
     int optCopyProp_LclVarScore(LclVarDsc* lclVarDsc, LclVarDsc* copyVarDsc);
     void optVnCopyProp();
-    INDEBUG(void optDumpCopyPropStack(CopyPropDomTreeVisitor& visitor));
 
 /**************************************************************************
  *               Early value propagation

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3876,6 +3876,7 @@ public:
 
     void SetPartialSsaDefNum(GenTreeLclFld* store, unsigned ssaNum);
     unsigned GetSsaDefNum(GenTreeLclVarCommon* lclNode);
+    INDEBUG(void MoveSsaDefNum(GenTreeLclVarCommon* from, GenTreeLclVarCommon* to);)
 
     // This map tracks nodes whose value numbers explicitly or implicitly depend on memory states.
     // The map provides the entry block of the most closely enclosing loop that

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -303,7 +303,7 @@ public:
     }
 
     // Get a pointer to the SSA definition at the specified index.
-    T* GetSsaDefByIndex(unsigned index)
+    T* GetSsaDefByIndex(unsigned index) const
     {
         assert(index < m_count);
         return &m_array[index];
@@ -316,7 +316,7 @@ public:
     }
 
     // Get a pointer to the SSA definition associated with the specified SSA number.
-    T* GetSsaDef(unsigned ssaNum)
+    T* GetSsaDef(unsigned ssaNum) const
     {
         assert(ssaNum != SsaConfig::RESERVED_SSA_NUM);
         return GetSsaDefByIndex(ssaNum - GetMinSsaNum());
@@ -989,6 +989,12 @@ public:
     LclSsaVarDsc* GetPerSsaData(unsigned ssaNum)
     {
         return lvPerSsaData.GetSsaDef(ssaNum);
+    }
+
+    bool HasImplicitSsaDef() const
+    {
+        return (lvPerSsaData.GetCount() != 0) &&
+               (lvPerSsaData.GetSsaDef(SsaConfig::FIRST_SSA_NUM)->GetAssignment() == nullptr);
     }
 
     var_types GetRegisterType(const GenTreeLclVarCommon* tree) const;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -504,17 +504,6 @@ public:
                                          // the prolog. If the local has gc pointers, there are no gc-safe points
                                          // between the prolog and the explicit initialization.
 
-    // TODO-MIKE-Cleanup/Fix: This is pretty much bogus. Only VN Copy Prop uses this and for the wrong reasons.
-    // It assumes that if this is set then the local is live, because "this" is supposed to always be live.
-    // Except that isn't really true, "this" is always live only in certain methods (e.g. those that need
-    // it for the generic context). Also, if "this" is stored to, a copy of "this" is created and lvIsThisPtr
-    // is set on that copy, not on the original "this" local. And that copy doesn't have the same "always live"
-    // behavior as the "this" param itself.
-    // This is primarily a cleanup issue, LclVarDsc already contains too much information and the last thing
-    // it needs is such bogus info.
-    // It's also a bug but it requires rather exotic IL code to reproduce it (see copy-prop-test.il test).
-    unsigned char lvIsThisPtr : 1;
-
     union {
         unsigned lvFieldLclStart; // The index of the local var representing the first field in the promoted
                                   // struct local. For implicit byref parameters, this gets hijacked between

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3861,20 +3861,12 @@ public:
         return BasicBlockRangeList(startBlock, endBlock);
     }
 
-    // The presence of a partial definition presents some difficulties for SSA: this is both a use of some SSA name
-    // of "x", and a def of a new SSA name for "x".  The tree only has one local variable for "x", so it has to choose
-    // whether to treat that as the use or def.  It chooses the "use", and thus the old SSA name.  This map allows us
-    // to record/recover the "def" SSA number, given the lcl var node for "x" in such a tree.
     typedef JitHashTable<GenTree*, JitPtrKeyFuncs<GenTree>, unsigned> NodeToUnsignedMap;
-    NodeToUnsignedMap* m_opAsgnVarDefSsaNums;
-    NodeToUnsignedMap* GetOpAsgnVarDefSsaNums()
-    {
-        if (m_opAsgnVarDefSsaNums == nullptr)
-        {
-            m_opAsgnVarDefSsaNums = new (getAllocator()) NodeToUnsignedMap(getAllocator());
-        }
-        return m_opAsgnVarDefSsaNums;
-    }
+
+    NodeToUnsignedMap* m_partialSsaDefMap;
+
+    void SetPartialSsaDefNum(GenTreeLclFld* store, unsigned ssaNum);
+    unsigned GetSsaDefNum(GenTreeLclVarCommon* lclNode);
 
     // This map tracks nodes whose value numbers explicitly or implicitly depend on memory states.
     // The map provides the entry block of the most closely enclosing loop that
@@ -3902,12 +3894,6 @@ public:
 
     void optRecordLoopMemoryDependence(GenTree* tree, BasicBlock* block, ValueNum memoryVN);
     void optCopyLoopMemoryDependence(GenTree* fromTree, GenTree* toTree);
-
-    // Requires that "lcl" has the GTF_VAR_DEF flag set.  Returns the SSA number of "lcl".
-    // Except: assumes that lcl is a def, and if it is
-    // a partial def (GTF_VAR_USEASG), looks up and returns the SSA number for the "def",
-    // rather than the "use" SSA number recorded in the tree "lcl".
-    inline unsigned GetSsaNumForLocalVarDef(GenTree* lcl);
 
     // Performs SSA conversion.
     void fgSsaBuild();

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5696,8 +5696,6 @@ public:
     class CopyPropDomTreeVisitor;
 
     void optCopyProp(GenTreeLclVar* use, CopyPropDomTreeVisitor& visitor);
-    void optBlockCopyProp(BasicBlock* block, CopyPropDomTreeVisitor& visitor);
-    GenTreeLclVarCommon* optIsSsaLocal(GenTree* node);
     int optCopyProp_LclVarScore(LclVarDsc* lclVarDsc, LclVarDsc* copyVarDsc);
     void optVnCopyProp();
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5693,8 +5693,6 @@ protected:
     static callInterf optCallInterf(GenTreeCall* call);
 
 public:
-    class CopyPropDomTreeVisitor;
-
     void optVnCopyProp();
 
 /**************************************************************************

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2685,8 +2685,6 @@ public:
     bool lvaIsParameter(unsigned varNum);
     bool lvaIsRegArgument(unsigned varNum);
     bool lvaIsOriginalThisArg(unsigned varNum); // Is this varNum the original this argument?
-    bool lvaIsOriginalThisReadOnly();           // return true if there is no place in the code
-                                                // that writes to arg0
 
     bool lvaIsImplicitByRefLocal(unsigned varNum)
     {

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5708,19 +5708,15 @@ protected:
     static callInterf optCallInterf(GenTreeCall* call);
 
 public:
-    // VN based copy propagation.
-    typedef JitHashTable<unsigned, JitSmallPrimitiveKeyFuncs<unsigned>, ArrayStack<GenTree*>*> LclNumToGenTreePtrStack;
+    class CopyPropDomTreeVisitor;
 
-    // Copy propagation functions.
-    void optCopyProp(GenTreeLclVar* tree, LclNumToGenTreePtrStack* curSsaName, class CopyPropLivenessUpdater& liveness);
-    void optBlockCopyPropPopStacks(BasicBlock* block, LclNumToGenTreePtrStack* curSsaName);
-    void optBlockCopyProp(BasicBlock*                    block,
-                          LclNumToGenTreePtrStack*       curSsaName,
-                          class CopyPropLivenessUpdater& liveness);
+    void optCopyProp(GenTreeLclVar* tree, CopyPropDomTreeVisitor& visitor);
+    void optBlockCopyPropPopStacks(BasicBlock* block, CopyPropDomTreeVisitor& visitor);
+    void optBlockCopyProp(BasicBlock* block, CopyPropDomTreeVisitor& visitor);
     GenTreeLclVarCommon* optIsSsaLocal(GenTree* node);
     int optCopyProp_LclVarScore(LclVarDsc* lclVarDsc, LclVarDsc* copyVarDsc, bool preferOp2);
     void optVnCopyProp();
-    INDEBUG(void optDumpCopyPropStack(LclNumToGenTreePtrStack* curSsaName));
+    INDEBUG(void optDumpCopyPropStack(CopyPropDomTreeVisitor& visitor));
 
 /**************************************************************************
  *               Early value propagation

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5712,7 +5712,7 @@ public:
     void optCopyProp(GenTreeLclVar* use, CopyPropDomTreeVisitor& visitor);
     void optBlockCopyProp(BasicBlock* block, CopyPropDomTreeVisitor& visitor);
     GenTreeLclVarCommon* optIsSsaLocal(GenTree* node);
-    int optCopyProp_LclVarScore(LclVarDsc* lclVarDsc, LclVarDsc* copyVarDsc, bool preferOp2);
+    int optCopyProp_LclVarScore(LclVarDsc* lclVarDsc, LclVarDsc* copyVarDsc);
     void optVnCopyProp();
     INDEBUG(void optDumpCopyPropStack(CopyPropDomTreeVisitor& visitor));
 

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -2032,11 +2032,6 @@ inline bool Compiler::lvaIsOriginalThisArg(unsigned varNum)
     return isOriginalThisArg;
 }
 
-inline bool Compiler::lvaIsOriginalThisReadOnly()
-{
-    return lvaArg0Var == info.compThisArg;
-}
-
 /*
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -3565,10 +3565,23 @@ inline unsigned Compiler::GetSsaDefNum(GenTreeLclVarCommon* lclNode)
         return lclNode->GetSsaNum();
     }
 
-    assert(lclNode->OperIs(GT_LCL_FLD));
+    assert(lclNode->OperIs(GT_LCL_FLD, GT_STORE_LCL_FLD));
 
     return *m_partialSsaDefMap->LookupPointer(lclNode);
 }
+
+#ifdef DEBUG
+inline void Compiler::MoveSsaDefNum(GenTreeLclVarCommon* from, GenTreeLclVarCommon* to)
+{
+    if (m_partialSsaDefMap != nullptr)
+    {
+        if (unsigned* ssaDefNum = m_partialSsaDefMap->LookupPointer(from))
+        {
+            m_partialSsaDefMap->Set(to, *ssaDefNum);
+        }
+    }
+}
+#endif
 
 template <typename TVisitor>
 void GenTree::VisitOperands(TVisitor visitor)

--- a/src/coreclr/jit/copyprop.cpp
+++ b/src/coreclr/jit/copyprop.cpp
@@ -350,13 +350,10 @@ public:
             // may again turn out to not be so great for CQ due to live range extension issues.
             // Maybe it could work well for parameters and other locals that have the single SSA
             // def at the start of the first block?
-            //
-            // TODO-MIKE-Cleanup: Well, `this` should really have only one def. Except that loop
-            // tail call morphing is messy and introduces unnecessary defs...
 
-            if ((newLclNum == m_compiler->info.compThisArg) && (newLcl->lvPerSsaData.GetCount() == 1))
+            if (newLclNum == m_compiler->info.compThisArg)
             {
-                assert(newLcl->HasImplicitSsaDef());
+                assert((newLcl->lvPerSsaData.GetCount() == 1) && newLcl->HasImplicitSsaDef());
             }
             else if (!VarSetOps::IsMember(m_compiler, liveness.GetLiveSet(), newLcl->GetLivenessBitIndex()))
             {

--- a/src/coreclr/jit/copyprop.cpp
+++ b/src/coreclr/jit/copyprop.cpp
@@ -399,17 +399,9 @@ void Compiler::optBlockCopyProp(BasicBlock* block, CopyPropDomTreeVisitor& visit
 
 void Compiler::optVnCopyProp()
 {
-#ifdef DEBUG
-    if (verbose)
-    {
-        printf("*************** In optVnCopyProp()\n");
-    }
-#endif
+    JITDUMP("*************** In optVnCopyProp()\n");
 
-    if (fgSsaPassesCompleted == 0)
-    {
-        return;
-    }
+    assert(ssaForm && (vnStore != nullptr));
 
     CopyPropDomTreeVisitor visitor(this);
     visitor.WalkTree();

--- a/src/coreclr/jit/copyprop.cpp
+++ b/src/coreclr/jit/copyprop.cpp
@@ -313,13 +313,7 @@ public:
                 continue;
             }
 
-            // Do not copy propagate if the old and new lclVar have different 'doNotEnregister' settings.
-            // This is primarily to avoid copy propagating to IND(ADDR(LCL_VAR)) where the replacement lclVar
-            // is not marked 'lvDoNotEnregister'.
-            // However, in addition, it may not be profitable to propagate a 'doNotEnregister' lclVar to an
-            // existing use of an enregisterable lclVar.
-
-            if (lcl->lvDoNotEnregister != newLcl->lvDoNotEnregister)
+            if (!lcl->lvDoNotEnregister && newLcl->lvDoNotEnregister)
             {
                 continue;
             }

--- a/src/coreclr/jit/copyprop.cpp
+++ b/src/coreclr/jit/copyprop.cpp
@@ -188,8 +188,7 @@ public:
         {
             LclVarDsc* lcl = m_compiler->lvaGetDesc(lclNum);
 
-            if ((lcl->lvPerSsaData.GetCount() > 0) &&
-                (lcl->GetPerSsaData(SsaConfig::FIRST_SSA_NUM)->GetAssignment() == nullptr))
+            if (lcl->HasImplicitSsaDef())
             {
                 PushSsaDef(lclSsaStackMap.Emplace(lclNum), m_compiler->fgFirstBB, SsaConfig::FIRST_SSA_NUM);
             }

--- a/src/coreclr/jit/copyprop.cpp
+++ b/src/coreclr/jit/copyprop.cpp
@@ -313,7 +313,7 @@ void Compiler::optCopyProp(GenTreeLclVar* tree, LclNumToGenTreePtrStack* curSsaN
         // 'c' with 'x.'
         // Because of this dependence on live variable analysis, CopyProp phase is immediately
         // after Liveness, SSA and VN.
-        if (!newLcl->lvIsThisPtr && !VarSetOps::IsMember(this, liveness.GetLiveSet(), newLcl->GetLivenessBitIndex()))
+        if (!VarSetOps::IsMember(this, liveness.GetLiveSet(), newLcl->GetLivenessBitIndex()))
         {
             continue;
         }
@@ -436,7 +436,7 @@ void Compiler::optBlockCopyProp(BasicBlock*              block,
 
             // If we encounter first use of a param or this pointer add it as a live definition.
             // Since they are always live, do it only once.
-            if (lclNode->OperIs(GT_LCL_VAR) && (lcl->IsParam() || lcl->lvIsThisPtr))
+            if (lclNode->OperIs(GT_LCL_VAR) && lcl->IsParam())
             {
                 ArrayStack<GenTree*>* stack;
                 if (!curSsaName->Lookup(lclNum, &stack))

--- a/src/coreclr/jit/copyprop.cpp
+++ b/src/coreclr/jit/copyprop.cpp
@@ -368,7 +368,7 @@ void Compiler::optBlockCopyProp(BasicBlock* block, CopyPropDomTreeVisitor& visit
             if ((lclNode->gtFlags & GTF_VAR_DEF) != 0)
             {
                 visitor.liveness.UpdateDef(lclNode);
-                visitor.PushSsaDef(visitor.lclSsaStackMap.Emplace(lclNum), block, GetSsaNumForLocalVarDef(lclNode));
+                visitor.PushSsaDef(visitor.lclSsaStackMap.Emplace(lclNum), block, GetSsaDefNum(lclNode));
 
                 continue;
             }

--- a/src/coreclr/jit/copyprop.cpp
+++ b/src/coreclr/jit/copyprop.cpp
@@ -218,9 +218,9 @@ void Compiler::optDumpCopyPropStack(CopyPropDomTreeVisitor& visitor)
 }
 #endif
 
-int Compiler::optCopyProp_LclVarScore(LclVarDsc* lclVarDsc, LclVarDsc* copyVarDsc, bool preferOp2)
+int Compiler::optCopyProp_LclVarScore(LclVarDsc* lclVarDsc, LclVarDsc* copyVarDsc)
 {
-    int score = 0;
+    int score = 1;
 
     if (lclVarDsc->lvVolatileHint)
     {
@@ -248,8 +248,7 @@ int Compiler::optCopyProp_LclVarScore(LclVarDsc* lclVarDsc, LclVarDsc* copyVarDs
     }
 #endif
 
-    // Otherwise we prefer to use the op2LclNum
-    return score + ((preferOp2) ? 1 : -1);
+    return score;
 }
 
 void Compiler::optCopyProp(GenTreeLclVar* use, CopyPropDomTreeVisitor& visitor)
@@ -305,7 +304,7 @@ void Compiler::optCopyProp(GenTreeLclVar* use, CopyPropDomTreeVisitor& visitor)
             continue;
         }
 
-        if (optCopyProp_LclVarScore(lcl, newLcl, true) <= 0)
+        if (optCopyProp_LclVarScore(lcl, newLcl) <= 0)
         {
             continue;
         }

--- a/src/coreclr/jit/copyprop.cpp
+++ b/src/coreclr/jit/copyprop.cpp
@@ -196,11 +196,16 @@ public:
                 {
                     // We obviously need to push a SSA def for VAR_DEF but we also push
                     // a "fake" one for VAR_DEATH, to prevent live range extension.
+                    // For STRUCT local live range extension isn't an issue as they're
+                    // currently not enregistered nor is any stack packing done.
 
                     unsigned ssaDefNum = ((lclNode->gtFlags & GTF_VAR_DEATH) != 0) ? SsaConfig::RESERVED_SSA_NUM
                                                                                    : m_compiler->GetSsaDefNum(lclNode);
 
-                    PushSsaDef(lclSsaStackMap.Emplace(lclNum), block, ssaDefNum);
+                    if (((lclNode->gtFlags & GTF_VAR_DEF) != 0) || !lcl->TypeIs(TYP_STRUCT))
+                    {
+                        PushSsaDef(lclSsaStackMap.Emplace(lclNum), block, ssaDefNum);
+                    }
 
                     if ((lclNode->gtFlags & GTF_VAR_DEF) != 0)
                     {

--- a/src/coreclr/jit/earlyprop.cpp
+++ b/src/coreclr/jit/earlyprop.cpp
@@ -155,7 +155,7 @@ void Compiler::optEarlyProp()
     }
 #endif
 
-    assert(fgSsaPassesCompleted == 1);
+    assert(ssaForm);
 
     for (BasicBlock* const block : Blocks())
     {

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -2177,16 +2177,12 @@ void Compiler::fgAdjustForAddressExposedOrWrittenThis()
         thisCopyLcl->lvAddrExposed     = thisLcl->lvAddrExposed;
         thisCopyLcl->lvDoNotEnregister = thisLcl->lvDoNotEnregister;
         thisCopyLcl->lvHasILStoreOp    = thisLcl->lvHasILStoreOp;
-        thisCopyLcl->lvIsThisPtr       = thisLcl->lvIsThisPtr;
 #ifdef DEBUG
         thisCopyLcl->lvLiveInOutOfHndlr = thisLcl->lvLiveInOutOfHndlr;
         thisCopyLcl->lvLclFieldExpr     = thisLcl->lvLclFieldExpr;
         thisCopyLcl->lvLiveAcrossUCall  = thisLcl->lvLiveAcrossUCall;
 #endif
 
-        noway_assert(thisCopyLcl->lvIsThisPtr);
-
-        thisLcl->lvIsThisPtr    = false;
         thisLcl->lvAddrExposed  = false;
         thisLcl->lvHasILStoreOp = false;
     }

--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -2119,7 +2119,7 @@ PhaseStatus Compiler::fgTailMergeThrows()
     BlockToBlockMap::KeyIterator end(blockMap.End());
     unsigned                     updateCount = 0;
 
-    for (; !iter.Equal(end); iter++)
+    for (; !iter.Equal(end); ++iter)
     {
         BasicBlock* const nonCanonicalBlock = iter.Get();
         BasicBlock* const canonicalBlock    = iter.GetValue();

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -7911,7 +7911,7 @@ void Compiler::dmpLclVarCommon(GenTreeLclVarCommon* node, IndentStack* indentSta
 
         if ((node->gtFlags & GTF_VAR_USEASG) != 0)
         {
-            printf("u:%d, d:%d", node->GetSsaNum(), GetSsaNumForLocalVarDef(node));
+            printf("u:%d, d:%d", node->GetSsaNum(), GetSsaDefNum(node));
         }
         else
         {

--- a/src/coreclr/jit/gschecks.cpp
+++ b/src/coreclr/jit/gschecks.cpp
@@ -440,7 +440,6 @@ void Compiler::gsParamsToShadows()
 
         shadowLcl->lvAddrExposed     = lcl->lvAddrExposed;
         shadowLcl->lvDoNotEnregister = lcl->lvDoNotEnregister;
-        shadowLcl->lvIsThisPtr       = lcl->lvIsThisPtr;
         shadowLcl->lvIsUnsafeBuffer  = lcl->lvIsUnsafeBuffer;
         shadowLcl->lvIsPtr           = lcl->lvIsPtr;
 #ifdef DEBUG

--- a/src/coreclr/jit/jithashtable.h
+++ b/src/coreclr/jit/jithashtable.h
@@ -597,6 +597,13 @@ public:
             return m_node->m_key;
         }
 
+        const Key& GetKey() const
+        {
+            assert(m_node != nullptr);
+
+            return m_node->m_key;
+        }
+
         //------------------------------------------------------------------------
         // GetValue: Get a reference to this iterator's value.
         //

--- a/src/coreclr/jit/jithashtable.h
+++ b/src/coreclr/jit/jithashtable.h
@@ -103,7 +103,13 @@ template <typename Key,
 class JitHashTable
 {
 public:
-    class KeyIterator;
+    struct Pair
+    {
+        const Key key;
+        Value     value;
+    };
+
+    class iterator;
 
     //------------------------------------------------------------------------
     // JitHashTable: Construct an empty JitHashTable object.
@@ -157,7 +163,7 @@ public:
         {
             if (pVal != nullptr)
             {
-                *pVal = pN->m_val;
+                *pVal = pN->m_value.value;
             }
             return true;
         }
@@ -188,7 +194,7 @@ public:
 
         if (pN != nullptr)
         {
-            return &(pN->m_val);
+            return &(pN->m_value.value);
         }
         else
         {
@@ -229,14 +235,14 @@ public:
         unsigned index = GetIndexForKey(k);
 
         Node* pN = m_table[index];
-        while ((pN != nullptr) && !KeyFuncs::Equals(k, pN->m_key))
+        while ((pN != nullptr) && !KeyFuncs::Equals(k, pN->m_value.key))
         {
             pN = pN->m_next;
         }
         if (pN != nullptr)
         {
             assert(kind == Overwrite);
-            pN->m_val = v;
+            pN->m_value.value = v;
             return true;
         }
         else
@@ -269,7 +275,7 @@ public:
         unsigned index = GetIndexForKey(k);
 
         Node* n = m_table[index];
-        while ((n != nullptr) && !KeyFuncs::Equals(k, n->m_key))
+        while ((n != nullptr) && !KeyFuncs::Equals(k, n->m_value.key))
         {
             n = n->m_next;
         }
@@ -282,7 +288,7 @@ public:
             m_tableCount++;
         }
 
-        return &n->m_val;
+        return &n->m_value.value;
     }
 
     //------------------------------------------------------------------------
@@ -303,7 +309,7 @@ public:
 
         Node*  pN  = m_table[index];
         Node** ppN = &m_table[index];
-        while ((pN != nullptr) && !KeyFuncs::Equals(k, pN->m_key))
+        while ((pN != nullptr) && !KeyFuncs::Equals(k, pN->m_value.key))
         {
             ppN = &pN->m_next;
             pN  = pN->m_next;
@@ -349,16 +355,27 @@ public:
     }
 
     // Get an iterator to the first key in the table.
-    KeyIterator Begin() const
+    // [[deprecated]]
+    iterator Begin() const
     {
-        KeyIterator i(this, true);
-        return i;
+        return iterator(this);
+    }
+
+    iterator begin() const
+    {
+        return iterator(this);
     }
 
     // Get an iterator following the last key in the table.
-    KeyIterator End() const
+    // [[deprecated]]
+    iterator End() const
     {
-        return KeyIterator(this, false);
+        return iterator();
+    }
+
+    iterator end() const
+    {
+        return iterator();
     }
 
     // Get the number of keys currently stored in the table.
@@ -419,12 +436,12 @@ private:
         }
 
         // Otherwise...
-        while ((pN != nullptr) && !KeyFuncs::Equals(k, pN->m_key))
+        while ((pN != nullptr) && !KeyFuncs::Equals(k, pN->m_value.key))
         {
             pN = pN->m_next;
         }
 
-        assert((pN == nullptr) || KeyFuncs::Equals(k, pN->m_key));
+        assert((pN == nullptr) || KeyFuncs::Equals(k, pN->m_value.key));
 
         // If pN != nullptr, it's the node for the key, else the key isn't mapped.
         return pN;
@@ -506,7 +523,7 @@ public:
             {
                 Node* pNext = pN->m_next;
 
-                unsigned newIndex  = newPrime.magicNumberRem(KeyFuncs::GetHashCode(pN->m_key));
+                unsigned newIndex  = newPrime.magicNumberRem(KeyFuncs::GetHashCode(pN->m_value.key));
                 pN->m_next         = newTable[newIndex];
                 newTable[newIndex] = pN;
 
@@ -536,160 +553,89 @@ public:
     // }
     // iter.Get() will yield (a reference to) the
     // current key.  It will assert the equivalent of "iter != end."
-    class KeyIterator
+    class iterator
     {
-    private:
         friend class JitHashTable;
 
-        Node**   m_table;
-        Node*    m_node;
-        unsigned m_tableSize;
-        unsigned m_index;
+        Node*  m_node;
+        Node** m_buckets;
+        Node** m_bucketsEnd;
+
+        iterator() : m_node(nullptr)
+        {
+        }
+
+        iterator(const JitHashTable* hash)
+            : m_node(nullptr), m_buckets(hash->m_table), m_bucketsEnd(hash->m_table + hash->m_tableSizeInfo.prime)
+        {
+            if (hash->m_tableCount > 0)
+            {
+                FindNextBucket();
+            }
+        }
+
+        void FindNextBucket()
+        {
+            while ((m_buckets < m_bucketsEnd) && ((m_node = *m_buckets++) == nullptr))
+            {
+            }
+        }
 
     public:
-        //------------------------------------------------------------------------
-        // KeyIterator: Construct an iterator for the specified JitHashTable.
-        //
-        // Arguments:
-        //    hash  - the hashtable
-        //    begin - `true` to construct an "begin" iterator,
-        //            `false` to construct an "end" iterator
-        //
-        KeyIterator(const JitHashTable* hash, bool begin)
-            : m_table(hash->m_table)
-            , m_node(nullptr)
-            , m_tableSize(hash->m_tableSizeInfo.prime)
-            , m_index(begin ? 0 : m_tableSize)
-        {
-            if (begin && (hash->m_tableCount > 0))
-            {
-                assert(m_table != nullptr);
-                while ((m_index < m_tableSize) && (m_table[m_index] == nullptr))
-                {
-                    m_index++;
-                }
-
-                if (m_index >= m_tableSize)
-                {
-                    return;
-                }
-                else
-                {
-                    m_node = m_table[m_index];
-                }
-                assert(m_node != nullptr);
-            }
-        }
-
-        //------------------------------------------------------------------------
-        // Get: Get a reference to this iterator's key.
-        //
-        // Return Value:
-        //    A reference to this iterator's key.
-        //
-        // Assumptions:
-        //    This must not be the "end" iterator.
-        //
-        const Key& Get() const
-        {
-            assert(m_node != nullptr);
-
-            return m_node->m_key;
-        }
-
-        const Key& GetKey() const
-        {
-            assert(m_node != nullptr);
-
-            return m_node->m_key;
-        }
-
-        //------------------------------------------------------------------------
-        // GetValue: Get a reference to this iterator's value.
-        //
-        // Return Value:
-        //    A reference to this iterator's value.
-        //
-        // Assumptions:
-        //    This must not be the "end" iterator.
-        //
-        Value& GetValue() const
-        {
-            assert(m_node != nullptr);
-
-            return m_node->m_val;
-        }
-
-        //------------------------------------------------------------------------
-        // SetValue: Assign a new value to this iterator's key
-        //
-        // Arguments:
-        //    value - the value to assign
-        //
-        // Assumptions:
-        //    This must not be the "end" iterator.
-        //
-        void SetValue(const Value& value) const
-        {
-            assert(m_node != nullptr);
-
-            m_node->m_val = value;
-        }
-
-        //------------------------------------------------------------------------
-        // Next: Advance the iterator to the next node.
-        //
-        // Notes:
-        //    Advancing the end iterator has no effect.
-        //
-        void Next()
-        {
-            if (m_node != nullptr)
-            {
-                m_node = m_node->m_next;
-                if (m_node != nullptr)
-                {
-                    return;
-                }
-
-                // Otherwise...
-                m_index++;
-            }
-            while ((m_index < m_tableSize) && (m_table[m_index] == nullptr))
-            {
-                m_index++;
-            }
-
-            if (m_index >= m_tableSize)
-            {
-                m_node = nullptr;
-                return;
-            }
-            else
-            {
-                m_node = m_table[m_index];
-            }
-            assert(m_node != nullptr);
-        }
-
-        // Return `true` if the specified iterator has the same position as this iterator
-        bool Equal(const KeyIterator& i) const
+        bool operator==(const iterator& i) const
         {
             return i.m_node == m_node;
         }
 
-        // Advance the iterator to the next node
-        void operator++()
+        bool operator!=(const iterator& i) const
         {
-            Next();
+            return i.m_node != m_node;
         }
 
-        // Advance the iterator to the next node
-        void operator++(int)
+        void operator++()
         {
-            Next();
+            m_node = m_node->m_next;
+
+            if (m_node == nullptr)
+            {
+                FindNextBucket();
+            }
+        }
+
+        Pair& operator*()
+        {
+            return m_node->m_value;
+        }
+
+        // [[deprecated]]
+        const Key& Get() const
+        {
+            return m_node->m_value.key;
+        }
+
+        const Key& GetKey() const
+        {
+            return m_node->m_value.key;
+        }
+
+        Value& GetValue() const
+        {
+            return m_node->m_value.value;
+        }
+
+        void SetValue(const Value& value) const
+        {
+            m_node->m_value.value = value;
+        }
+
+        // [[deprecated]]
+        bool Equal(const iterator& i) const
+        {
+            return i.m_node == m_node;
         }
     };
+
+    using KeyIterator = iterator;
 
     //------------------------------------------------------------------------
     // operator[]: Get a reference to the value associated with the specified key.
@@ -737,13 +683,11 @@ private:
     // The node type.
     struct Node
     {
-        Node* m_next; // Assume that the alignment requirement of Key and Value are no greater than Node*,
-                      // so put m_next first to avoid unnecessary padding.
-        Key   m_key;
-        Value m_val;
+        Node* m_next;
+        Pair  m_value;
 
         template <class... Args>
-        Node(Node* next, Key k, Args&&... args) : m_next(next), m_key(k), m_val(std::forward<Args>(args)...)
+        Node(Node* next, Key k, Args&&... args) : m_next(next), m_value{k, Value(std::forward<Args>(args)...)}
         {
         }
 
@@ -906,22 +850,18 @@ public:
     {
         friend class JitHashSet;
 
-        Node*    m_node;
-        Node**   m_buckets;
-        unsigned m_bucketCount;
-        unsigned m_bucketIndex;
+        Node*  m_node;
+        Node** m_buckets;
+        Node** m_bucketsEnd;
 
         iterator() : m_node(nullptr)
         {
         }
 
         iterator(const JitHashSet* hash)
-            : m_node(nullptr)
-            , m_buckets(hash->m_buckets)
-            , m_bucketCount(hash->GetBucketCount())
-            , m_bucketIndex(UINT32_MAX) // FindNextBucket starts by incrementing the index
+            : m_node(nullptr), m_buckets(hash->m_buckets), m_bucketsEnd(hash->m_buckets + hash->GetBucketCount())
         {
-            if (hash->m_count != 0)
+            if (hash->m_count > 0)
             {
                 FindNextBucket();
             }
@@ -929,16 +869,8 @@ public:
 
         void FindNextBucket()
         {
-            assert(m_node == nullptr);
-
-            while (++m_bucketIndex < m_bucketCount)
+            while ((m_buckets < m_bucketsEnd) && ((m_node = *m_buckets++) == nullptr))
             {
-                m_node = m_buckets[m_bucketIndex];
-
-                if (m_node != nullptr)
-                {
-                    break;
-                }
             }
         }
 

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -480,8 +480,7 @@ void Compiler::lvaInitThisPtr(InitVarDscInfo* varDscInfo)
             lvaSetClass(varDscInfo->varNum, info.compClassHnd);
         }
 
-        varDsc->lvIsThisPtr = true;
-        varDsc->lvIsRegArg  = true;
+        varDsc->lvIsRegArg = true;
         noway_assert(varDscInfo->intRegArgNum == 0);
 
         varDsc->SetArgReg(genMapRegArgNumToRegNum(varDscInfo->allocRegArg(TYP_INT), varDsc->TypeGet()));
@@ -6178,10 +6177,6 @@ void Compiler::lvaDumpEntry(unsigned lclNum, FrameLayoutState curState, size_t r
     if (varDsc->lvHasLdAddrOp)
     {
         printf(" ld-addr-op");
-    }
-    if (varDsc->lvIsThisPtr)
-    {
-        printf(" this");
     }
     if (varDsc->lvPinned)
     {

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -8459,7 +8459,7 @@ void Compiler::optRemoveRedundantZeroInits()
         {
             LclVarRefCounts::KeyIterator iter(defsInBlock.Begin());
             LclVarRefCounts::KeyIterator end(defsInBlock.End());
-            for (; !iter.Equal(end); iter++)
+            for (; !iter.Equal(end); ++iter)
             {
                 unsigned int lclNum = iter.Get();
                 if (defsInBlock[lclNum] == 0)

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1297,10 +1297,8 @@ Range RangeCheck::GetRange(BasicBlock* block, GenTree* expr, bool monIncreasing 
 // Entry point to range check optimizations.
 void RangeCheck::OptimizeRangeChecks()
 {
-    if (m_pCompiler->fgSsaPassesCompleted == 0)
-    {
-        return;
-    }
+    assert(m_pCompiler->ssaForm && (m_pCompiler->vnStore != nullptr));
+
 #ifdef DEBUG
     if (m_pCompiler->verbose)
     {

--- a/src/coreclr/jit/rationalize.cpp
+++ b/src/coreclr/jit/rationalize.cpp
@@ -113,8 +113,8 @@ void Rationalizer::RewriteLocalAssignment(GenTreeOp* assignment, GenTreeLclVarCo
     store->gtFlags |= GTF_VAR_DEF;
     store->gtFlags &= ~GTF_EXCEPT;
 
-    DISPNODE(store);
-    JITDUMP("\n");
+    // We don't use SSA in LIR but being able to still display SSA use/defs might be useful.
+    INDEBUG(comp->MoveSsaDefNum(location, store));
 }
 
 void Rationalizer::RewriteAssignment(LIR::Use& use)

--- a/src/coreclr/jit/ssabuilder.cpp
+++ b/src/coreclr/jit/ssabuilder.cpp
@@ -1212,22 +1212,14 @@ void SsaBuilder::RenameVariables()
     // virtual definition before entry -- they start out at SSA name 1.
     for (unsigned lclNum = 0; lclNum < m_pCompiler->lvaCount; lclNum++)
     {
-        if (!m_pCompiler->lvaInSsa(lclNum))
+        LclVarDsc* lcl = m_pCompiler->lvaGetDesc(lclNum);
+
+        if (lcl->IsInSsa() &&
+            VarSetOps::IsMember(m_pCompiler, m_pCompiler->fgFirstBB->bbLiveIn, lcl->GetLivenessBitIndex()))
         {
-            continue;
-        }
-
-        LclVarDsc* varDsc = &m_pCompiler->lvaTable[lclNum];
-        assert(varDsc->lvTracked);
-
-        if (varDsc->lvIsParam || m_pCompiler->info.compInitMem || varDsc->lvMustInit ||
-            VarSetOps::IsMember(m_pCompiler, m_pCompiler->fgFirstBB->bbLiveIn, varDsc->lvVarIndex))
-        {
-            unsigned ssaNum = varDsc->lvPerSsaData.AllocSsaNum(m_allocator);
-
-            // In ValueNum we'd assume un-inited variables get FIRST_SSA_NUM.
+            unsigned ssaNum = lcl->lvPerSsaData.AllocSsaNum(m_allocator);
+            // HasImplicitSsaDef assumes that this is always the first SSA def.
             assert(ssaNum == SsaConfig::FIRST_SSA_NUM);
-
             m_renameStack.Push(m_pCompiler->fgFirstBB, lclNum, ssaNum);
         }
     }

--- a/src/coreclr/jit/ssabuilder.cpp
+++ b/src/coreclr/jit/ssabuilder.cpp
@@ -729,11 +729,8 @@ void SsaBuilder::RenameDef(GenTreeOp* asgNode, BasicBlock* block)
             {
                 assert((lclNode->gtFlags & GTF_VAR_USEASG) != 0);
 
-                // This is a partial definition of a variable. The node records only the SSA number
-                // of the use that is implied by this partial definition. The SSA number of the new
-                // definition will be recorded in the m_opAsgnVarDefSsaNums map.
                 lclNode->SetSsaNum(m_renameStack.Top(lclNum));
-                m_pCompiler->GetOpAsgnVarDefSsaNums()->Set(lclNode, ssaNum);
+                m_pCompiler->SetPartialSsaDefNum(lclNode->AsLclFld(), ssaNum);
             }
             else
             {

--- a/src/coreclr/jit/ssabuilder.cpp
+++ b/src/coreclr/jit/ssabuilder.cpp
@@ -55,15 +55,11 @@ static inline BasicBlock* IntersectDom(BasicBlock* finger1, BasicBlock* finger2)
 
 void Compiler::fgSsaBuild()
 {
-    // If this is not the first invocation, reset data structures for SSA.
-    if (fgSsaPassesCompleted > 0)
-    {
-        fgResetForSsa();
-    }
+    assert(!ssaForm);
 
     SsaBuilder builder(this);
     builder.Build();
-    fgSsaPassesCompleted++;
+    ssaForm = true;
 
 #ifdef DEBUG
     if (verbose)
@@ -80,6 +76,7 @@ void Compiler::fgResetForSsa()
     {
         lvaTable[i].lvPerSsaData.Reset();
     }
+
     lvMemoryPerSsaData.Reset();
     m_memorySsaMap = nullptr;
 

--- a/src/coreclr/jit/ssarenamestate.h
+++ b/src/coreclr/jit/ssarenamestate.h
@@ -5,6 +5,7 @@
 
 class SsaRenameState
 {
+public:
     struct StackNode;
 
     class Stack
@@ -16,7 +17,7 @@ class SsaRenameState
         {
         }
 
-        StackNode* Top()
+        StackNode* Top() const
         {
             return m_top;
         }
@@ -52,6 +53,7 @@ class SsaRenameState
         }
     };
 
+private:
     // Memory allocator
     CompAllocator m_alloc;
     // Number of local variables to allocate stacks for

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -7445,12 +7445,10 @@ void Compiler::fgValueNumber()
     {
         LclVarDsc* varDsc = lvaGetDesc(lclNum);
 
-        if (!varDsc->IsInSsa())
+        if (!varDsc->HasImplicitSsaDef())
         {
             continue;
         }
-
-        assert(varDsc->HasLiveness());
 
         if (varDsc->IsParam())
         {
@@ -7464,8 +7462,7 @@ void Compiler::fgValueNumber()
             ssaDef->SetBlock(fgFirstBB);
             INDEBUG(vnTraceLocal(lclNum, ssaDef->GetVNP()));
         }
-        else if (info.compInitMem || varDsc->lvMustInit ||
-                 VarSetOps::IsMember(this, fgFirstBB->bbLiveIn, varDsc->lvVarIndex))
+        else
         {
             // The last clause covers the use-before-def variables (the ones that are live-in to the the first block),
             // these are variables that are read before being initialized (at least on some control flow paths)

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -4763,7 +4763,13 @@ void Compiler::vnLocalLoad(GenTreeLclVar* load)
         return;
     }
 
-    ValueNumPair vnp = lcl->GetPerSsaData(load->GetSsaNum())->m_vnPair;
+    load->SetVNP(vnLocalLoad(load, lcl, load->GetSsaNum()));
+    ;
+}
+
+ValueNumPair Compiler::vnLocalLoad(GenTreeLclVar* load, LclVarDsc* lcl, unsigned ssaNum)
+{
+    ValueNumPair vnp = lcl->GetPerSsaData(ssaNum)->GetVNP();
 
     assert(vnp.GetLiberal() != ValueNumStore::NoVN);
 
@@ -4779,6 +4785,7 @@ void Compiler::vnLocalLoad(GenTreeLclVar* load)
         }
         else
         {
+            printf("bad type %s %s\n", varTypeName(load->GetType()), varTypeName(lcl->GetType()));
             vnp.SetBoth(vnStore->VNForExpr(compCurBB, load->GetType()));
         }
     }
@@ -4790,7 +4797,7 @@ void Compiler::vnLocalLoad(GenTreeLclVar* load)
         {
             ValueNum extendVN = vnStore->ExtendPtrVN(vnp.GetLiberal(), fieldSeq, 0);
 
-            if (extendVN != ValueNumStore::NoVN)
+            if (extendVN != NoVN)
             {
                 // TODO-MIKE-Fix: This doesn't make a lot of sense. We only look at the liberal VN,
                 // the conservative VN might be different (e.g. the value stored in the local could
@@ -4800,7 +4807,7 @@ void Compiler::vnLocalLoad(GenTreeLclVar* load)
         }
     }
 
-    load->SetVNP(vnp);
+    return vnp;
 }
 
 void Compiler::vnLocalFieldStore(GenTreeLclFld* store, GenTreeOp* asg, GenTree* value)

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -4877,7 +4877,7 @@ void Compiler::vnLocalFieldStore(GenTreeLclFld* store, GenTreeOp* asg, GenTree* 
         }
     }
 
-    lcl->GetPerSsaData(GetSsaNumForLocalVarDef(store))->SetVNP(valueVNP);
+    lcl->GetPerSsaData(GetSsaDefNum(store))->SetVNP(valueVNP);
     store->SetVNP(valueVNP);
 
     INDEBUG(vnTraceLocal(store->GetLclNum(), valueVNP));


### PR DESCRIPTION
win-x64 pmi diff:
```
Total bytes of base: 60554909
Total bytes of diff: 60523896
Total bytes of delta: -31013 (-0.05 % of base)
Total relative delta: -64.87
    diff is an improvement.
    relative diff is an improvement.

Top file regressions (bytes):
          29 : System.Text.Encoding.CodePages.dasm (0.04% of base)
          24 : System.Data.Common.dasm (0.00% of base)
          19 : System.Private.Xml.Linq.dasm (0.01% of base)
          13 : System.Memory.Data.dasm (0.10% of base)
          12 : System.Reflection.MetadataLoadContext.dasm (0.01% of base)
           3 : System.Net.Http.WinHttpHandler.dasm (0.00% of base)
           3 : System.Resources.Extensions.dasm (0.01% of base)
           2 : System.IO.Packaging.dasm (0.00% of base)

Top file improvements (bytes):
       -6459 : System.Collections.Immutable.dasm (-0.40% of base)
       -4634 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.12% of base)
       -2954 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.04% of base)
       -2089 : System.Private.CoreLib.dasm (-0.04% of base)
       -2084 : FSharp.Core.dasm (-0.06% of base)
       -1557 : Microsoft.CodeAnalysis.CSharp.dasm (-0.03% of base)
       -1351 : System.Threading.Tasks.Dataflow.dasm (-0.12% of base)
       -1270 : CommandLine.dasm (-0.25% of base)
       -1110 : Microsoft.CodeAnalysis.dasm (-0.06% of base)
        -794 : System.Private.Xml.dasm (-0.02% of base)
        -469 : System.Linq.Expressions.dasm (-0.06% of base)
        -313 : System.Security.Cryptography.Algorithms.dasm (-0.08% of base)
        -309 : System.Text.RegularExpressions.dasm (-0.11% of base)
        -293 : System.Linq.Parallel.dasm (-0.01% of base)
        -253 : System.Net.Http.dasm (-0.03% of base)
        -249 : System.Collections.Concurrent.dasm (-0.06% of base)
        -238 : System.Security.Cryptography.Pkcs.dasm (-0.06% of base)
        -205 : Microsoft.VisualBasic.Core.dasm (-0.04% of base)
        -192 : System.Composition.TypedParts.dasm (-0.41% of base)
        -183 : System.Text.Json.dasm (-0.02% of base)

130 total files with Code Size differences (122 improved, 8 regressed), 141 unchanged.

Top method regressions (bytes):
         627 ( 1.09% of base) : System.Data.Common.dasm - RBTree`1:RBInsert(int,int,int,int,bool):int:this (8 methods)
         106 ( 1.94% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AsyncMethodToClassRewriter:GenerateMoveNext(BoundStatement,MethodSymbol):this
          82 ( 4.77% of base) : FSharp.Core.dasm - List:filter(FSharpFunc`2,FSharpList`1):FSharpList`1 (8 methods)
          78 ( 2.99% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AsyncMethodToClassRewriter:VisitBinaryOperator(BoundBinaryOperator):BoundNode:this
          64 ( 0.75% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AsyncMethodToClassRewriter:GenerateAwaitForIncompleteTask(LocalSymbol):BoundBlock:this
          57 ( 1.05% of base) : System.Memory.dasm - ReadOnlySequence`1:Slice(long,SequencePosition):ReadOnlySequence`1:this (8 methods)
          50 ( 0.62% of base) : Microsoft.CSharp.dasm - ExpressionBinder:bindUserDefinedConversion(Expr,CType,CType,bool,byref,bool):bool:this
          48 ( 1.24% of base) : System.Collections.Immutable.dasm - Enumerator:PushNext(Node):this (16 methods)
          48 ( 1.47% of base) : Microsoft.Diagnostics.FastSerialization.dasm - SegmentedList`1:AddRoomForElement(int):this (8 methods)
          44 ( 2.08% of base) : FSharp.Core.dasm - FSharpList`1:CompareTo(Object,IComparer):int:this (8 methods)
          42 ( 2.46% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AsyncMethodToClassRewriter:VisitReturnStatement(BoundReturnStatement):BoundNode:this
          42 ( 2.88% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceNamedTypeSymbol:AddDeclaredNonTypeMembers(MembersAndInitializersBuilder,DiagnosticBag):this
          41 ( 0.50% of base) : FSharp.Core.dasm - OperatorIntrinsics:GetArraySlice4D(ref,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1):ref (8 methods)
          36 ( 2.34% of base) : System.Text.Encoding.CodePages.dasm - ISO2022Encoding:GetCharsCP5022xJP(long,int,long,int,ISO2022Decoder):int:this
          36 ( 0.41% of base) : System.Collections.Immutable.dasm - Node:RemoveAll(Predicate`1):Node:this (8 methods)
          35 ( 1.69% of base) : System.Private.Xml.dasm - XsltLoader:LoadDecimalFormat(NsDecl):this
          34 (17.00% of base) : System.IO.Compression.Brotli.dasm - BrotliStream:Read(Span`1):int:this
          33 ( 1.94% of base) : FSharp.Core.dasm - Filter:filterViaMask(ref,int,int,ref):ref (8 methods)
          32 ( 2.69% of base) : System.Private.CoreLib.dasm - EventProvider:EtwEnableCallBack(byref,int,ubyte,long,long,long,long):this
          32 ( 1.96% of base) : System.Text.Json.dasm - Utf8JsonReader:ConsumeNextTokenUntilAfterAllCommentsAreSkippedMultiSegment(ubyte):ubyte:this

Top method improvements (bytes):
       -1485 (-3.22% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - StateMachineMethodToClassRewriter:VisitTryStatement(BoundTryStatement):BoundNode:this (8 methods)
        -708 (-6.33% of base) : System.Collections.Immutable.dasm - Builder:System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(ref,int):this (16 methods)
        -668 (-4.97% of base) : System.Collections.Immutable.dasm - Builder:System.Collections.ICollection.CopyTo(Array,int):this (32 methods)
        -668 (-5.08% of base) : System.Collections.Immutable.dasm - ImmutableDictionary`2:System.Collections.ICollection.CopyTo(Array,int):this (8 methods)
        -514 (-4.70% of base) : System.Collections.Immutable.dasm - Builder:ContainsValue(Nullable`1):bool:this (16 methods)
        -514 (-4.86% of base) : System.Collections.Immutable.dasm - ImmutableDictionary`2:ContainsValue(Nullable`1):bool:this (8 methods)
        -514 (-4.45% of base) : System.Collections.Immutable.dasm - ImmutableDictionary`2:System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(ref,int):this (8 methods)
        -497 (-7.65% of base) : System.Collections.Immutable.dasm - <get_Keys>d__25:MoveNext():bool:this (8 methods)
        -497 (-7.67% of base) : System.Collections.Immutable.dasm - <get_Values>d__27:MoveNext():bool:this (8 methods)
        -476 (-11.83% of base) : FSharp.Core.dasm - Array:splitInto$cont@1174(int,ref,int,Unit):ref (8 methods)
        -403 (-3.87% of base) : System.Threading.Tasks.Dataflow.dasm - BatchBlockTargetCore:RetrievePostponedItemsGreedyBounded(bool):this (8 methods)
        -378 (-3.28% of base) : System.Threading.Tasks.Dataflow.dasm - BatchBlockTargetCore:RetrievePostponedItemsNonGreedy(bool):this (8 methods)
        -252 (-1.10% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:SymmetricExcept(IEnumerable`1,MutationInput):MutationResult (8 methods)
        -201 (-1.86% of base) : System.Collections.Immutable.dasm - Builder:System.Collections.Generic.ICollection<T>.CopyTo(ref,int):this (16 methods)
        -201 (-1.72% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:IsProperSupersetOf(IEnumerable`1,MutationInput):bool (8 methods)
        -201 (-1.87% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:System.Collections.Generic.ICollection<T>.CopyTo(ref,int):this (8 methods)
        -201 (-1.72% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:System.Collections.ICollection.CopyTo(Array,int):this (8 methods)
        -190 (-1.34% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:Intersect(IEnumerable`1,MutationInput):MutationResult (8 methods)
        -183 (-1.66% of base) : System.Private.CoreLib.dasm - DefaultBinder:BindToMethod(int,ref,byref,ref,CultureInfo,ref,byref):MethodBase:this
        -176 (-1.25% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:Except(IEnumerable`1,IEqualityComparer`1,IEqualityComparer`1,SortedInt32KeyNode`1):MutationResult (8 methods)

Top method regressions (percentages):
          34 (17.00% of base) : System.IO.Compression.Brotli.dasm - BrotliStream:Read(Span`1):int:this
           3 ( 9.38% of base) : System.Private.CoreLib.dasm - Type:IsRuntimeImplemented():bool:this
           3 ( 9.38% of base) : ILCompiler.TypeSystem.ReadyToRun.dasm - TypeDesc:get_IsArray():bool:this
           3 ( 9.38% of base) : ILCompiler.TypeSystem.ReadyToRun.dasm - TypeDesc:get_IsByRef():bool:this
           3 ( 9.38% of base) : ILCompiler.TypeSystem.ReadyToRun.dasm - TypeDesc:get_IsFunctionPointer():bool:this
           3 ( 9.38% of base) : ILCompiler.TypeSystem.ReadyToRun.dasm - TypeDesc:get_IsPointer():bool:this
          17 ( 6.61% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:IndexOf(ref,Vector`1,int,int):int:this
           6 ( 6.19% of base) : Microsoft.CodeAnalysis.CSharp.dasm - PropertySymbol:GetSynthesizedSealedAccessor(int):IMethodReference:this
          20 ( 4.98% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourcePropertySymbol:CloneParametersForAccessor(MethodSymbol,ArrayBuilder`1):this
          82 ( 4.77% of base) : FSharp.Core.dasm - List:filter(FSharpFunc`2,FSharpList`1):FSharpList`1 (8 methods)
          14 ( 4.64% of base) : System.Text.Json.dasm - Utf8JsonReader:SkipMultiLineComment(ReadOnlySpan`1,byref):bool:this
          16 ( 4.38% of base) : System.Formats.Asn1.dasm - AsnWriter:WriteNamedBitList(Nullable`1,long):this
           7 ( 4.24% of base) : System.Drawing.Common.dasm - Pen:InternalSetColor(Color):this
           3 ( 4.11% of base) : System.Data.OleDb.dasm - ColumnBinding:Value_HCHAPTER():OleDbDataReader:this
           3 ( 3.95% of base) : System.Numerics.Tensors.dasm - Tensor`1:Fill(Vector`1):this
          13 ( 3.88% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BinderFactoryVisitor:DefaultVisit(SyntaxNode):Binder:this
          17 ( 3.81% of base) : System.Text.Encodings.Web.dasm - TextEncoder:EncodeUtf8Core(ReadOnlySpan`1,Span`1,byref,byref,bool):int:this
           8 ( 3.79% of base) : System.Private.Xml.Linq.dasm - XHashtable`1:Add(double):double:this
          15 ( 3.72% of base) : Microsoft.CodeAnalysis.CSharp.dasm - DocumentationCommentCompiler:WriteFormattedSingleLineComment(String):this
          13 ( 3.68% of base) : System.Text.Json.dasm - Utf8JsonReader:ConsumePropertyName():bool:this

Top method improvements (percentages):
         -11 (-35.48% of base) : System.ComponentModel.TypeConverter.dasm - InterlockedBitVector32:DangerousSet(int,bool):this
          -8 (-25.81% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Flags:set_ReturnsVoid(bool):this
          -6 (-24.00% of base) : Microsoft.CodeAnalysis.CSharp.dasm - InterpolatedStringScanner:IsAtEnd():bool:this
          -8 (-23.53% of base) : System.Management.dasm - EnumerationOptions:set_DirectRead(bool):this
          -8 (-23.53% of base) : System.Management.dasm - EnumerationOptions:set_EnsureLocatable(bool):this
          -8 (-23.53% of base) : System.Management.dasm - EnumerationOptions:set_UseAmendedQualifiers(bool):this
          -8 (-23.53% of base) : System.Management.dasm - ManagementOptions:set_SendStatus(bool):this
          -8 (-23.53% of base) : System.Management.dasm - PutOptions:set_UseAmendedQualifiers(bool):this
          -7 (-23.33% of base) : System.Data.Common.dasm - SqlDecimal:SetSignBit(bool):this
          -6 (-22.22% of base) : Microsoft.Extensions.Caching.Memory.dasm - CacheEntryState:set_IsDisposed(bool):this
          -6 (-22.22% of base) : Microsoft.Extensions.Caching.Memory.dasm - CacheEntryState:set_IsExpired(bool):this
          -6 (-22.22% of base) : Microsoft.Extensions.Caching.Memory.dasm - CacheEntryState:set_IsValueSet(bool):this
          -6 (-21.43% of base) : System.Management.dasm - EnumerationOptions:set_EnumerateDeep(bool):this
          -6 (-21.43% of base) : System.Management.dasm - EnumerationOptions:set_PrototypeOnly(bool):this
          -6 (-21.43% of base) : System.Management.dasm - EnumerationOptions:set_ReturnImmediately(bool):this
          -6 (-21.43% of base) : System.Management.dasm - EnumerationOptions:set_Rewindable(bool):this
         -51 (-18.41% of base) : System.Linq.Expressions.dasm - LambdaCompiler:GetParameterTypes(LambdaExpression,Type):ref
         -24 (-18.05% of base) : System.Private.CoreLib.dasm - Random:ThrowMaxValueMustBeNonNegative()
          -6 (-16.67% of base) : Microsoft.Extensions.Caching.Memory.dasm - CacheEntryState:SetFlag(ubyte,bool):this
         -48 (-15.58% of base) : System.Management.dasm - EnumerationOptions:.ctor(ManagementNamedValueCollection,TimeSpan,int,bool,bool,bool,bool,bool,bool,bool):this

3630 total methods with Code Size differences (2939 improved, 691 regressed), 272493 unchanged.
```
Regressions usually caused by changes in register allocation - different register selection (`RBTree1:RBInsert` uses `r8d` instead of `rdx` in many places), difference in spilling and extra reg-reg moves.

alt-arm64 pmi diff:
```
Total bytes of base: 68070260
Total bytes of diff: 68047688
Total bytes of delta: -22572 (-0.03 % of base)
Total relative delta: -33.43
    diff is an improvement.
    relative diff is an improvement.

Top file regressions (bytes):
          12 : System.Net.Http.WinHttpHandler.dasm (0.01% of base)
           4 : System.IO.Packaging.dasm (0.00% of base)

Top file improvements (bytes):
       -4392 : System.Collections.Immutable.dasm (-0.26% of base)
       -2136 : System.Private.CoreLib.dasm (-0.04% of base)
       -1624 : FSharp.Core.dasm (-0.04% of base)
       -1544 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.02% of base)
       -1448 : CommandLine.dasm (-0.25% of base)
       -1408 : Microsoft.CodeAnalysis.CSharp.dasm (-0.02% of base)
       -1040 : Microsoft.CodeAnalysis.dasm (-0.05% of base)
        -888 : System.Private.Xml.dasm (-0.02% of base)
        -872 : System.Threading.Tasks.Dataflow.dasm (-0.07% of base)
        -588 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.01% of base)
        -484 : System.Data.Common.dasm (-0.03% of base)
        -300 : System.Linq.Expressions.dasm (-0.03% of base)
        -240 : System.Composition.TypedParts.dasm (-0.43% of base)
        -232 : System.Text.Json.dasm (-0.02% of base)
        -228 : System.Collections.Concurrent.dasm (-0.05% of base)
        -216 : System.Text.RegularExpressions.dasm (-0.07% of base)
        -188 : System.Linq.Parallel.dasm (-0.01% of base)
        -184 : xunit.execution.dotnet.dasm (-0.06% of base)
        -184 : System.Collections.dasm (-0.03% of base)
        -184 : System.Security.Cryptography.Algorithms.dasm (-0.05% of base)

116 total files with Code Size differences (114 improved, 2 regressed), 155 unchanged.

Top method regressions (bytes):
          92 ( 3.02% of base) : FSharp.Core.dasm - SetTreeModule:intersectionAux(IComparer`1,SetTree`1,SetTree`1,SetTree`1):SetTree`1 (8 methods)
          80 ( 3.80% of base) : FSharp.Core.dasm - List:filter(FSharpFunc`2,FSharpList`1):FSharpList`1 (8 methods)
          64 ( 0.10% of base) : System.Data.Common.dasm - RBTree`1:RBInsert(int,int,int,int,bool):int:this (8 methods)
          52 (26.00% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DirectiveTriviaSyntax:GetNextRelatedDirective():DirectiveTriviaSyntax:this
          52 (26.00% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DirectiveTriviaSyntax:GetPreviousRelatedDirective():DirectiveTriviaSyntax:this
          36 ( 0.54% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AsyncMethodToClassRewriter:GenerateAwaitForIncompleteTask(LocalSymbol):BoundBlock:this
          36 ( 0.72% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AsyncMethodToClassRewriter:GenerateMoveNext(BoundStatement,MethodSymbol):this
          32 ( 5.00% of base) : System.Private.DataContractSerialization.dasm - <>c__41`1:<GetCollectionSetItemDelegate>b__41_6(Object,Object,int):Object:this (8 methods)
          32 ( 1.32% of base) : FSharp.Core.dasm - Filter:filterViaMask(ref,int,int,ref):ref (8 methods)
          32 ( 1.13% of base) : FSharp.Core.dasm - FSharpList`1:CompareTo(Object,IComparer):int:this (8 methods)
          32 ( 0.81% of base) : System.Linq.dasm - LargeArrayBuilder`1:CopyTo(CopyPosition,ref,int,int):CopyPosition:this (8 methods)
          32 ( 3.03% of base) : FSharp.Core.dasm - MapIndexed@1327-2:Invoke(int):this (8 methods)
          32 ( 0.63% of base) : System.Linq.Parallel.dasm - OrderedPipeliningMergeEnumerator:TryWaitForElement(int,byref):bool:this (8 methods)
          32 ( 2.35% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceNamedTypeSymbol:AddDeclaredNonTypeMembers(MembersAndInitializersBuilder,DiagnosticBag):this
          32 ( 0.41% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SynthesizedWrapperMethod:.ctor(InstanceTypeSymbol,MethodSymbol,String,VisualBasicSyntaxNode):this (8 methods)
          28 ( 1.26% of base) : System.Memory.dasm - BuffersExtensions:WriteMultiSegment(IBufferWriter`1,byref,Span`1) (8 methods)
          28 ( 0.12% of base) : System.Linq.Parallel.dasm - FirstQueryOperator`1:WrapPartitionedStream(PartitionedStream`2,IPartitionedStreamRecipient`1,bool,QuerySettings):this (64 methods)
          28 ( 0.12% of base) : System.Linq.Parallel.dasm - LastQueryOperator`1:WrapPartitionedStream(PartitionedStream`2,IPartitionedStreamRecipient`1,bool,QuerySettings):this (64 methods)
          28 ( 0.35% of base) : System.Collections.Immutable.dasm - Node:RemoveAll(Predicate`1):Node:this (8 methods)
          28 ( 0.12% of base) : System.Linq.Parallel.dasm - TakeOrSkipQueryOperator`1:WrapPartitionedStream(PartitionedStream`2,IPartitionedStreamRecipient`1,bool,QuerySettings):this (64 methods)

Top method improvements (bytes):
        -396 (-3.38% of base) : System.Collections.Immutable.dasm - Builder:System.Collections.ICollection.CopyTo(Array,int):this (32 methods)
        -396 (-3.57% of base) : System.Collections.Immutable.dasm - ImmutableDictionary`2:System.Collections.ICollection.CopyTo(Array,int):this (8 methods)
        -392 (-4.15% of base) : System.Collections.Immutable.dasm - Builder:ContainsValue(Nullable`1):bool:this (16 methods)
        -392 (-4.32% of base) : System.Collections.Immutable.dasm - ImmutableDictionary`2:ContainsValue(Nullable`1):bool:this (8 methods)
        -388 (-4.11% of base) : System.Collections.Immutable.dasm - Builder:System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(ref,int):this (16 methods)
        -388 (-4.05% of base) : System.Collections.Immutable.dasm - ImmutableDictionary`2:System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(ref,int):this (8 methods)
        -364 (-6.37% of base) : System.Collections.Immutable.dasm - <get_Keys>d__25:MoveNext():bool:this (8 methods)
        -364 (-6.38% of base) : System.Collections.Immutable.dasm - <get_Values>d__27:MoveNext():bool:this (8 methods)
        -300 (-6.32% of base) : FSharp.Core.dasm - Array:splitInto$cont@1174(int,ref,int,Unit):ref (8 methods)
        -236 (-0.67% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - StateMachineMethodToClassRewriter:VisitTryStatement(BoundTryStatement):BoundNode:this (8 methods)
        -216 (-2.14% of base) : System.Threading.Tasks.Dataflow.dasm - BatchBlockTargetCore:RetrievePostponedItemsGreedyBounded(bool):this (8 methods)
        -216 (-1.87% of base) : System.Threading.Tasks.Dataflow.dasm - BatchBlockTargetCore:RetrievePostponedItemsNonGreedy(bool):this (8 methods)
        -160 (-1.24% of base) : System.Collections.Immutable.dasm - Enumerator:Reset():this (64 methods)
        -156 (-0.80% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:SymmetricExcept(IEnumerable`1,MutationInput):MutationResult (8 methods)
        -140 (-1.21% of base) : System.Private.CoreLib.dasm - DefaultBinder:BindToMethod(int,ref,byref,ref,CultureInfo,ref,byref):MethodBase:this
        -128 (-2.03% of base) : System.Private.CoreLib.dasm - CancellationPromise`1:.ctor(Task,int,CancellationToken):this (8 methods)
        -128 (-1.24% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:IsSupersetOf(IEnumerable`1,MutationInput):bool (8 methods)
        -128 (-1.20% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:Overlaps(IEnumerable`1,MutationInput):bool (8 methods)
        -112 (-13.02% of base) : System.Linq.Expressions.dasm - Expression:ValidateSpan(int,int,int,int)
        -112 (-7.93% of base) : FSharp.Core.dasm - SetTreeModule:countAux(SetTree`1,int):int (8 methods)

Top method regressions (percentages):
          52 (26.00% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DirectiveTriviaSyntax:GetNextRelatedDirective():DirectiveTriviaSyntax:this
          52 (26.00% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DirectiveTriviaSyntax:GetPreviousRelatedDirective():DirectiveTriviaSyntax:this
           4 ( 7.14% of base) : System.Private.CoreLib.dasm - Type:IsRuntimeImplemented():bool:this
           4 ( 7.14% of base) : ILCompiler.TypeSystem.ReadyToRun.dasm - TypeDesc:get_IsArray():bool:this
           4 ( 7.14% of base) : ILCompiler.TypeSystem.ReadyToRun.dasm - TypeDesc:get_IsByRef():bool:this
           4 ( 7.14% of base) : ILCompiler.TypeSystem.ReadyToRun.dasm - TypeDesc:get_IsFunctionPointer():bool:this
           4 ( 7.14% of base) : ILCompiler.TypeSystem.ReadyToRun.dasm - TypeDesc:get_IsPointer():bool:this
           8 ( 5.71% of base) : Microsoft.CodeAnalysis.CSharp.dasm - PropertySymbol:GetSynthesizedSealedAccessor(int):IMethodReference:this
          32 ( 5.00% of base) : System.Private.DataContractSerialization.dasm - <>c__41`1:<GetCollectionSetItemDelegate>b__41_6(Object,Object,int):Object:this (8 methods)
           8 ( 4.88% of base) : System.Text.Json.dasm - JsonNode:AsArray():JsonArray:this
           8 ( 4.88% of base) : System.Text.Json.dasm - JsonNode:AsObject():JsonObject:this
           4 ( 4.35% of base) : System.Data.OleDb.dasm - ColumnBinding:Value_HCHAPTER():OleDbDataReader:this
           4 ( 4.17% of base) : System.Linq.Expressions.dasm - InterpretedFrame:Dup():this
           4 ( 4.00% of base) : System.Linq.Expressions.dasm - DupInstruction:Run(InterpretedFrame):int:this
          80 ( 3.80% of base) : FSharp.Core.dasm - List:filter(FSharpFunc`2,FSharpList`1):FSharpList`1 (8 methods)
           4 ( 3.57% of base) : System.Private.CoreLib.dasm - Marshal:StringToBSTR(String):long
           4 ( 3.57% of base) : System.Data.Common.dasm - SchemaMapping:MappedValues():this
          12 ( 3.49% of base) : Microsoft.CodeAnalysis.CSharp.dasm - EventDeclarationSyntax:AddAccessorListAccessors(ref):EventDeclarationSyntax:this
           4 ( 3.45% of base) : Microsoft.CSharp.dasm - Symbol:isUserCallable():bool:this
          16 ( 3.36% of base) : Microsoft.CodeAnalysis.CSharp.dasm - DocumentationCommentCompiler:WriteFormattedSingleLineComment(String):this

Top method improvements (percentages):
         -32 (-21.62% of base) : System.Private.CoreLib.dasm - Random:ThrowMaxValueMustBeNonNegative()
          -8 (-18.18% of base) : Microsoft.CodeAnalysis.CSharp.dasm - InterpolatedStringScanner:IsAtEnd():bool:this
         -20 (-16.13% of base) : System.Net.Requests.dasm - <>c:<GetRequestStreamAsync>b__67_1(AsyncCallback,Object):IAsyncResult:this
         -20 (-16.13% of base) : System.Net.Requests.dasm - <>c:<GetResponseAsync>b__68_1(AsyncCallback,Object):IAsyncResult:this
         -44 (-15.94% of base) : System.Private.CoreLib.dasm - ArrayList:.ctor(int):this
         -40 (-14.71% of base) : System.Private.CoreLib.dasm - BufferedStream:.ctor(Stream,int):this
          -8 (-14.29% of base) : Microsoft.Extensions.Caching.Memory.dasm - CacheEntryState:set_IsDisposed(bool):this
          -8 (-14.29% of base) : Microsoft.Extensions.Caching.Memory.dasm - CacheEntryState:set_IsExpired(bool):this
          -8 (-14.29% of base) : Microsoft.Extensions.Caching.Memory.dasm - CacheEntryState:set_IsValueSet(bool):this
          -8 (-14.29% of base) : System.Management.dasm - EnumerationOptions:set_DirectRead(bool):this
          -8 (-14.29% of base) : System.Management.dasm - EnumerationOptions:set_EnsureLocatable(bool):this
          -8 (-14.29% of base) : System.Management.dasm - EnumerationOptions:set_EnumerateDeep(bool):this
          -8 (-14.29% of base) : System.Management.dasm - EnumerationOptions:set_PrototypeOnly(bool):this
          -8 (-14.29% of base) : System.Management.dasm - EnumerationOptions:set_ReturnImmediately(bool):this
          -8 (-14.29% of base) : System.Management.dasm - EnumerationOptions:set_Rewindable(bool):this
          -8 (-14.29% of base) : System.Management.dasm - EnumerationOptions:set_UseAmendedQualifiers(bool):this
          -8 (-14.29% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Flags:set_ReturnsVoid(bool):this
          -8 (-14.29% of base) : System.Management.dasm - ManagementOptions:set_SendStatus(bool):this
          -8 (-14.29% of base) : System.Management.dasm - PutOptions:set_UseAmendedQualifiers(bool):this
          -8 (-14.29% of base) : System.Private.Xml.dasm - XmlSerializer:Deserialize(XmlReader,String):Object:this

1801 total methods with Code Size differences (1541 improved, 260 regressed), 274322 unchanged.
```
crossjit pin: 11,931,292,014 11,858,718,025 -0.6%
nraUsed: 1,768,341,680 1,755,873,984  -0.7%