### PR TITLE
AssertionProp type improvements

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1044,14 +1044,11 @@ private:
         return AddEqualityAssertions(assertion);
     }
 
-    AssertionIndex CreateExactTypeAssertion(GenTreeIndir* op1, GenTree* op2, ApKind kind)
+    AssertionIndex CreateExactTypeAssertion(GenTreeLclVar* addr, GenTree* op2, ApKind kind)
     {
-        assert((op1 != nullptr) && (op2 != nullptr));
-        assert(op1->OperIs(GT_IND));
-        assert((kind == OAK_EQUAL) || (kind == OAK_NOT_EQUAL));
-
-        GenTreeLclVar* addr = op1->GetAddr()->AsLclVar();
         assert(addr->OperIs(GT_LCL_VAR) && addr->TypeIs(TYP_REF));
+        assert(op2 != nullptr);
+        assert((kind == OAK_EQUAL) || (kind == OAK_NOT_EQUAL));
 
         // TODO: only copy assertions rely on valid SSA number so we could generate more assertions here
         if (addr->GetSsaNum() == SsaConfig::RESERVED_SSA_NUM)
@@ -1059,10 +1056,7 @@ private:
             return NO_ASSERTION_INDEX;
         }
 
-        unsigned   lclNum = addr->GetLclNum();
-        LclVarDsc* lcl    = compiler->lvaGetDesc(lclNum);
-
-        assert(lcl->IsInSsa());
+        assert(compiler->lvaGetDesc(addr)->IsInSsa());
 
         ValueNum vn1 = addr->GetConservativeVN();
 
@@ -1585,7 +1579,7 @@ private:
                 return NO_ASSERTION_INDEX;
             }
 
-            return CreateExactTypeAssertion(op1->AsIndir(), op2, assertionKind);
+            return CreateExactTypeAssertion(addr->AsLclVar(), op2, assertionKind);
         }
 
         if (!compiler->opts.IsReadyToRun() && (op1->IsCall() || op2->IsCall()))

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -488,7 +488,7 @@ enum ApOp1Kind : uint8_t
     O1K_LCLVAR,
     O1K_BOUND_OPER_BND,
     O1K_BOUND_LOOP_BND,
-    O1K_SUBTYPE,
+    O1K_INSTANCE_OF,
     O1K_VALUE_NUMBER
 };
 
@@ -1599,7 +1599,7 @@ private:
             AssertionDsc assertion;
 
             assertion.kind     = (assertionKind == OAK_EQUAL) ? OAK_NOT_EQUAL : OAK_EQUAL;
-            assertion.op1.kind = O1K_SUBTYPE;
+            assertion.op1.kind = O1K_INSTANCE_OF;
             assertion.op1.vn   = objVN;
             assertion.op2.kind = O2K_VALUE_NUMBER;
             assertion.op2.vn   = mtVN;
@@ -2338,7 +2338,7 @@ private:
         return call;
     }
 
-    const AssertionDsc* FindSubtypeAssertion(const ASSERT_TP assertions, ValueNum objVN, ValueNum mtVN)
+    const AssertionDsc* FindInstanceOfAssertion(const ASSERT_TP assertions, ValueNum objVN, ValueNum mtVN)
     {
         ValueNum objMTVN = vnStore->HasFunc(TYP_I_IMPL, VNF_ObjMT, objVN);
 
@@ -2347,7 +2347,7 @@ private:
             const AssertionDsc& assertion = GetAssertion(GetAssertionIndex(en.Current()));
 
             if ((assertion.kind == OAK_EQUAL) && (assertion.op2.vn == mtVN) &&
-                (((assertion.op1.kind == O1K_SUBTYPE) && (assertion.op1.vn == objVN)) ||
+                (((assertion.op1.kind == O1K_INSTANCE_OF) && (assertion.op1.vn == objVN)) ||
                  ((assertion.op1.kind == O1K_VALUE_NUMBER) && (assertion.op1.vn == objMTVN))))
             {
                 return &assertion;
@@ -2390,7 +2390,7 @@ private:
         ValueNum objectVN      = objectArg->GetConservativeVN();
         ValueNum methodTableVN = vnStore->VNNormalValue(call->GetArgNodeByArgNum(0)->GetConservativeVN());
 
-        const AssertionDsc* assertion = FindSubtypeAssertion(assertions, objectVN, methodTableVN);
+        const AssertionDsc* assertion = FindInstanceOfAssertion(assertions, objectVN, methodTableVN);
 
         if (assertion == nullptr)
         {
@@ -2687,7 +2687,7 @@ private:
             return;
         }
 
-        if ((assertion.kind == OAK_EQUAL) && (assertion.op1.kind == O1K_SUBTYPE))
+        if ((assertion.kind == OAK_EQUAL) && (assertion.op1.kind == O1K_INSTANCE_OF))
         {
             AddTypeImpliedNotNullAssertions(assertion, assertions);
             return;
@@ -2700,7 +2700,7 @@ private:
 
     void AddTypeImpliedNotNullAssertions(const AssertionDsc& typeAssertion, ASSERT_TP& assertions)
     {
-        assert((typeAssertion.kind == OAK_EQUAL) && (typeAssertion.op1.kind == O1K_SUBTYPE));
+        assert((typeAssertion.kind == OAK_EQUAL) && (typeAssertion.op1.kind == O1K_INSTANCE_OF));
 
         const ASSERT_TP vnAssertions = GetVNAssertions(typeAssertion.op1.vn);
 
@@ -3930,7 +3930,7 @@ private:
             return;
         }
 
-        if (op1.kind == O1K_SUBTYPE)
+        if (op1.kind == O1K_INSTANCE_OF)
         {
             assert(vnStore->TypeOfVN(op1.vn) == TYP_REF);
             assert(op2.kind == O2K_VALUE_NUMBER);
@@ -4013,7 +4013,7 @@ void Compiler::apDumpAssertion(const AssertionDsc& assertion, unsigned index)
         return;
     }
 
-    if (op1.kind == O1K_SUBTYPE)
+    if (op1.kind == O1K_INSTANCE_OF)
     {
         printf("Type assertion A%02u: MT(" FMT_VN ") %s " FMT_VN, index, op1.vn, (kind == OAK_EQUAL) ? "IS" : "IS NOT",
                op2.vn);

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1119,35 +1119,25 @@ private:
             return NO_ASSERTION_INDEX;
         }
 
-        AssertionDsc assertion;
-
-        if (op2->OperIs(GT_IND))
-        {
-            op2 = op2->AsIndir()->GetAddr();
-
-            assertion.op2.kind = O2K_IND_CNS_INT;
-        }
-        else
-        {
-            assertion.op2.kind = O2K_CONST_INT;
-        }
-
         if (!op2->IsIntCon())
         {
             return NO_ASSERTION_INDEX;
         }
 
         ValueNum vn1 = op1->GetConservativeVN();
-        ValueNum vn2 = vnStore->VNNormalValue(op2->GetConservativeVN());
+        ValueNum vn2 = op2->GetConservativeVN();
 
         if ((vn1 == NoVN) || (vn2 == NoVN))
         {
             return NO_ASSERTION_INDEX;
         }
 
+        AssertionDsc assertion;
+
         assertion.kind             = kind;
         assertion.op1.kind         = O1K_SUBTYPE;
         assertion.op1.vn           = vn1;
+        assertion.op2.kind         = O2K_CONST_INT;
         assertion.op2.vn           = vn2;
         assertion.op2.intCon.value = op2->AsIntCon()->GetValue();
         assertion.op2.intCon.flags = op2->GetIconHandleFlag();
@@ -1600,7 +1590,7 @@ private:
             return CreateExactTypeAssertion(op1->AsIndir(), op2, assertionKind);
         }
 
-        if (op1->IsCall() || op2->IsCall())
+        if (!compiler->opts.IsReadyToRun() && (op1->IsCall() || op2->IsCall()))
         {
             if (!op1->IsCall())
             {
@@ -2451,7 +2441,7 @@ private:
             return UpdateTree(call, call, stmt);
         }
 
-        if (!call->IsHelperCall())
+        if (compiler->opts.IsReadyToRun() || !call->IsHelperCall())
         {
             return nullptr;
         }

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -2736,8 +2736,7 @@ private:
             return;
         }
 
-        if ((assertion.kind == OAK_EQUAL) &&
-            ((assertion.op1.kind == O1K_SUBTYPE) || (assertion.op1.kind == O1K_EXACT_TYPE)))
+        if ((assertion.kind == OAK_EQUAL) && (assertion.op1.kind == O1K_SUBTYPE))
         {
             AddTypeImpliedNotNullAssertions(assertion, assertions);
             return;
@@ -2750,8 +2749,7 @@ private:
 
     void AddTypeImpliedNotNullAssertions(const AssertionDsc& typeAssertion, ASSERT_TP& assertions)
     {
-        assert(typeAssertion.kind == OAK_EQUAL);
-        assert((typeAssertion.op1.kind == O1K_SUBTYPE) || (typeAssertion.op1.kind == O1K_EXACT_TYPE));
+        assert((typeAssertion.kind == OAK_EQUAL) && (typeAssertion.op1.kind == O1K_SUBTYPE));
 
         const ASSERT_TP vnAssertions = GetVNAssertions(typeAssertion.op1.vn);
 
@@ -2778,9 +2776,8 @@ private:
 
                 if (BitVecOps::TryAddElemD(&countTraits, assertions, en.Current()))
                 {
-                    JITDUMP("%s A%02d implies A%02d\n",
-                            (typeAssertion.op1.kind == O1K_SUBTYPE) ? "Subtype" : "Exact-type",
-                            &typeAssertion - assertionTable, &notNullAssertion - assertionTable);
+                    JITDUMP("Assertion A%02d implies A%02d\n", &typeAssertion - assertionTable,
+                            &notNullAssertion - assertionTable);
                 }
 
                 // There is at most one not null assertion that is implied by a type assertion.

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1050,13 +1050,10 @@ private:
         assert(op2 != nullptr);
         assert((kind == OAK_EQUAL) || (kind == OAK_NOT_EQUAL));
 
-        // TODO: only copy assertions rely on valid SSA number so we could generate more assertions here
-        if (addr->GetSsaNum() == SsaConfig::RESERVED_SSA_NUM)
+        if (compiler->lvaGetDesc(addr)->IsAddressExposed())
         {
             return NO_ASSERTION_INDEX;
         }
-
-        assert(compiler->lvaGetDesc(addr)->IsInSsa());
 
         ValueNum vn1 = addr->GetConservativeVN();
 

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1108,12 +1108,6 @@ private:
         assert(op1->OperIs(GT_LCL_VAR));
         assert((kind == OAK_EQUAL) || (kind == OAK_NOT_EQUAL));
 
-        // TODO: only copy assertions rely on valid SSA number so we could generate more assertions here
-        if (op1->GetSsaNum() == SsaConfig::RESERVED_SSA_NUM)
-        {
-            return NO_ASSERTION_INDEX;
-        }
-
         if (compiler->lvaGetDesc(op1)->IsAddressExposed())
         {
             return NO_ASSERTION_INDEX;

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -1890,6 +1890,15 @@ ValueNum ValueNumStore::VNForFunc(var_types typ, VNFunc func, ValueNum arg0VN)
     return resultVN;
 }
 
+ValueNum ValueNumStore::HasFunc(var_types type, VNFunc func, ValueNum arg0VN)
+{
+    assert(func != VNF_MemOpaque);
+    assert(arg0VN == VNNormalValue(arg0VN)); // Arguments don't carry exceptions.
+
+    ValueNum* funcVN = GetVNFunc1Map()->LookupPointer({func, arg0VN});
+    return funcVN == nullptr ? NoVN : *funcVN;
+}
+
 //----------------------------------------------------------------------------------------
 //  VNForFunc  - Returns the ValueNum associated with 'func'('arg0VN','arg1VN')
 //               There is a one-to-one relationship between the ValueNum

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -524,6 +524,7 @@ public:
     // VNForFunc: We have five overloads, for arities 0, 1, 2, 3 and 4
     ValueNum VNForFunc(var_types typ, VNFunc func);
     ValueNum VNForFunc(var_types typ, VNFunc func, ValueNum opVNwx);
+    ValueNum HasFunc(var_types typ, VNFunc func, ValueNum arg0VN);
     // This must not be used for VNF_MapSelect applications; instead use VNForMapSelect, below.
     ValueNum VNForFunc(var_types typ, VNFunc func, ValueNum op1VNwx, ValueNum op2VNwx);
     ValueNum VNForFunc(var_types typ, VNFunc func, ValueNum op1VNwx, ValueNum op2VNwx, ValueNum op3VNwx);

--- a/src/coreclr/jit/valuenumfuncs.h
+++ b/src/coreclr/jit/valuenumfuncs.h
@@ -150,6 +150,8 @@ ValueNumFuncDef(LazyStrCns, 2, false, true, false)  // lazy-initialized string l
 ValueNumFuncDef(NonNullIndirect, 1, false, true, false)  // this indirect is expected to always return a non-null value
 ValueNumFuncDef(Unbox, 2, false, true, false)
 
+ValueNumFuncDef(ObjMT, 1, false, true, false)
+
 ValueNumFuncDef(LT_UN, 2, false, false, false)      // unsigned or unordered comparisons
 ValueNumFuncDef(LE_UN, 2, false, false, false)
 ValueNumFuncDef(GE_UN, 2, false, false, false)


### PR DESCRIPTION
win-x64 pmi diff:
```
Total bytes of base: 60494545
Total bytes of diff: 60447949
Total bytes of delta: -46596 (-0.08 % of base)
Total relative delta: -138.54
    diff is an improvement.
    relative diff is an improvement.


Top file improvements (bytes):
      -10639 : System.Private.CoreLib.dasm (-0.19% of base)
       -6573 : Microsoft.VisualBasic.Core.dasm (-1.33% of base)
       -5725 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.09% of base)
       -3654 : Microsoft.CodeAnalysis.dasm (-0.18% of base)
       -3229 : Newtonsoft.Json.dasm (-0.34% of base)
       -2545 : System.Reflection.Metadata.dasm (-0.47% of base)
       -1425 : System.Collections.Concurrent.dasm (-0.37% of base)
       -1415 : System.Data.Common.dasm (-0.08% of base)
        -922 : System.ComponentModel.TypeConverter.dasm (-0.32% of base)
        -908 : Microsoft.CodeAnalysis.CSharp.dasm (-0.02% of base)
        -852 : System.Private.Xml.dasm (-0.02% of base)
        -619 : System.Diagnostics.DiagnosticSource.dasm (-0.35% of base)
        -597 : System.Private.Xml.Linq.dasm (-0.34% of base)
        -529 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.01% of base)
        -500 : System.Data.OleDb.dasm (-0.15% of base)
        -441 : Microsoft.Extensions.Logging.Console.dasm (-0.85% of base)
        -415 : System.Private.DataContractSerialization.dasm (-0.05% of base)
        -379 : System.Drawing.Primitives.dasm (-0.92% of base)
        -378 : System.Collections.Immutable.dasm (-0.02% of base)
        -378 : CommandLine.dasm (-0.07% of base)

61 total files with Code Size differences (61 improved, 0 regressed), 210 unchanged.

Top method improvements (bytes):
        -693 (-36.07% of base) : System.Private.CoreLib.dasm - Memory`1:Equals(Object):bool:this (8 methods)
        -688 (-35.37% of base) : System.Private.CoreLib.dasm - ReadOnlyMemory`1:Equals(Object):bool:this (8 methods)
        -673 (-33.15% of base) : System.Private.CoreLib.dasm - Comparer`1:System.Collections.IComparer.Compare(Object,Object):int:this (8 methods)
        -473 (-33.22% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Conversions:ToString(Object):String
        -441 (-34.48% of base) : Microsoft.Extensions.Logging.Console.dasm - JsonConsoleFormatter:WriteItem(Utf8JsonWriter,KeyValuePair`2):this
        -426 (-28.21% of base) : System.Private.CoreLib.dasm - ValueTask`1:Equals(Object):bool:this (8 methods)
        -417 (-43.48% of base) : System.Private.CoreLib.dasm - ValueTuple`1:Equals(Object):bool:this (8 methods)
        -414 (-44.14% of base) : System.Private.CoreLib.dasm - ArraySegment`1:Equals(Object):bool:this (8 methods)
        -403 (-37.31% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Conversions:ToByte(Object):ubyte
        -403 (-36.94% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Conversions:ToSByte(Object):byte
        -403 (-36.97% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Conversions:ToShort(Object):short
        -403 (-37.18% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Conversions:ToUShort(Object):ushort
        -400 (-37.45% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Conversions:ToInteger(Object):int
        -400 (-37.24% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Conversions:ToLong(Object):long
        -400 (-37.38% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Conversions:ToUInteger(Object):int
        -400 (-37.24% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Conversions:ToULong(Object):long
        -399 (-36.67% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Conversions:ToBoolean(Object):bool
        -399 (-30.65% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Conversions:ToDecimal(Object):Decimal
        -399 (-36.27% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Conversions:ToDouble(Object):double
        -399 (-36.14% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Conversions:ToSingle(Object):float

Top method improvements (percentages):
         -60 (-61.22% of base) : System.Diagnostics.DiagnosticSource.dasm - ObjectSequenceMany:Equals(Object):bool:this
         -60 (-61.22% of base) : System.Diagnostics.DiagnosticSource.dasm - StringSequenceMany:Equals(Object):bool:this
         -60 (-61.22% of base) : Microsoft.CodeAnalysis.CSharp.dasm - TypeDeclarationIdentity:Equals(Object):bool:this
        -360 (-61.22% of base) : System.Private.CoreLib.dasm - Vector64`1:Equals(Object):bool:this (6 methods)
         -57 (-58.16% of base) : System.Diagnostics.DiagnosticSource.dasm - ActivitySpanId:Equals(Object):bool:this
         -57 (-58.16% of base) : System.Diagnostics.DiagnosticSource.dasm - ActivityTraceId:Equals(Object):bool:this
         -57 (-58.16% of base) : System.Reflection.Metadata.dasm - AssemblyDefinitionHandle:Equals(Object):bool:this
         -57 (-58.16% of base) : System.Reflection.Metadata.dasm - AssemblyFileHandle:Equals(Object):bool:this
         -57 (-58.16% of base) : System.Reflection.Metadata.dasm - AssemblyReferenceHandle:Equals(Object):bool:this
         -57 (-58.16% of base) : System.Collections.Specialized.dasm - BitVector32:Equals(Object):bool:this
         -57 (-58.16% of base) : System.Reflection.Metadata.dasm - BlobHandle:Equals(Object):bool:this
         -57 (-58.16% of base) : Microsoft.CodeAnalysis.dasm - BlobIdx:Equals(Object):bool:this
         -57 (-58.16% of base) : System.Private.CoreLib.dasm - CLong:Equals(Object):bool:this
         -57 (-58.16% of base) : System.Reflection.Metadata.dasm - ConstantHandle:Equals(Object):bool:this
         -57 (-58.16% of base) : System.Private.CoreLib.dasm - CountsOfThreadsProcessingUserCallbacks:Equals(Object):bool:this
         -57 (-58.16% of base) : System.Private.CoreLib.dasm - CULong:Equals(Object):bool:this
         -57 (-58.16% of base) : System.Reflection.Metadata.dasm - CustomAttributeHandle:Equals(Object):bool:this
         -57 (-58.16% of base) : System.Reflection.Metadata.dasm - CustomDebugInformationHandle:Equals(Object):bool:this
         -57 (-58.16% of base) : System.Private.CoreLib.dasm - DateOnly:Equals(Object):bool:this
         -57 (-58.16% of base) : System.Reflection.Metadata.dasm - DeclarativeSecurityAttributeHandle:Equals(Object):bool:this

516 total methods with Code Size differences (516 improved, 0 regressed), 275607 unchanged.
```