### PR TITLE
Early prop cleanup

### DIFF
--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -510,10 +510,17 @@ enum BasicBlockFlags : uint64_t
 
     BBF_LOOP_FLAGS = BBF_LOOP_PREHEADER | BBF_LOOP_HEAD | BBF_LOOP_CALL0 | BBF_LOOP_CALL1,
 
+    // Flags that record the presence of certain IR patterns in the block. If the block is split,
+    // the new block should "inherit" these flags from the existing block, unless the IR in the
+    // new block is known not to contain these patterns.
+    // Likewise, when moving statements between blocks, these flags should be copied to the destination
+    // block if the statements may contain these patterns.
+    // Adding unnecessary flags may be a throughput issue but is not a correctness issue.
+    BBF_IR_SUMMARY = BBF_HAS_NEWOBJ | BBF_HAS_IDX_LEN | BBF_HAS_NEWARRAY | BBF_HAS_NULLCHECK,
+
     // Flags to update when two blocks are compacted
 
-    BBF_COMPACT_UPD = BBF_GC_SAFE_POINT | BBF_HAS_JMP | BBF_HAS_IDX_LEN | BBF_BACKWARD_JUMP | BBF_HAS_NEWARRAY | \
-                      BBF_HAS_NEWOBJ | BBF_HAS_NULLCHECK,
+    BBF_COMPACT_UPD = BBF_GC_SAFE_POINT | BBF_HAS_JMP | BBF_IR_SUMMARY | BBF_BACKWARD_JUMP,
 
     // Flags a block should not have had before it is split.
 
@@ -525,14 +532,6 @@ enum BasicBlockFlags : uint64_t
     // but we assume it does not have BBF_GC_SAFE_POINT any more.
 
     BBF_SPLIT_LOST = BBF_GC_SAFE_POINT | BBF_HAS_JMP | BBF_KEEP_BBJ_ALWAYS | BBF_CLONED_FINALLY_END,
-
-    // Flags that record the presence of certain IR patterns in the block. If the block is split,
-    // the new block should "inherit" these flags from the existing block, unless the IR in the
-    // new block is known not to contain these patterns.
-    // Likewise, when moving statements between blocks, these flags should be copied to the destination
-    // block if the statements may contain these patterns.
-    // Adding unnecessary flags may be a throughput issue but is not a correctness issue.
-    BBF_IR_SUMMARY = BBF_HAS_NEWOBJ | BBF_HAS_IDX_LEN | BBF_HAS_NEWARRAY | BBF_HAS_NULLCHECK,
 
     // Flags gained by the bottom block when a block is split.
     // Note, this is a conservative guess.

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -540,7 +540,7 @@ void Compiler::compStartup()
     grossVMsize = grossNCsize = totalNCsize = 0;
 #endif // DISPLAY_SIZES
 
-    /* Initialize the table of tree node sizes */
+/* Initialize the table of tree node sizes */
 
 #ifdef JIT32_GCENCODER
     // Initialize the GC encoder lookup table
@@ -7845,8 +7845,6 @@ void Compiler::gtChangeOperToNullCheck(GenTree* tree, BasicBlock* block)
 
     tree->ChangeOper(GT_NULLCHECK);
     tree->SetType(TYP_INT);
-    block->bbFlags |= BBF_HAS_NULLCHECK;
-    optMethodFlags |= OMF_HAS_NULLCHECK;
 }
 
 #if defined(DEBUG)

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2114,7 +2114,7 @@ public:
     GenTreeIndexAddr* gtNewStringIndexAddr(GenTree* arr, GenTree* ind);
     GenTreeIndir* gtNewIndexIndir(var_types type, GenTreeIndexAddr* indexAddr);
 
-    GenTreeArrLen* gtNewArrLen(GenTree* arr, uint8_t lenOffs, BasicBlock* block);
+    GenTreeArrLen* gtNewArrLen(GenTree* arr, uint8_t lenOffs);
     GenTreeBoundsChk* gtNewArrBoundsChk(GenTree* index, GenTree* length, SpecialCodeKind kind);
 
     GenTreeIndir* gtNewIndir(var_types typ, GenTree* addr);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4513,6 +4513,7 @@ public:
 
 protected:
     friend class SsaBuilder;
+    friend class EarlyProp;
     friend struct ValueNumberState;
 
     //--------------------- Detect the basic blocks ---------------------------
@@ -5800,37 +5801,7 @@ public:
 
     unsigned optNoReturnCallCount;
 
-    // Recursion bound controls how far we can go backwards tracking for a SSA value.
-    // No throughput diff was found with backward walk bound between 3-8.
-    static const int optEarlyPropRecurBound = 5;
-
-    typedef JitHashTable<unsigned, JitSmallPrimitiveKeyFuncs<unsigned>, GenTree*> LocalNumberToNullCheckTreeMap;
-
-    GenTree* getArrayLengthFromAllocation(GenTree* tree DEBUGARG(BasicBlock* block));
-    GenTree* optPropGetValueRec(GenTreeLclVar* lclVar, int walkDepth);
-    GenTree* optPropGetValue(GenTreeLclVar* lclVar);
-    GenTree* optEarlyPropRewriteTree(GenTree* tree, LocalNumberToNullCheckTreeMap* nullCheckMap);
-    bool optDoEarlyPropForBlock(BasicBlock* block);
-    bool optDoEarlyPropForFunc();
     void optEarlyProp();
-    void optFoldNullCheck(GenTree* tree, LocalNumberToNullCheckTreeMap* nullCheckMap);
-    GenTree* optFindNullCheckToFold(GenTree* tree, LocalNumberToNullCheckTreeMap* nullCheckMap);
-    bool optIsNullCheckFoldingLegal(GenTree*    tree,
-                                    GenTree*    nullCheckTree,
-                                    GenTree**   nullCheckParent,
-                                    Statement** nullCheckStmt);
-    bool optCanMoveNullCheckPastTree(GenTree* tree,
-                                     unsigned nullCheckLclNum,
-                                     bool     isInsideTry,
-                                     bool     checkSideEffectSummary);
-#if DEBUG
-    void optCheckFlagsAreSet(unsigned    methodFlag,
-                             const char* methodFlagStr,
-                             unsigned    bbFlag,
-                             const char* bbFlagStr,
-                             GenTree*    tree,
-                             BasicBlock* basicBlock);
-#endif
 
     // Redundant branch opts
     //

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1020,15 +1020,8 @@ inline GenTreeIndir* Compiler::gtNewIndexIndir(var_types type, GenTreeIndexAddr*
     return indir;
 }
 
-inline GenTreeArrLen* Compiler::gtNewArrLen(GenTree* arr, uint8_t lenOffs, BasicBlock* block)
+inline GenTreeArrLen* Compiler::gtNewArrLen(GenTree* arr, uint8_t lenOffs)
 {
-    if (block != nullptr)
-    {
-        block->bbFlags |= BBF_HAS_IDX_LEN;
-    }
-
-    optMethodFlags |= OMF_HAS_ARRAYREF;
-
     GenTreeArrLen* arrLen = new (this, GT_ARR_LENGTH) GenTreeArrLen(arr, lenOffs);
     arrLen->SetIndirExceptionFlags(this);
     return arrLen;
@@ -1071,8 +1064,6 @@ inline GenTree* Compiler::gtNewNullCheck(GenTree* addr, BasicBlock* basicBlock)
     assert(fgAddrCouldBeNull(addr));
     GenTree* nullCheck = gtNewOperNode(GT_NULLCHECK, TYP_BYTE, addr);
     nullCheck->gtFlags |= GTF_EXCEPT;
-    basicBlock->bbFlags |= BBF_HAS_NULLCHECK;
-    optMethodFlags |= OMF_HAS_NULLCHECK;
     return nullCheck;
 }
 

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1219,6 +1219,7 @@ inline GenTreeIntCon* GenTree::ChangeToIntCon(ssize_t value)
     GenTreeIntCon* intCon = AsIntCon();
     intCon->SetValue(value);
     intCon->gtCompileTimeHandle = 0;
+    INDEBUG(intCon->gtTargetHandle = 0);
     return intCon;
 }
 

--- a/src/coreclr/jit/earlyprop.cpp
+++ b/src/coreclr/jit/earlyprop.cpp
@@ -163,12 +163,7 @@ private:
 
     void DoEarlyProp()
     {
-#ifdef DEBUG
-        if (compiler->verbose)
-        {
-            printf("*************** In DoEarlyProp()\n");
-        }
-#else
+#ifndef DEBUG
         if (!DoEarlyPropForFunc())
         {
             return;

--- a/src/coreclr/jit/earlyprop.cpp
+++ b/src/coreclr/jit/earlyprop.cpp
@@ -15,651 +15,645 @@
 #include "jitpch.h"
 #include "ssabuilder.h"
 
-bool Compiler::optDoEarlyPropForFunc()
+class EarlyProp
 {
-    bool propArrayLen  = (optMethodFlags & OMF_HAS_NEWARRAY) && (optMethodFlags & OMF_HAS_ARRAYREF);
-    bool propNullCheck = (optMethodFlags & OMF_HAS_NULLCHECK) != 0;
-    return propArrayLen || propNullCheck;
-}
+    static const int optEarlyPropRecurBound = 5;
 
-bool Compiler::optDoEarlyPropForBlock(BasicBlock* block)
-{
-    bool bbHasArrayRef  = (block->bbFlags & BBF_HAS_IDX_LEN) != 0;
-    bool bbHasNullCheck = (block->bbFlags & BBF_HAS_NULLCHECK) != 0;
-    return bbHasArrayRef || bbHasNullCheck;
-}
+    typedef JitHashTable<unsigned, JitSmallPrimitiveKeyFuncs<unsigned>, GenTree*> LocalNumberToNullCheckTreeMap;
 
-//------------------------------------------------------------------------------
-// getArrayLengthFromAllocation: Return the array length for an array allocation
-//                               helper call.
-//
-// Arguments:
-//    tree           - The array allocation helper call.
-//    block          - tree's basic block.
-//
-// Return Value:
-//    Return the array length node.
+    Compiler* compiler;
 
-GenTree* Compiler::getArrayLengthFromAllocation(GenTree* tree DEBUGARG(BasicBlock* block))
-{
-    assert(tree != nullptr);
-
-    GenTree* arrayLength = nullptr;
-
-    if (tree->OperGet() == GT_CALL)
+public:
+    EarlyProp(Compiler* compiler) : compiler(compiler)
     {
-        GenTreeCall* call = tree->AsCall();
-
-        if (call->gtCallType == CT_HELPER)
-        {
-            if (call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_NEWARR_1_DIRECT) ||
-                call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_NEWARR_1_OBJ) ||
-                call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_NEWARR_1_VC) ||
-                call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_NEWARR_1_ALIGN8))
-            {
-                // This is an array allocation site. Grab the array length node.
-                arrayLength = call->GetArgNodeByArgNum(1);
-            }
-            else if (call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_READYTORUN_NEWARR_1))
-            {
-                // On arm when compiling on certain platforms for ready to run, a handle will be
-                // inserted before the length. To handle this case, we will grab the last argument
-                // as that's always the length. See fgInitArgInfo for where the handle is inserted.
-                arrayLength = call->GetArgNodeByArgNum(call->GetInfo()->GetArgCount() - 1);
-            }
-#ifdef DEBUG
-            if (arrayLength != nullptr)
-            {
-                optCheckFlagsAreSet(OMF_HAS_NEWARRAY, "OMF_HAS_NEWARRAY", BBF_HAS_NEWARRAY, "BBF_HAS_NEWARRAY", tree,
-                                    block);
-            }
-#endif
-        }
     }
 
-    return arrayLength;
-}
-
-#ifdef DEBUG
-//-----------------------------------------------------------------------------
-// optCheckFlagsAreSet: Check that the method flag and the basic block flag are set.
-//
-// Arguments:
-//    methodFlag           - The method flag to check.
-//    methodFlagStr        - String representation of the method flag.
-//    bbFlag               - The basic block flag to check.
-//    bbFlagStr            - String representation of the basic block flag.
-//    tree                 - Tree that makes the flags required.
-//    basicBlock           - The basic block to check the flag on.
-
-void Compiler::optCheckFlagsAreSet(unsigned    methodFlag,
-                                   const char* methodFlagStr,
-                                   unsigned    bbFlag,
-                                   const char* bbFlagStr,
-                                   GenTree*    tree,
-                                   BasicBlock* basicBlock)
-{
-    if ((optMethodFlags & methodFlag) == 0)
+    void Run()
     {
-        printf("%s is not set on optMethodFlags but is required because of the following tree\n", methodFlagStr);
-        gtDispTree(tree);
-        assert(false);
+        optEarlyProp();
     }
 
-    if ((basicBlock->bbFlags & bbFlag) == 0)
+private:
+    bool optDoEarlyPropForFunc()
     {
-        printf("%s is not set on " FMT_BB " but is required because of the following tree \n", bbFlagStr,
-               compCurBB->bbNum);
-        gtDispTree(tree);
-        assert(false);
-    }
-}
-#endif
-
-//------------------------------------------------------------------------------------------
-// optEarlyProp: The entry point of the early value propagation.
-//
-// Notes:
-//    This phase performs an SSA-based value propagation, including
-//      1. Array length propagation.
-//      2. Runtime type handle propagation.
-//      3. Null check folding.
-//
-//    For array length propagation, a demand-driven SSA-based backwards tracking of constant
-//    array lengths is performed at each array length reference site which is in form of a
-//    GT_ARR_LENGTH node. When a GT_ARR_LENGTH node is seen, the array ref pointer which is
-//    the only child node of the GT_ARR_LENGTH is tracked. This is only done for array ref
-//    pointers that have valid SSA forms.The tracking is along SSA use-def chain and stops
-//    at the original array allocation site where we can grab the array length. The
-//    GT_ARR_LENGTH node will then be rewritten to a GT_CNS_INT node if the array length is
-//    constant.
-//
-//    Similarly, the same algorithm also applies to rewriting a method table (also known as
-//    vtable) reference site which is in form of GT_INDIR node. The base pointer, which is
-//    an object reference pointer, is treated in the same way as an array reference pointer.
-//
-//    Null check folding tries to find GT_INDIR(obj + const) that GT_NULLCHECK(obj) can be folded into
-//    and removed. Currently, the algorithm only matches GT_INDIR and GT_NULLCHECK in the same basic block.
-
-void Compiler::optEarlyProp()
-{
-#ifdef DEBUG
-    if (verbose)
-    {
-        printf("*************** In optEarlyProp()\n");
-    }
-#else
-    if (!optDoEarlyPropForFunc())
-    {
-        return;
-    }
-#endif
-
-    assert(ssaForm);
-
-    for (BasicBlock* const block : Blocks())
-    {
-#ifndef DEBUG
-        if (!optDoEarlyPropForBlock(block))
-        {
-            continue;
-        }
-#endif
-
-        compCurBB = block;
-
-        CompAllocator                 allocator(getAllocator(CMK_EarlyProp));
-        LocalNumberToNullCheckTreeMap nullCheckMap(allocator);
-
-        for (Statement* stmt = block->firstStmt(); stmt != nullptr;)
-        {
-            // Preserve the next link before the propagation and morph.
-            Statement* next = stmt->GetNextStmt();
-
-            compCurStmt = stmt;
-
-            // Walk the stmt tree in linear order to rewrite any array length reference with a
-            // constant array length.
-            bool isRewritten = false;
-            for (GenTree* tree = stmt->GetTreeList(); tree != nullptr; tree = tree->gtNext)
-            {
-                GenTree* rewrittenTree = optEarlyPropRewriteTree(tree, &nullCheckMap);
-                if (rewrittenTree != nullptr)
-                {
-                    gtUpdateSideEffects(stmt, rewrittenTree);
-                    isRewritten = true;
-                    tree        = rewrittenTree;
-                }
-            }
-
-            // Update the evaluation order and the statement info if the stmt has been rewritten.
-            if (isRewritten)
-            {
-                // Make sure the transformation happens in debug, check, and release build.
-                assert(optDoEarlyPropForFunc() && optDoEarlyPropForBlock(block));
-                gtSetStmtInfo(stmt);
-                fgSetStmtSeq(stmt);
-            }
-
-            stmt = next;
-        }
+        bool propArrayLen =
+            (compiler->optMethodFlags & OMF_HAS_NEWARRAY) && (compiler->optMethodFlags & OMF_HAS_ARRAYREF);
+        bool propNullCheck = (compiler->optMethodFlags & OMF_HAS_NULLCHECK) != 0;
+        return propArrayLen || propNullCheck;
     }
 
-#ifdef DEBUG
-    if (verbose)
+    bool optDoEarlyPropForBlock(BasicBlock* block)
     {
-        JITDUMP("\nAfter optEarlyProp:\n");
-        fgDispBasicBlocks(/*dumpTrees*/ true);
-    }
-#endif
-}
-
-//----------------------------------------------------------------
-// optEarlyPropRewriteValue: Rewrite a tree to the actual value.
-//
-// Arguments:
-//    tree           - The input tree node to be rewritten.
-//    nullCheckMap   - Map of the local numbers to the latest NULLCHECKs on those locals in the current basic block.
-//
-// Return Value:
-//    Return a new tree if the original tree was successfully rewritten.
-//    The containing tree links are updated.
-//
-GenTree* Compiler::optEarlyPropRewriteTree(GenTree* tree, LocalNumberToNullCheckTreeMap* nullCheckMap)
-{
-    if (!tree->OperIsIndirOrArrLength())
-    {
-        return nullptr;
+        bool bbHasArrayRef  = (block->bbFlags & BBF_HAS_IDX_LEN) != 0;
+        bool bbHasNullCheck = (block->bbFlags & BBF_HAS_NULLCHECK) != 0;
+        return bbHasArrayRef || bbHasNullCheck;
     }
 
-    // optFoldNullCheck takes care of updating statement info if a null check is removed.
-    optFoldNullCheck(tree, nullCheckMap);
-
-    if (tree->OperGet() != GT_ARR_LENGTH)
-    {
-        return nullptr;
-    }
-
-    GenTree* objectRefPtr = tree->AsOp()->gtOp1;
-
-    if (!objectRefPtr->OperIs(GT_LCL_VAR) || !lvaInSsa(objectRefPtr->AsLclVar()->GetLclNum()))
-    {
-        return nullptr;
-    }
-
-    INDEBUG(
-        optCheckFlagsAreSet(OMF_HAS_ARRAYREF, "OMF_HAS_ARRAYREF", BBF_HAS_IDX_LEN, "BBF_HAS_IDX_LEN", tree, compCurBB));
-
-    GenTree* actualVal = optPropGetValue(objectRefPtr->AsLclVar());
-
-    if (actualVal == nullptr)
-    {
-        return nullptr;
-    }
-
-    assert(actualVal->IsCnsIntOrI() && !actualVal->AsIntCon()->IsIconHandle());
-    assert(actualVal->GetNodeSize() == TREE_NODE_SZ_SMALL);
-
-    ssize_t actualConstVal = actualVal->AsIntCon()->IconValue();
-
-    if ((actualConstVal < 0) || (actualConstVal > INT32_MAX))
-    {
-        // Don't propagate array lengths that are beyond the maximum value of a GT_ARR_LENGTH or negative.
-        // node. CORINFO_HELP_NEWARR_1_OBJ helper call allows to take a long integer as the
-        // array length argument, but the type of GT_ARR_LENGTH is always INT32.
-        return nullptr;
-    }
-
-    // When replacing GT_ARR_LENGTH nodes with constants we can end up with GT_ARR_BOUNDS_CHECK
-    // nodes that have constant operands and thus can be trivially proved to be useless. It's
-    // better to remove these range checks here, otherwise they'll pass through assertion prop
-    // (creating useless (c1 < c2)-like assertions) and reach RangeCheck where they are finally
-    // removed. Common patterns like new int[] { x, y, z } benefit from this.
-
-    if ((tree->gtNext != nullptr) && tree->gtNext->OperIs(GT_ARR_BOUNDS_CHECK))
-    {
-        GenTreeBoundsChk* check = tree->gtNext->AsBoundsChk();
-
-        if ((check->gtArrLen == tree) && check->gtIndex->IsCnsIntOrI())
-        {
-            ssize_t checkConstVal = check->gtIndex->AsIntCon()->IconValue();
-            if ((checkConstVal >= 0) && (checkConstVal < actualConstVal))
-            {
-                GenTree* comma = check->FindUser();
-
-                // We should never see cases other than these in the IR,
-                // as the check node does not produce a value.
-                assert(((comma != nullptr) && comma->OperIs(GT_COMMA) &&
-                        (comma->gtGetOp1() == check || comma->TypeIs(TYP_VOID))) ||
-                       (check == compCurStmt->GetRootNode()));
-
-                // Still, we guard here so that release builds do not try to optimize trees we don't understand.
-                if (((comma != nullptr) && comma->OperIs(GT_COMMA) && (comma->gtGetOp1() == check)) ||
-                    (check == compCurStmt->GetRootNode()))
-                {
-                    // Both `tree` and `check` have been removed from the statement.
-                    // 'tree' was replaced with 'nop' or side effect list under 'comma'.
-                    // optRemoveRangeCheck returns this modified tree.
-                    return optRemoveRangeCheck(check, comma, compCurStmt);
-                }
-            }
-        }
-    }
-
-#ifdef DEBUG
-    if (verbose)
-    {
-        printf("optEarlyProp Rewriting " FMT_BB "\n", compCurBB->bbNum);
-        gtDispStmt(compCurStmt);
-        printf("\n");
-    }
-#endif
-
-    GenTree* actualValClone = gtCloneExpr(actualVal);
-
-    if (actualValClone->gtType != tree->gtType)
-    {
-        assert(actualValClone->gtType == TYP_LONG);
-        assert(tree->gtType == TYP_INT);
-        assert((actualConstVal >= 0) && (actualConstVal <= INT32_MAX));
-        actualValClone->gtType = tree->gtType;
-    }
-
-    // actualValClone has small tree node size, it is safe to use CopyFrom here.
-    tree->ReplaceWith(actualValClone, this);
-
-    // Propagating a constant may create an opportunity to use a division by constant optimization
+    //------------------------------------------------------------------------------
+    // getArrayLengthFromAllocation: Return the array length for an array allocation
+    //                               helper call.
     //
-    if ((tree->gtNext != nullptr) && tree->gtNext->OperIsBinary())
+    // Arguments:
+    //    tree           - The array allocation helper call.
+    //    block          - tree's basic block.
+    //
+    // Return Value:
+    //    Return the array length node.
+
+    GenTree* getArrayLengthFromAllocation(GenTree* tree DEBUGARG(BasicBlock* block))
     {
-        // We need to mark the parent divide/mod operation when this occurs
-        tree->gtNext->AsOp()->CheckDivideByConstOptimized(this);
-    }
+        assert(tree != nullptr);
 
-#ifdef DEBUG
-    if (verbose)
-    {
-        printf("to\n");
-        gtDispStmt(compCurStmt);
-        printf("\n");
-    }
-#endif
-    return tree;
-}
+        GenTree* arrayLength = nullptr;
 
-GenTree* Compiler::optPropGetValue(GenTreeLclVar* lclVar)
-{
-    return optPropGetValueRec(lclVar, 0);
-}
-
-GenTree* Compiler::optPropGetValueRec(GenTreeLclVar* lclVar, int walkDepth)
-{
-    unsigned ssaNum = lclVar->GetSsaNum();
-
-    if (ssaNum == SsaConfig::RESERVED_SSA_NUM)
-    {
-        return nullptr;
-    }
-
-    // Bound the recursion with a hard limit.
-    if (walkDepth > optEarlyPropRecurBound)
-    {
-        return nullptr;
-    }
-
-    // Track along the use-def chain to get the array length
-    LclSsaVarDsc* ssaVarDsc = lvaGetDesc(lclVar)->GetPerSsaData(ssaNum);
-    GenTreeOp*    ssaDefAsg = ssaVarDsc->GetAssignment();
-
-    if (ssaDefAsg == nullptr)
-    {
-        // Incoming parameters or live-in variables don't have actual definition tree node
-        // for their FIRST_SSA_NUM. See SsaBuilder::RenameVariables.
-        assert(ssaNum == SsaConfig::FIRST_SSA_NUM);
-        return nullptr;
-    }
-
-    assert(ssaDefAsg->OperIs(GT_ASG));
-
-    GenTree* treeRhs = ssaDefAsg->gtGetOp2();
-
-    if (treeRhs->OperIs(GT_LCL_VAR) && lvaInSsa(treeRhs->AsLclVar()->GetLclNum()) && treeRhs->AsLclVar()->HasSsaName())
-    {
-        return optPropGetValueRec(treeRhs->AsLclVar(), walkDepth + 1);
-    }
-
-    GenTree* value = getArrayLengthFromAllocation(treeRhs DEBUGARG(ssaVarDsc->GetBlock()));
-    if ((value != nullptr) && !value->IsCnsIntOrI())
-    {
-        // Leave out non-constant-sized array
-        value = nullptr;
-    }
-
-    return value;
-}
-
-//----------------------------------------------------------------
-// optFoldNullChecks: Try to find a GT_NULLCHECK node that can be folded into the indirection node mark it for removal
-// if possible.
-//
-// Arguments:
-//    tree           - The input indirection tree.
-//    nullCheckMap   - Map of the local numbers to the latest NULLCHECKs on those locals in the current basic block
-//
-// Notes:
-//    If a GT_NULLCHECK node is post-dominated by an indirection node on the same local and the trees between
-//    the GT_NULLCHECK and the indirection don't have unsafe side effects, the GT_NULLCHECK can be removed.
-//    The indir will cause a NullReferenceException if and only if GT_NULLCHECK will cause the same
-//    NullReferenceException.
-
-void Compiler::optFoldNullCheck(GenTree* tree, LocalNumberToNullCheckTreeMap* nullCheckMap)
-{
-#ifdef DEBUG
-    if (tree->OperGet() == GT_NULLCHECK)
-    {
-        optCheckFlagsAreSet(OMF_HAS_NULLCHECK, "OMF_HAS_NULLCHECK", BBF_HAS_NULLCHECK, "BBF_HAS_NULLCHECK", tree,
-                            compCurBB);
-    }
-#else
-    if ((compCurBB->bbFlags & BBF_HAS_NULLCHECK) == 0)
-    {
-        return;
-    }
-#endif
-
-    GenTree*   nullCheckTree   = optFindNullCheckToFold(tree, nullCheckMap);
-    GenTree*   nullCheckParent = nullptr;
-    Statement* nullCheckStmt   = nullptr;
-    if ((nullCheckTree != nullptr) && optIsNullCheckFoldingLegal(tree, nullCheckTree, &nullCheckParent, &nullCheckStmt))
-    {
-#ifdef DEBUG
-        // Make sure the transformation happens in debug, check, and release build.
-        assert(optDoEarlyPropForFunc() && optDoEarlyPropForBlock(compCurBB) &&
-               (compCurBB->bbFlags & BBF_HAS_NULLCHECK) != 0);
-        if (verbose)
+        if (tree->OperGet() == GT_CALL)
         {
-            printf("optEarlyProp Marking a null check for removal\n");
-            gtDispTree(nullCheckTree);
+            GenTreeCall* call = tree->AsCall();
+
+            if (call->gtCallType == CT_HELPER)
+            {
+                if (call->gtCallMethHnd == Compiler::eeFindHelper(CORINFO_HELP_NEWARR_1_DIRECT) ||
+                    call->gtCallMethHnd == Compiler::eeFindHelper(CORINFO_HELP_NEWARR_1_OBJ) ||
+                    call->gtCallMethHnd == Compiler::eeFindHelper(CORINFO_HELP_NEWARR_1_VC) ||
+                    call->gtCallMethHnd == Compiler::eeFindHelper(CORINFO_HELP_NEWARR_1_ALIGN8))
+                {
+                    // This is an array allocation site. Grab the array length node.
+                    arrayLength = call->GetArgNodeByArgNum(1);
+                }
+                else if (call->gtCallMethHnd == Compiler::eeFindHelper(CORINFO_HELP_READYTORUN_NEWARR_1))
+                {
+                    // On arm when compiling on certain platforms for ready to run, a handle will be
+                    // inserted before the length. To handle this case, we will grab the last argument
+                    // as that's always the length. See fgInitArgInfo for where the handle is inserted.
+                    arrayLength = call->GetArgNodeByArgNum(call->GetInfo()->GetArgCount() - 1);
+                }
+#ifdef DEBUG
+                if (arrayLength != nullptr)
+                {
+                    optCheckFlagsAreSet(OMF_HAS_NEWARRAY, "OMF_HAS_NEWARRAY", BBF_HAS_NEWARRAY, "BBF_HAS_NEWARRAY",
+                                        tree, block);
+                }
+#endif
+            }
+        }
+
+        return arrayLength;
+    }
+
+#ifdef DEBUG
+    //-----------------------------------------------------------------------------
+    // optCheckFlagsAreSet: Check that the method flag and the basic block flag are set.
+    //
+    // Arguments:
+    //    methodFlag           - The method flag to check.
+    //    methodFlagStr        - String representation of the method flag.
+    //    bbFlag               - The basic block flag to check.
+    //    bbFlagStr            - String representation of the basic block flag.
+    //    tree                 - Tree that makes the flags required.
+    //    basicBlock           - The basic block to check the flag on.
+
+    void optCheckFlagsAreSet(unsigned    methodFlag,
+                             const char* methodFlagStr,
+                             unsigned    bbFlag,
+                             const char* bbFlagStr,
+                             GenTree*    tree,
+                             BasicBlock* basicBlock)
+    {
+        if ((compiler->optMethodFlags & methodFlag) == 0)
+        {
+            printf("%s is not set on optMethodFlags but is required because of the following tree\n", methodFlagStr);
+            compiler->gtDispTree(tree);
+            assert(false);
+        }
+
+        if ((basicBlock->bbFlags & bbFlag) == 0)
+        {
+            printf("%s is not set on " FMT_BB " but is required because of the following tree \n", bbFlagStr,
+                   compiler->compCurBB->bbNum);
+            compiler->gtDispTree(tree);
+            assert(false);
+        }
+    }
+#endif
+
+    //------------------------------------------------------------------------------------------
+    // optEarlyProp: The entry point of the early value propagation.
+    //
+    // Notes:
+    //    This phase performs an SSA-based value propagation, including
+    //      1. Array length propagation.
+    //      2. Runtime type handle propagation.
+    //      3. Null check folding.
+    //
+    //    For array length propagation, a demand-driven SSA-based backwards tracking of constant
+    //    array lengths is performed at each array length reference site which is in form of a
+    //    GT_ARR_LENGTH node. When a GT_ARR_LENGTH node is seen, the array ref pointer which is
+    //    the only child node of the GT_ARR_LENGTH is tracked. This is only done for array ref
+    //    pointers that have valid SSA forms.The tracking is along SSA use-def chain and stops
+    //    at the original array allocation site where we can grab the array length. The
+    //    GT_ARR_LENGTH node will then be rewritten to a GT_CNS_INT node if the array length is
+    //    constant.
+    //
+    //    Similarly, the same algorithm also applies to rewriting a method table (also known as
+    //    vtable) reference site which is in form of GT_INDIR node. The base pointer, which is
+    //    an object reference pointer, is treated in the same way as an array reference pointer.
+    //
+    //    Null check folding tries to find GT_INDIR(obj + const) that GT_NULLCHECK(obj) can be folded into
+    //    and removed. Currently, the algorithm only matches GT_INDIR and GT_NULLCHECK in the same basic block.
+
+    void optEarlyProp()
+    {
+#ifdef DEBUG
+        if (compiler->verbose)
+        {
+            printf("*************** In optEarlyProp()\n");
+        }
+#else
+        if (!optDoEarlyPropForFunc())
+        {
+            return;
+        }
+#endif
+
+        assert(compiler->ssaForm);
+
+        for (BasicBlock* const block : compiler->Blocks())
+        {
+#ifndef DEBUG
+            if (!optDoEarlyPropForBlock(block))
+            {
+                continue;
+            }
+#endif
+
+            compiler->compCurBB = block;
+
+            CompAllocator                 allocator(compiler->getAllocator(CMK_EarlyProp));
+            LocalNumberToNullCheckTreeMap nullCheckMap(allocator);
+
+            for (Statement* stmt = block->firstStmt(); stmt != nullptr;)
+            {
+                // Preserve the next link before the propagation and morph.
+                Statement* next = stmt->GetNextStmt();
+
+                compiler->compCurStmt = stmt;
+
+                // Walk the stmt tree in linear order to rewrite any array length reference with a
+                // constant array length.
+                bool isRewritten = false;
+                for (GenTree* tree = stmt->GetTreeList(); tree != nullptr; tree = tree->gtNext)
+                {
+                    GenTree* rewrittenTree = optEarlyPropRewriteTree(tree, &nullCheckMap);
+                    if (rewrittenTree != nullptr)
+                    {
+                        compiler->gtUpdateSideEffects(stmt, rewrittenTree);
+                        isRewritten = true;
+                        tree        = rewrittenTree;
+                    }
+                }
+
+                // Update the evaluation order and the statement info if the stmt has been rewritten.
+                if (isRewritten)
+                {
+                    // Make sure the transformation happens in debug, check, and release build.
+                    assert(optDoEarlyPropForFunc() && optDoEarlyPropForBlock(block));
+                    compiler->gtSetStmtInfo(stmt);
+                    compiler->fgSetStmtSeq(stmt);
+                }
+
+                stmt = next;
+            }
+        }
+
+#ifdef DEBUG
+        if (compiler->verbose)
+        {
+            JITDUMP("\nAfter optEarlyProp:\n");
+            compiler->fgDispBasicBlocks(/*dumpTrees*/ true);
+        }
+#endif
+    }
+
+    //----------------------------------------------------------------
+    // optEarlyPropRewriteValue: Rewrite a tree to the actual value.
+    //
+    // Arguments:
+    //    tree           - The input tree node to be rewritten.
+    //    nullCheckMap   - Map of the local numbers to the latest NULLCHECKs on those locals in the current basic block.
+    //
+    // Return Value:
+    //    Return a new tree if the original tree was successfully rewritten.
+    //    The containing tree links are updated.
+    //
+    GenTree* optEarlyPropRewriteTree(GenTree* tree, LocalNumberToNullCheckTreeMap* nullCheckMap)
+    {
+        if (!tree->OperIsIndirOrArrLength())
+        {
+            return nullptr;
+        }
+
+        // optFoldNullCheck takes care of updating statement info if a null check is removed.
+        optFoldNullCheck(tree, nullCheckMap);
+
+        if (tree->OperGet() != GT_ARR_LENGTH)
+        {
+            return nullptr;
+        }
+
+        GenTree* objectRefPtr = tree->AsOp()->gtOp1;
+
+        if (!objectRefPtr->OperIs(GT_LCL_VAR) || !compiler->lvaInSsa(objectRefPtr->AsLclVar()->GetLclNum()))
+        {
+            return nullptr;
+        }
+
+        INDEBUG(optCheckFlagsAreSet(OMF_HAS_ARRAYREF, "OMF_HAS_ARRAYREF", BBF_HAS_IDX_LEN, "BBF_HAS_IDX_LEN", tree,
+                                    compiler->compCurBB));
+
+        GenTree* actualVal = optPropGetValue(objectRefPtr->AsLclVar());
+
+        if (actualVal == nullptr)
+        {
+            return nullptr;
+        }
+
+        assert(actualVal->IsCnsIntOrI() && !actualVal->AsIntCon()->IsIconHandle());
+        assert(actualVal->GetNodeSize() == TREE_NODE_SZ_SMALL);
+
+        ssize_t actualConstVal = actualVal->AsIntCon()->IconValue();
+
+        if ((actualConstVal < 0) || (actualConstVal > INT32_MAX))
+        {
+            // Don't propagate array lengths that are beyond the maximum value of a GT_ARR_LENGTH or negative.
+            // node. CORINFO_HELP_NEWARR_1_OBJ helper call allows to take a long integer as the
+            // array length argument, but the type of GT_ARR_LENGTH is always INT32.
+            return nullptr;
+        }
+
+        // When replacing GT_ARR_LENGTH nodes with constants we can end up with GT_ARR_BOUNDS_CHECK
+        // nodes that have constant operands and thus can be trivially proved to be useless. It's
+        // better to remove these range checks here, otherwise they'll pass through assertion prop
+        // (creating useless (c1 < c2)-like assertions) and reach RangeCheck where they are finally
+        // removed. Common patterns like new int[] { x, y, z } benefit from this.
+
+        if ((tree->gtNext != nullptr) && tree->gtNext->OperIs(GT_ARR_BOUNDS_CHECK))
+        {
+            GenTreeBoundsChk* check = tree->gtNext->AsBoundsChk();
+
+            if ((check->gtArrLen == tree) && check->gtIndex->IsCnsIntOrI())
+            {
+                ssize_t checkConstVal = check->gtIndex->AsIntCon()->IconValue();
+                if ((checkConstVal >= 0) && (checkConstVal < actualConstVal))
+                {
+                    GenTree* comma = check->FindUser();
+
+                    // We should never see cases other than these in the IR,
+                    // as the check node does not produce a value.
+                    assert(((comma != nullptr) && comma->OperIs(GT_COMMA) &&
+                            (comma->gtGetOp1() == check || comma->TypeIs(TYP_VOID))) ||
+                           (check == compiler->compCurStmt->GetRootNode()));
+
+                    // Still, we guard here so that release builds do not try to optimize trees we don't understand.
+                    if (((comma != nullptr) && comma->OperIs(GT_COMMA) && (comma->gtGetOp1() == check)) ||
+                        (check == compiler->compCurStmt->GetRootNode()))
+                    {
+                        // Both `tree` and `check` have been removed from the statement.
+                        // 'tree' was replaced with 'nop' or side effect list under 'comma'.
+                        // optRemoveRangeCheck returns this modified tree.
+                        return compiler->optRemoveRangeCheck(check, comma, compiler->compCurStmt);
+                    }
+                }
+            }
+        }
+
+#ifdef DEBUG
+        if (compiler->verbose)
+        {
+            printf("optEarlyProp Rewriting " FMT_BB "\n", compiler->compCurBB->bbNum);
+            compiler->gtDispStmt(compiler->compCurStmt);
             printf("\n");
         }
 #endif
-        // Remove the null check
-        nullCheckTree->gtFlags &= ~(GTF_EXCEPT | GTF_DONT_CSE);
 
-        // Set this flag to prevent reordering
-        nullCheckTree->gtFlags |= GTF_ORDER_SIDEEFF;
-        nullCheckTree->gtFlags |= GTF_IND_NONFAULTING;
+        GenTree* actualValClone = compiler->gtCloneExpr(actualVal);
 
-        if (nullCheckParent != nullptr)
+        if (actualValClone->gtType != tree->gtType)
         {
-            nullCheckParent->gtFlags &= ~GTF_DONT_CSE;
+            assert(actualValClone->gtType == TYP_LONG);
+            assert(tree->gtType == TYP_INT);
+            assert((actualConstVal >= 0) && (actualConstVal <= INT32_MAX));
+            actualValClone->gtType = tree->gtType;
         }
 
-        nullCheckMap->Remove(nullCheckTree->gtGetOp1()->AsLclVarCommon()->GetLclNum());
+        // actualValClone has small tree node size, it is safe to use CopyFrom here.
+        tree->ReplaceWith(actualValClone, compiler);
 
-        // Re-morph the statement.
-        Statement* curStmt = compCurStmt;
-        fgMorphBlockStmt(compCurBB, nullCheckStmt DEBUGARG("optFoldNullCheck"));
-        compCurStmt = curStmt;
-    }
-
-    if ((tree->OperGet() == GT_NULLCHECK) && (tree->gtGetOp1()->OperGet() == GT_LCL_VAR))
-    {
-        nullCheckMap->Set(tree->gtGetOp1()->AsLclVarCommon()->GetLclNum(), tree,
-                          LocalNumberToNullCheckTreeMap::SetKind::Overwrite);
-    }
-}
-
-//----------------------------------------------------------------
-// optFindNullCheckToFold: Try to find a GT_NULLCHECK node that can be folded into the indirection node.
-//
-// Arguments:
-//    tree           - The input indirection tree.
-//    nullCheckMap   - Map of the local numbers to the latest NULLCHECKs on those locals in the current basic block
-//
-// Notes:
-//    Check for cases where
-//    1. One of the following trees
-//
-//       nullcheck(x)
-//       or
-//       x = comma(nullcheck(y), add(y, const1))
-//
-//       is post-dominated in the same basic block by one of the following trees
-//
-//       indir(x)
-//       or
-//       indir(add(x, const2))
-//
-//       (indir is any node for which OperIsIndirOrArrLength() is true.)
-//
-//     2.  const1 + const2 if sufficiently small.
-
-GenTree* Compiler::optFindNullCheckToFold(GenTree* tree, LocalNumberToNullCheckTreeMap* nullCheckMap)
-{
-    assert(tree->OperIsIndirOrArrLength());
-
-    GenTree* addr = tree->IsArrLen() ? tree->AsArrLen()->GetArray() : tree->AsIndir()->GetAddr();
-
-    ssize_t offsetValue = 0;
-
-    if ((addr->OperGet() == GT_ADD) && addr->gtGetOp2()->IsCnsIntOrI())
-    {
-        offsetValue += addr->gtGetOp2()->AsIntConCommon()->IconValue();
-        addr = addr->gtGetOp1();
-    }
-
-    if (addr->OperGet() != GT_LCL_VAR)
-    {
-        return nullptr;
-    }
-
-    GenTreeLclVarCommon* const lclVarNode = addr->AsLclVarCommon();
-    const unsigned             ssaNum     = lclVarNode->GetSsaNum();
-
-    if (ssaNum == SsaConfig::RESERVED_SSA_NUM)
-    {
-        return nullptr;
-    }
-
-    const unsigned lclNum          = lclVarNode->GetLclNum();
-    GenTree*       nullCheckTree   = nullptr;
-    unsigned       nullCheckLclNum = BAD_VAR_NUM;
-
-    // Check if we saw a nullcheck on this local in this basic block
-    // This corresponds to nullcheck(x) tree in the header comment.
-    if (nullCheckMap->Lookup(lclNum, &nullCheckTree))
-    {
-        GenTree* nullCheckAddr = nullCheckTree->AsIndir()->Addr();
-        if ((nullCheckAddr->OperGet() != GT_LCL_VAR) || (nullCheckAddr->AsLclVarCommon()->GetSsaNum() != ssaNum))
+        // Propagating a constant may create an opportunity to use a division by constant optimization
+        //
+        if ((tree->gtNext != nullptr) && tree->gtNext->OperIsBinary())
         {
-            nullCheckTree = nullptr;
+            // We need to mark the parent divide/mod operation when this occurs
+            tree->gtNext->AsOp()->CheckDivideByConstOptimized(compiler);
+        }
+
+#ifdef DEBUG
+        if (compiler->verbose)
+        {
+            printf("to\n");
+            compiler->gtDispStmt(compiler->compCurStmt);
+            printf("\n");
+        }
+#endif
+        return tree;
+    }
+
+    GenTree* optPropGetValue(GenTreeLclVar* lclVar)
+    {
+        return optPropGetValueRec(lclVar, 0);
+    }
+
+    GenTree* optPropGetValueRec(GenTreeLclVar* lclVar, int walkDepth)
+    {
+        unsigned ssaNum = lclVar->GetSsaNum();
+
+        if (ssaNum == SsaConfig::RESERVED_SSA_NUM)
+        {
+            return nullptr;
+        }
+
+        // Bound the recursion with a hard limit.
+        if (walkDepth > optEarlyPropRecurBound)
+        {
+            return nullptr;
+        }
+
+        // Track along the use-def chain to get the array length
+        LclSsaVarDsc* ssaVarDsc = compiler->lvaGetDesc(lclVar)->GetPerSsaData(ssaNum);
+        GenTreeOp*    ssaDefAsg = ssaVarDsc->GetAssignment();
+
+        if (ssaDefAsg == nullptr)
+        {
+            // Incoming parameters or live-in variables don't have actual definition tree node
+            // for their FIRST_SSA_NUM. See SsaBuilder::RenameVariables.
+            assert(ssaNum == SsaConfig::FIRST_SSA_NUM);
+            return nullptr;
+        }
+
+        assert(ssaDefAsg->OperIs(GT_ASG));
+
+        GenTree* treeRhs = ssaDefAsg->gtGetOp2();
+
+        if (treeRhs->OperIs(GT_LCL_VAR) && compiler->lvaInSsa(treeRhs->AsLclVar()->GetLclNum()) &&
+            treeRhs->AsLclVar()->HasSsaName())
+        {
+            return optPropGetValueRec(treeRhs->AsLclVar(), walkDepth + 1);
+        }
+
+        GenTree* value = getArrayLengthFromAllocation(treeRhs DEBUGARG(ssaVarDsc->GetBlock()));
+        if ((value != nullptr) && !value->IsCnsIntOrI())
+        {
+            // Leave out non-constant-sized array
+            value = nullptr;
+        }
+
+        return value;
+    }
+
+    //----------------------------------------------------------------
+    // optFoldNullChecks: Try to find a GT_NULLCHECK node that can be folded into the indirection node mark it for
+    // removal
+    // if possible.
+    //
+    // Arguments:
+    //    tree           - The input indirection tree.
+    //    nullCheckMap   - Map of the local numbers to the latest NULLCHECKs on those locals in the current basic block
+    //
+    // Notes:
+    //    If a GT_NULLCHECK node is post-dominated by an indirection node on the same local and the trees between
+    //    the GT_NULLCHECK and the indirection don't have unsafe side effects, the GT_NULLCHECK can be removed.
+    //    The indir will cause a NullReferenceException if and only if GT_NULLCHECK will cause the same
+    //    NullReferenceException.
+
+    void optFoldNullCheck(GenTree* tree, LocalNumberToNullCheckTreeMap* nullCheckMap)
+    {
+#ifdef DEBUG
+        if (tree->OperGet() == GT_NULLCHECK)
+        {
+            optCheckFlagsAreSet(OMF_HAS_NULLCHECK, "OMF_HAS_NULLCHECK", BBF_HAS_NULLCHECK, "BBF_HAS_NULLCHECK", tree,
+                                compiler->compCurBB);
+        }
+#else
+        if ((compiler->compCurBB->bbFlags & BBF_HAS_NULLCHECK) == 0)
+        {
+            return;
+        }
+#endif
+
+        GenTree*   nullCheckTree   = optFindNullCheckToFold(tree, nullCheckMap);
+        GenTree*   nullCheckParent = nullptr;
+        Statement* nullCheckStmt   = nullptr;
+        if ((nullCheckTree != nullptr) &&
+            optIsNullCheckFoldingLegal(tree, nullCheckTree, &nullCheckParent, &nullCheckStmt))
+        {
+#ifdef DEBUG
+            // Make sure the transformation happens in debug, check, and release build.
+            assert(optDoEarlyPropForFunc() && optDoEarlyPropForBlock(compiler->compCurBB) &&
+                   (compiler->compCurBB->bbFlags & BBF_HAS_NULLCHECK) != 0);
+            if (compiler->verbose)
+            {
+                printf("optEarlyProp Marking a null check for removal\n");
+                compiler->gtDispTree(nullCheckTree);
+                printf("\n");
+            }
+#endif
+            // Remove the null check
+            nullCheckTree->gtFlags &= ~(GTF_EXCEPT | GTF_DONT_CSE);
+
+            // Set this flag to prevent reordering
+            nullCheckTree->gtFlags |= GTF_ORDER_SIDEEFF;
+            nullCheckTree->gtFlags |= GTF_IND_NONFAULTING;
+
+            if (nullCheckParent != nullptr)
+            {
+                nullCheckParent->gtFlags &= ~GTF_DONT_CSE;
+            }
+
+            nullCheckMap->Remove(nullCheckTree->gtGetOp1()->AsLclVarCommon()->GetLclNum());
+
+            // Re-morph the statement.
+            Statement* curStmt = compiler->compCurStmt;
+            compiler->fgMorphBlockStmt(compiler->compCurBB, nullCheckStmt DEBUGARG("optFoldNullCheck"));
+            compiler->compCurStmt = curStmt;
+        }
+
+        if ((tree->OperGet() == GT_NULLCHECK) && (tree->gtGetOp1()->OperGet() == GT_LCL_VAR))
+        {
+            nullCheckMap->Set(tree->gtGetOp1()->AsLclVarCommon()->GetLclNum(), tree,
+                              LocalNumberToNullCheckTreeMap::SetKind::Overwrite);
+        }
+    }
+
+    //----------------------------------------------------------------
+    // optFindNullCheckToFold: Try to find a GT_NULLCHECK node that can be folded into the indirection node.
+    //
+    // Arguments:
+    //    tree           - The input indirection tree.
+    //    nullCheckMap   - Map of the local numbers to the latest NULLCHECKs on those locals in the current basic block
+    //
+    // Notes:
+    //    Check for cases where
+    //    1. One of the following trees
+    //
+    //       nullcheck(x)
+    //       or
+    //       x = comma(nullcheck(y), add(y, const1))
+    //
+    //       is post-dominated in the same basic block by one of the following trees
+    //
+    //       indir(x)
+    //       or
+    //       indir(add(x, const2))
+    //
+    //       (indir is any node for which OperIsIndirOrArrLength() is true.)
+    //
+    //     2.  const1 + const2 if sufficiently small.
+
+    GenTree* optFindNullCheckToFold(GenTree* tree, LocalNumberToNullCheckTreeMap* nullCheckMap)
+    {
+        assert(tree->OperIsIndirOrArrLength());
+
+        GenTree* addr = tree->IsArrLen() ? tree->AsArrLen()->GetArray() : tree->AsIndir()->GetAddr();
+
+        ssize_t offsetValue = 0;
+
+        if ((addr->OperGet() == GT_ADD) && addr->gtGetOp2()->IsCnsIntOrI())
+        {
+            offsetValue += addr->gtGetOp2()->AsIntConCommon()->IconValue();
+            addr = addr->gtGetOp1();
+        }
+
+        if (addr->OperGet() != GT_LCL_VAR)
+        {
+            return nullptr;
+        }
+
+        GenTreeLclVarCommon* const lclVarNode = addr->AsLclVarCommon();
+        const unsigned             ssaNum     = lclVarNode->GetSsaNum();
+
+        if (ssaNum == SsaConfig::RESERVED_SSA_NUM)
+        {
+            return nullptr;
+        }
+
+        const unsigned lclNum          = lclVarNode->GetLclNum();
+        GenTree*       nullCheckTree   = nullptr;
+        unsigned       nullCheckLclNum = BAD_VAR_NUM;
+
+        // Check if we saw a nullcheck on this local in this basic block
+        // This corresponds to nullcheck(x) tree in the header comment.
+        if (nullCheckMap->Lookup(lclNum, &nullCheckTree))
+        {
+            GenTree* nullCheckAddr = nullCheckTree->AsIndir()->Addr();
+            if ((nullCheckAddr->OperGet() != GT_LCL_VAR) || (nullCheckAddr->AsLclVarCommon()->GetSsaNum() != ssaNum))
+            {
+                nullCheckTree = nullptr;
+            }
+            else
+            {
+                nullCheckLclNum = nullCheckAddr->AsLclVarCommon()->GetLclNum();
+            }
+        }
+
+        if (nullCheckTree == nullptr)
+        {
+            // Check if we have x = comma(nullcheck(y), add(y, const1)) pattern.
+
+            // Find the definition of the indirected local ('x' in the pattern above).
+            LclSsaVarDsc* defLoc = compiler->lvaTable[lclNum].GetPerSsaData(ssaNum);
+
+            if (compiler->compCurBB != defLoc->GetBlock())
+            {
+                return nullptr;
+            }
+
+            GenTree* defRHS = defLoc->GetAssignment()->gtGetOp2();
+
+            if (defRHS->OperGet() != GT_COMMA)
+            {
+                return nullptr;
+            }
+
+            GenTree* commaOp1EffectiveValue = defRHS->gtGetOp1()->SkipComma();
+
+            if (commaOp1EffectiveValue->OperGet() != GT_NULLCHECK)
+            {
+                return nullptr;
+            }
+
+            GenTree* nullCheckAddress = commaOp1EffectiveValue->gtGetOp1();
+
+            if ((nullCheckAddress->OperGet() != GT_LCL_VAR) || (defRHS->gtGetOp2()->OperGet() != GT_ADD))
+            {
+                return nullptr;
+            }
+
+            // We found a candidate for 'y' in the pattern above.
+
+            GenTree* additionNode = defRHS->gtGetOp2();
+            GenTree* additionOp1  = additionNode->gtGetOp1();
+            GenTree* additionOp2  = additionNode->gtGetOp2();
+            if ((additionOp1->OperGet() == GT_LCL_VAR) &&
+                (additionOp1->AsLclVarCommon()->GetLclNum() == nullCheckAddress->AsLclVarCommon()->GetLclNum()) &&
+                (additionOp2->IsCnsIntOrI()))
+            {
+                offsetValue += additionOp2->AsIntConCommon()->IconValue();
+                nullCheckTree = commaOp1EffectiveValue;
+            }
+        }
+
+        if (compiler->fgIsBigOffset(offsetValue))
+        {
+            return nullptr;
         }
         else
         {
-            nullCheckLclNum = nullCheckAddr->AsLclVarCommon()->GetLclNum();
+            return nullCheckTree;
         }
     }
 
-    if (nullCheckTree == nullptr)
+    //----------------------------------------------------------------
+    // optIsNullCheckFoldingLegal: Check the nodes between the GT_NULLCHECK node and the indirection to determine
+    //                             if null check folding is legal.
+    //
+    // Arguments:
+    //    tree                - The input indirection tree.
+    //    nullCheckTree       - The GT_NULLCHECK tree that is a candidate for removal.
+    //    nullCheckParent     - The parent of the GT_NULLCHECK tree that is a candidate for removal (out-parameter).
+    //    nullCheckStatement  - The statement of the GT_NULLCHECK tree that is a candidate for removal (out-parameter).
+
+    bool optIsNullCheckFoldingLegal(GenTree*    tree,
+                                    GenTree*    nullCheckTree,
+                                    GenTree**   nullCheckParent,
+                                    Statement** nullCheckStmt)
     {
-        // Check if we have x = comma(nullcheck(y), add(y, const1)) pattern.
+        // Check all nodes between the GT_NULLCHECK and the indirection to see
+        // if any nodes have unsafe side effects.
+        unsigned       nullCheckLclNum    = nullCheckTree->gtGetOp1()->AsLclVarCommon()->GetLclNum();
+        bool           isInsideTry        = compiler->compCurBB->hasTryIndex();
+        bool           canRemoveNullCheck = true;
+        const unsigned maxNodesWalked     = 50;
+        unsigned       nodesWalked        = 0;
 
-        // Find the definition of the indirected local ('x' in the pattern above).
-        LclSsaVarDsc* defLoc = lvaTable[lclNum].GetPerSsaData(ssaNum);
-
-        if (compCurBB != defLoc->GetBlock())
+        // First walk the nodes in the statement containing the GT_NULLCHECK in forward execution order
+        // until we get to the indirection or process the statement root.
+        GenTree* previousTree = nullCheckTree;
+        GenTree* currentTree  = nullCheckTree->gtNext;
+        while (canRemoveNullCheck && (currentTree != tree) && (currentTree != nullptr))
         {
-            return nullptr;
-        }
-
-        GenTree* defRHS = defLoc->GetAssignment()->gtGetOp2();
-
-        if (defRHS->OperGet() != GT_COMMA)
-        {
-            return nullptr;
-        }
-
-        GenTree* commaOp1EffectiveValue = defRHS->gtGetOp1()->SkipComma();
-
-        if (commaOp1EffectiveValue->OperGet() != GT_NULLCHECK)
-        {
-            return nullptr;
-        }
-
-        GenTree* nullCheckAddress = commaOp1EffectiveValue->gtGetOp1();
-
-        if ((nullCheckAddress->OperGet() != GT_LCL_VAR) || (defRHS->gtGetOp2()->OperGet() != GT_ADD))
-        {
-            return nullptr;
-        }
-
-        // We found a candidate for 'y' in the pattern above.
-
-        GenTree* additionNode = defRHS->gtGetOp2();
-        GenTree* additionOp1  = additionNode->gtGetOp1();
-        GenTree* additionOp2  = additionNode->gtGetOp2();
-        if ((additionOp1->OperGet() == GT_LCL_VAR) &&
-            (additionOp1->AsLclVarCommon()->GetLclNum() == nullCheckAddress->AsLclVarCommon()->GetLclNum()) &&
-            (additionOp2->IsCnsIntOrI()))
-        {
-            offsetValue += additionOp2->AsIntConCommon()->IconValue();
-            nullCheckTree = commaOp1EffectiveValue;
-        }
-    }
-
-    if (fgIsBigOffset(offsetValue))
-    {
-        return nullptr;
-    }
-    else
-    {
-        return nullCheckTree;
-    }
-}
-
-//----------------------------------------------------------------
-// optIsNullCheckFoldingLegal: Check the nodes between the GT_NULLCHECK node and the indirection to determine
-//                             if null check folding is legal.
-//
-// Arguments:
-//    tree                - The input indirection tree.
-//    nullCheckTree       - The GT_NULLCHECK tree that is a candidate for removal.
-//    nullCheckParent     - The parent of the GT_NULLCHECK tree that is a candidate for removal (out-parameter).
-//    nullCheckStatement  - The statement of the GT_NULLCHECK tree that is a candidate for removal (out-parameter).
-
-bool Compiler::optIsNullCheckFoldingLegal(GenTree*    tree,
-                                          GenTree*    nullCheckTree,
-                                          GenTree**   nullCheckParent,
-                                          Statement** nullCheckStmt)
-{
-    // Check all nodes between the GT_NULLCHECK and the indirection to see
-    // if any nodes have unsafe side effects.
-    unsigned       nullCheckLclNum    = nullCheckTree->gtGetOp1()->AsLclVarCommon()->GetLclNum();
-    bool           isInsideTry        = compCurBB->hasTryIndex();
-    bool           canRemoveNullCheck = true;
-    const unsigned maxNodesWalked     = 50;
-    unsigned       nodesWalked        = 0;
-
-    // First walk the nodes in the statement containing the GT_NULLCHECK in forward execution order
-    // until we get to the indirection or process the statement root.
-    GenTree* previousTree = nullCheckTree;
-    GenTree* currentTree  = nullCheckTree->gtNext;
-    assert(fgStmtListThreaded);
-    while (canRemoveNullCheck && (currentTree != tree) && (currentTree != nullptr))
-    {
-        if ((*nullCheckParent == nullptr) && (currentTree->FindUse(nullCheckTree) != nullptr))
-        {
-            *nullCheckParent = currentTree;
-        }
-        const bool checkExceptionSummary = false;
-        if ((nodesWalked++ > maxNodesWalked) ||
-            !optCanMoveNullCheckPastTree(currentTree, nullCheckLclNum, isInsideTry, checkExceptionSummary))
-        {
-            canRemoveNullCheck = false;
-        }
-        else
-        {
-            previousTree = currentTree;
-            currentTree  = currentTree->gtNext;
-        }
-    }
-
-    if (currentTree == tree)
-    {
-        // The GT_NULLCHECK and the indirection are in the same statements.
-        *nullCheckStmt = compCurStmt;
-    }
-    else
-    {
-        // The GT_NULLCHECK and the indirection are in different statements.
-        // Walk the nodes in the statement containing the indirection
-        // in reverse execution order starting with the indirection's
-        // predecessor.
-        GenTree* nullCheckStatementRoot = previousTree;
-        currentTree                     = tree->gtPrev;
-        while (canRemoveNullCheck && (currentTree != nullptr))
-        {
+            if ((*nullCheckParent == nullptr) && (currentTree->FindUse(nullCheckTree) != nullptr))
+            {
+                *nullCheckParent = currentTree;
+            }
             const bool checkExceptionSummary = false;
             if ((nodesWalked++ > maxNodesWalked) ||
                 !optCanMoveNullCheckPastTree(currentTree, nullCheckLclNum, isInsideTry, checkExceptionSummary))
@@ -668,103 +662,138 @@ bool Compiler::optIsNullCheckFoldingLegal(GenTree*    tree,
             }
             else
             {
-                currentTree = currentTree->gtPrev;
+                previousTree = currentTree;
+                currentTree  = currentTree->gtNext;
             }
         }
 
-        // Finally, walk the statement list in reverse execution order
-        // until we get to the statement containing the null check.
-        // We only check the side effects at the root of each statement.
-        Statement* curStmt = compCurStmt->GetPrevStmt();
-        currentTree        = curStmt->GetRootNode();
-        while (canRemoveNullCheck && (currentTree != nullCheckStatementRoot))
+        if (currentTree == tree)
         {
-            const bool checkExceptionSummary = true;
-            if ((nodesWalked++ > maxNodesWalked) ||
-                !optCanMoveNullCheckPastTree(currentTree, nullCheckLclNum, isInsideTry, checkExceptionSummary))
-            {
-                canRemoveNullCheck = false;
-            }
-            else
-            {
-                curStmt     = curStmt->GetPrevStmt();
-                currentTree = curStmt->GetRootNode();
-            }
-        }
-        *nullCheckStmt = curStmt;
-    }
-
-    if (canRemoveNullCheck && (*nullCheckParent == nullptr))
-    {
-        *nullCheckParent = nullCheckTree->FindUser();
-    }
-
-    return canRemoveNullCheck;
-}
-
-//----------------------------------------------------------------
-// optCanMoveNullCheckPastTree: Check if a nullcheck node that is before `tree`
-//                              in execution order may be folded into an indirection node that
-//                              is after `tree` is execution order.
-//
-// Arguments:
-//    tree                  - The tree to check.
-//    nullCheckLclNum       - The local variable that GT_NULLCHECK checks.
-//    isInsideTry           - True if tree is inside try, false otherwise.
-//    checkSideEffectSummary -If true, check side effect summary flags only,
-//                            otherwise check the side effects of the operation itself.
-//
-// Return Value:
-//    True if nullcheck may be folded into a node that is after tree in execution order,
-//    false otherwise.
-
-bool Compiler::optCanMoveNullCheckPastTree(GenTree* tree,
-                                           unsigned nullCheckLclNum,
-                                           bool     isInsideTry,
-                                           bool     checkSideEffectSummary)
-{
-    bool result = true;
-
-    if ((tree->gtFlags & GTF_CALL) != 0)
-    {
-        result = !checkSideEffectSummary && !tree->OperRequiresCallFlag(this);
-    }
-
-    if (result && (tree->gtFlags & GTF_EXCEPT) != 0)
-    {
-        result = !checkSideEffectSummary && !tree->OperMayThrow(this);
-    }
-
-    if (result && ((tree->gtFlags & GTF_ASG) != 0))
-    {
-        if (tree->OperGet() == GT_ASG)
-        {
-            GenTree* lhs = tree->gtGetOp1();
-            GenTree* rhs = tree->gtGetOp2();
-            if (checkSideEffectSummary && ((rhs->gtFlags & GTF_ASG) != 0))
-            {
-                result = false;
-            }
-            else if (isInsideTry)
-            {
-                // Inside try we allow only assignments to locals not live in handlers.
-                result = lhs->OperIs(GT_LCL_VAR) && !lvaGetDesc(lhs->AsLclVar())->lvEHLive;
-            }
-            else
-            {
-                // We disallow only assignments to global memory.
-                result = ((lhs->gtFlags & GTF_GLOB_REF) == 0);
-            }
-        }
-        else if (checkSideEffectSummary)
-        {
-            result = !isInsideTry && ((tree->gtFlags & GTF_GLOB_REF) == 0);
+            // The GT_NULLCHECK and the indirection are in the same statements.
+            *nullCheckStmt = compiler->compCurStmt;
         }
         else
         {
-            result = !isInsideTry && (!tree->OperRequiresAsgFlag() || ((tree->gtFlags & GTF_GLOB_REF) == 0));
+            // The GT_NULLCHECK and the indirection are in different statements.
+            // Walk the nodes in the statement containing the indirection
+            // in reverse execution order starting with the indirection's
+            // predecessor.
+            GenTree* nullCheckStatementRoot = previousTree;
+            currentTree                     = tree->gtPrev;
+            while (canRemoveNullCheck && (currentTree != nullptr))
+            {
+                const bool checkExceptionSummary = false;
+                if ((nodesWalked++ > maxNodesWalked) ||
+                    !optCanMoveNullCheckPastTree(currentTree, nullCheckLclNum, isInsideTry, checkExceptionSummary))
+                {
+                    canRemoveNullCheck = false;
+                }
+                else
+                {
+                    currentTree = currentTree->gtPrev;
+                }
+            }
+
+            // Finally, walk the statement list in reverse execution order
+            // until we get to the statement containing the null check.
+            // We only check the side effects at the root of each statement.
+            Statement* curStmt = compiler->compCurStmt->GetPrevStmt();
+            currentTree        = curStmt->GetRootNode();
+            while (canRemoveNullCheck && (currentTree != nullCheckStatementRoot))
+            {
+                const bool checkExceptionSummary = true;
+                if ((nodesWalked++ > maxNodesWalked) ||
+                    !optCanMoveNullCheckPastTree(currentTree, nullCheckLclNum, isInsideTry, checkExceptionSummary))
+                {
+                    canRemoveNullCheck = false;
+                }
+                else
+                {
+                    curStmt     = curStmt->GetPrevStmt();
+                    currentTree = curStmt->GetRootNode();
+                }
+            }
+            *nullCheckStmt = curStmt;
         }
+
+        if (canRemoveNullCheck && (*nullCheckParent == nullptr))
+        {
+            *nullCheckParent = nullCheckTree->FindUser();
+        }
+
+        return canRemoveNullCheck;
     }
 
-    return result;
+    //----------------------------------------------------------------
+    // optCanMoveNullCheckPastTree: Check if a nullcheck node that is before `tree`
+    //                              in execution order may be folded into an indirection node that
+    //                              is after `tree` is execution order.
+    //
+    // Arguments:
+    //    tree                  - The tree to check.
+    //    nullCheckLclNum       - The local variable that GT_NULLCHECK checks.
+    //    isInsideTry           - True if tree is inside try, false otherwise.
+    //    checkSideEffectSummary -If true, check side effect summary flags only,
+    //                            otherwise check the side effects of the operation itself.
+    //
+    // Return Value:
+    //    True if nullcheck may be folded into a node that is after tree in execution order,
+    //    false otherwise.
+
+    bool optCanMoveNullCheckPastTree(GenTree* tree,
+                                     unsigned nullCheckLclNum,
+                                     bool     isInsideTry,
+                                     bool     checkSideEffectSummary)
+    {
+        bool result = true;
+
+        if ((tree->gtFlags & GTF_CALL) != 0)
+        {
+            result = !checkSideEffectSummary && !tree->OperRequiresCallFlag(compiler);
+        }
+
+        if (result && (tree->gtFlags & GTF_EXCEPT) != 0)
+        {
+            result = !checkSideEffectSummary && !tree->OperMayThrow(compiler);
+        }
+
+        if (result && ((tree->gtFlags & GTF_ASG) != 0))
+        {
+            if (tree->OperGet() == GT_ASG)
+            {
+                GenTree* lhs = tree->gtGetOp1();
+                GenTree* rhs = tree->gtGetOp2();
+                if (checkSideEffectSummary && ((rhs->gtFlags & GTF_ASG) != 0))
+                {
+                    result = false;
+                }
+                else if (isInsideTry)
+                {
+                    // Inside try we allow only assignments to locals not live in handlers.
+                    result = lhs->OperIs(GT_LCL_VAR) && !compiler->lvaGetDesc(lhs->AsLclVar())->lvEHLive;
+                }
+                else
+                {
+                    // We disallow only assignments to global memory.
+                    result = ((lhs->gtFlags & GTF_GLOB_REF) == 0);
+                }
+            }
+            else if (checkSideEffectSummary)
+            {
+                result = !isInsideTry && ((tree->gtFlags & GTF_GLOB_REF) == 0);
+            }
+            else
+            {
+                result = !isInsideTry && (!tree->OperRequiresAsgFlag() || ((tree->gtFlags & GTF_GLOB_REF) == 0));
+            }
+        }
+
+        return result;
+    }
+};
+
+void Compiler::optEarlyProp()
+{
+    EarlyProp prop(this);
+    prop.Run();
 }

--- a/src/coreclr/jit/earlyprop.cpp
+++ b/src/coreclr/jit/earlyprop.cpp
@@ -593,7 +593,6 @@ private:
     {
         // Check all nodes between the GT_NULLCHECK and the indirection to see
         // if any nodes have unsafe side effects.
-        unsigned       nullCheckLclNum    = nullCheckTree->gtGetOp1()->AsLclVarCommon()->GetLclNum();
         bool           isInsideTry        = compiler->compCurBB->hasTryIndex();
         bool           canRemoveNullCheck = true;
         const unsigned maxNodesWalked     = 50;
@@ -611,7 +610,7 @@ private:
             }
             const bool checkExceptionSummary = false;
             if ((nodesWalked++ > maxNodesWalked) ||
-                !CanMoveNullCheckPastTree(currentTree, nullCheckLclNum, isInsideTry, checkExceptionSummary))
+                !CanMoveNullCheckPastTree(currentTree, isInsideTry, checkExceptionSummary))
             {
                 canRemoveNullCheck = false;
             }
@@ -639,7 +638,7 @@ private:
             {
                 const bool checkExceptionSummary = false;
                 if ((nodesWalked++ > maxNodesWalked) ||
-                    !CanMoveNullCheckPastTree(currentTree, nullCheckLclNum, isInsideTry, checkExceptionSummary))
+                    !CanMoveNullCheckPastTree(currentTree, isInsideTry, checkExceptionSummary))
                 {
                     canRemoveNullCheck = false;
                 }
@@ -658,7 +657,7 @@ private:
             {
                 const bool checkExceptionSummary = true;
                 if ((nodesWalked++ > maxNodesWalked) ||
-                    !CanMoveNullCheckPastTree(currentTree, nullCheckLclNum, isInsideTry, checkExceptionSummary))
+                    !CanMoveNullCheckPastTree(currentTree, isInsideTry, checkExceptionSummary))
                 {
                     canRemoveNullCheck = false;
                 }
@@ -686,7 +685,6 @@ private:
     //
     // Arguments:
     //    tree                  - The tree to check.
-    //    nullCheckLclNum       - The local variable that GT_NULLCHECK checks.
     //    isInsideTry           - True if tree is inside try, false otherwise.
     //    checkSideEffectSummary -If true, check side effect summary flags only,
     //                            otherwise check the side effects of the operation itself.
@@ -695,10 +693,7 @@ private:
     //    True if nullcheck may be folded into a node that is after tree in execution order,
     //    false otherwise.
 
-    bool CanMoveNullCheckPastTree(GenTree* tree,
-                                  unsigned nullCheckLclNum,
-                                  bool     isInsideTry,
-                                  bool     checkSideEffectSummary)
+    bool CanMoveNullCheckPastTree(GenTree* tree, bool isInsideTry, bool checkSideEffectSummary)
     {
         bool result = true;
 

--- a/src/coreclr/jit/earlyprop.cpp
+++ b/src/coreclr/jit/earlyprop.cpp
@@ -253,10 +253,15 @@ private:
             return nullptr;
         }
 
-        assert(actualVal->IsCnsIntOrI() && !actualVal->AsIntCon()->IsIconHandle());
+        return PropagateConstArrayLength(tree->AsArrLen(), actualVal->AsIntCon());
+    }
+
+    GenTree* PropagateConstArrayLength(GenTreeArrLen* tree, GenTreeIntCon* actualVal)
+    {
+        assert(!actualVal->IsIconHandle());
         assert(actualVal->GetNodeSize() == TREE_NODE_SZ_SMALL);
 
-        ssize_t actualConstVal = actualVal->AsIntCon()->IconValue();
+        ssize_t actualConstVal = actualVal->IconValue();
 
         if ((actualConstVal < 0) || (actualConstVal > INT32_MAX))
         {

--- a/src/coreclr/jit/earlyprop.cpp
+++ b/src/coreclr/jit/earlyprop.cpp
@@ -450,6 +450,9 @@ private:
         Statement* indirStatement         = currentStatement;
         GenTree*   nullCheckStatementRoot = nullCheck;
 
+        // TODO-MIKE-Review: Could we simply remove null checks from the map as we traverse
+        // the block and entirely avoid this intereference check?
+
         for (GenTree* node = nullCheck->gtNext; node != nullptr; node = node->gtNext)
         {
             if (node == indir)
@@ -508,6 +511,8 @@ private:
             return false;
         }
 
+        // TODO-MIKE-Review: Perhaps we can move a null check past another null check,
+        // they should always throw NullReferenceException.
         if (((node->gtFlags & GTF_EXCEPT) != 0) && node->OperMayThrow(compiler))
         {
             return false;

--- a/src/coreclr/jit/earlyprop.cpp
+++ b/src/coreclr/jit/earlyprop.cpp
@@ -225,18 +225,9 @@ private:
 
         JITDUMPTREE(currentStatement->GetRootNode(), "PropagateConstArrayLength rewriting\n");
 
-        GenTree* constLenClone = compiler->gtCloneExpr(constLen);
-
-        if (constLenClone->GetType() != arrLen->GetType())
-        {
-            assert(constLenClone->TypeIs(TYP_LONG));
-            assert(arrLen->TypeIs(TYP_INT));
-
-            constLenClone->SetType(arrLen->GetType());
-        }
-
-        // constLenClone has small tree node size, it is safe to use ReplaceWith here.
-        arrLen->ReplaceWith(constLenClone, compiler);
+        assert(arrLen->TypeIs(TYP_INT));
+        arrLen->ChangeToIntCon(TYP_INT, constVal);
+        arrLen->gtFlags = constLen->gtFlags;
 
         // Propagating a constant may create an opportunity to use a division by constant optimization
         if ((arrLen->gtNext != nullptr) && arrLen->gtNext->OperIs(GT_DIV, GT_MOD, GT_UDIV, GT_UMOD))

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -3614,7 +3614,7 @@ bool Compiler::fgOptimizeBranch(BasicBlock* bJump)
     gtReverseCond(condTree);
 
     // We need to update the following flags of the bJump block if they were set in the bDest block
-    bJump->bbFlags |= (bDest->bbFlags & (BBF_HAS_NEWOBJ | BBF_HAS_NEWARRAY | BBF_HAS_NULLCHECK | BBF_HAS_IDX_LEN));
+    bJump->bbFlags |= (bDest->bbFlags & BBF_IR_SUMMARY);
 
     bJump->bbJumpKind = BBJ_COND;
     bJump->bbJumpDest = bDest->bbNext;

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1689,6 +1689,10 @@ public:
     // Find the use of a node within this node.
     GenTree** FindUse(GenTree* def);
 
+    bool HasUse(GenTree* def) {
+        return FindUse(def) != nullptr;
+    }
+
     // Find the user of this node, and optionally capture the use so that it can be modified.
     GenTree* FindUser(GenTree*** use = nullptr);
 

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1689,7 +1689,8 @@ public:
     // Find the use of a node within this node.
     GenTree** FindUse(GenTree* def);
 
-    bool HasUse(GenTree* def) {
+    bool HasUse(GenTree* def)
+    {
         return FindUse(def) != nullptr;
     }
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3262,7 +3262,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                             break;
                         }
                     }
-                    op1 = gtNewArrLen(op1, OFFSETOF__CORINFO_String__stringLen, compCurBB);
+                    op1 = gtNewArrLen(op1, OFFSETOF__CORINFO_String__stringLen);
                 }
                 else
                 {
@@ -10525,18 +10525,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 }
 
                 op1 = impCheckForNullPointer(op1);
-
-                /* Mark the block as containing an index expression */
-
-                if (op1->gtOper == GT_LCL_VAR)
-                {
-                    if (op2->gtOper == GT_LCL_VAR || op2->gtOper == GT_CNS_INT || op2->gtOper == GT_ADD)
-                    {
-                        block->bbFlags |= BBF_HAS_IDX_LEN;
-                        optMethodFlags |= OMF_HAS_ARRAYREF;
-                    }
-                }
-
                 op1 = gtNewArrayIndexAddr(op1, op2, lclTyp);
 
                 if (lclTyp == TYP_STRUCT)
@@ -10646,18 +10634,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 assertImp(op3->TypeIs(TYP_REF));
 
                 op3 = impCheckForNullPointer(op3);
-
-                // Mark the block as containing an index expression
-
-                if (op3->gtOper == GT_LCL_VAR)
-                {
-                    if (op1->gtOper == GT_LCL_VAR || op1->gtOper == GT_CNS_INT || op1->gtOper == GT_ADD)
-                    {
-                        block->bbFlags |= BBF_HAS_IDX_LEN;
-                        optMethodFlags |= OMF_HAS_ARRAYREF;
-                    }
-                }
-
                 op1 = gtNewArrayIndexAddr(op3, op1, lclTyp);
 
                 if (lclTyp == TYP_STRUCT)
@@ -13518,7 +13494,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 op1 = impPopStack().val;
                 if (opts.OptimizationEnabled())
                 {
-                    op1 = gtNewArrLen(op1, OFFSETOF__CORINFO_Array__length, block);
+                    op1 = gtNewArrLen(op1, OFFSETOF__CORINFO_Array__length);
                 }
                 else
                 {

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -83,7 +83,7 @@ GenTree* LC_Array::ToGenTree(Compiler* comp, BasicBlock* bb)
         // If asked for arrlen invoke arr length operator.
         if (oper == ArrLen)
         {
-            GenTree* arrLen = comp->gtNewArrLen(arr, OFFSETOF__CORINFO_Array__length, bb);
+            GenTree* arrLen = comp->gtNewArrLen(arr, OFFSETOF__CORINFO_Array__length);
 
             // We already guaranteed (by a sequence of preceding checks) that the array length operator will not
             // throw an exception because we null checked the base array.

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5345,7 +5345,7 @@ GenTree* Compiler::fgMorphIndexAddr(GenTreeIndexAddr* tree)
             noway_assert(array2 != nullptr);
         }
 
-        GenTree* arrLen = gtNewArrLen(array2, lenOffs, compCurBB);
+        GenTree* arrLen = gtNewArrLen(array2, lenOffs);
 
 #ifdef TARGET_64BIT
         // The CLI Spec allows an array to be indexed by either an int32 or a native int.  In the case

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -4384,7 +4384,7 @@ bool Compiler::optInvertWhileLoop(BasicBlock* block)
     // Flag the block that received the copy as potentially having an array/vtable
     // reference, nullcheck, object/array allocation if the block copied from did;
     // this is a conservative guess.
-    if (auto copyFlags = bTest->bbFlags & (BBF_HAS_IDX_LEN | BBF_HAS_NULLCHECK | BBF_HAS_NEWOBJ | BBF_HAS_NEWARRAY))
+    if (auto copyFlags = bTest->bbFlags & BBF_IR_SUMMARY)
     {
         bNewCond->bbFlags |= copyFlags;
     }

--- a/src/coreclr/jit/simdashwintrinsic.cpp
+++ b/src/coreclr/jit/simdashwintrinsic.cpp
@@ -820,7 +820,7 @@ GenTree* Compiler::impGetArrayElementsAsVector(ClassLayout*    layout,
     array = arrayUses[0];
 
     GenTree* lastIndex = gtNewIconNode(layout->GetElementCount() - 1);
-    GenTree* arrLen    = gtNewArrLen(arrayUses[1], OFFSETOF__CORINFO_Array__length, compCurBB);
+    GenTree* arrLen    = gtNewArrLen(arrayUses[1], OFFSETOF__CORINFO_Array__length);
 
     if (index != nullptr)
     {
@@ -830,7 +830,7 @@ GenTree* Compiler::impGetArrayElementsAsVector(ClassLayout*    layout,
 
         lastIndex = gtNewOperNode(GT_ADD, TYP_INT, indexUses[1], lastIndex);
         array     = gtNewCommaNode(gtNewArrBoundsChk(lastIndex, arrLen, lastIndexThrowKind), array);
-        arrLen    = gtNewArrLen(arrayUses[2], OFFSETOF__CORINFO_Array__length, compCurBB);
+        arrLen    = gtNewArrLen(arrayUses[2], OFFSETOF__CORINFO_Array__length);
         array     = gtNewCommaNode(gtNewArrBoundsChk(indexUses[2], arrLen, indexThrowKind), array);
     }
     else
@@ -3008,9 +3008,8 @@ void Compiler::SIMDCoalescingBuffer::ChangeToSIMDMem(Compiler* compiler, GenTree
 
             unsigned simdElementCount = varTypeSize(simdType) / varTypeSize(TYP_FLOAT);
 
-            GenTree* lastIndex = compiler->gtNewIconNode(index + simdElementCount - 1, TYP_INT);
-            GenTree* arrLen    = compiler->gtNewArrLen(compiler->gtCloneExpr(array), OFFSETOF__CORINFO_Array__length,
-                                                    compiler->compCurBB);
+            GenTree* lastIndex  = compiler->gtNewIconNode(index + simdElementCount - 1, TYP_INT);
+            GenTree* arrLen     = compiler->gtNewArrLen(compiler->gtCloneExpr(array), OFFSETOF__CORINFO_Array__length);
             GenTree* arrBndsChk = compiler->gtNewArrBoundsChk(lastIndex, arrLen, SCK_RNGCHK_FAIL);
 
             addr   = compiler->gtNewCommaNode(arrBndsChk, array);


### PR DESCRIPTION
win-x64 pmi:
```
Total bytes of base: 60447949
Total bytes of diff: 60438369
Total bytes of delta: -9580 (-0.02 % of base)
Total relative delta: -10.20
    diff is an improvement.
    relative diff is an improvement.


Top file improvements (bytes):
       -4656 : FSharp.Core.dasm (-0.12% of base)
       -1460 : System.Numerics.Tensors.dasm (-0.50% of base)
       -1091 : System.Private.Xml.dasm (-0.03% of base)
        -545 : xunit.execution.dotnet.dasm (-0.21% of base)
        -289 : Microsoft.CodeAnalysis.dasm (-0.01% of base)
        -279 : xunit.runner.utility.netcoreapp10.dasm (-0.14% of base)
        -155 : Microsoft.VisualBasic.Core.dasm (-0.03% of base)
        -149 : System.Speech.dasm (-0.03% of base)
        -139 : System.Private.DataContractSerialization.dasm (-0.02% of base)
        -106 : xunit.runner.reporters.netcoreapp10.dasm (-0.20% of base)
        -105 : System.Net.WebSockets.dasm (-0.09% of base)
         -99 : System.Runtime.Caching.dasm (-0.16% of base)
         -84 : xunit.core.dasm (-0.11% of base)
         -82 : Microsoft.Extensions.Http.dasm (-0.18% of base)
         -73 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00% of base)
         -68 : System.Net.HttpListener.dasm (-0.03% of base)
         -48 : System.Drawing.Common.dasm (-0.01% of base)
         -44 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
         -37 : System.Runtime.Serialization.Formatters.dasm (-0.04% of base)
         -27 : Microsoft.Extensions.Configuration.Binder.dasm (-0.18% of base)

22 total files with Code Size differences (22 improved, 0 regressed), 249 unchanged.

Top method regressions (bytes):
          24 ( 0.41% of base) : System.Private.Xml.dasm - XmlSerializationWriterCodeGen:WriteStructMethod(StructMapping):this
          12 ( 0.16% of base) : System.Private.Xml.dasm - XmlSerializationWriterCodeGen:WriteElements(String,String,ref,TextAccessor,ChoiceIdentifierAccessor,String,bool,bool):this

Top method improvements (bytes):
        -425 (-3.85% of base) : System.Numerics.Tensors.dasm - Tensor`1:CompareTo(Tensor`1,IComparer):int:this (8 methods)
        -387 (-3.39% of base) : System.Numerics.Tensors.dasm - Tensor`1:Equals(Tensor`1,IEqualityComparer):bool:this (8 methods)
        -360 (-4.77% of base) : FSharp.Core.dasm - Array4DModule:ZeroCreate(int,int,int,int):ref (8 methods)
        -280 (-4.86% of base) : FSharp.Core.dasm - Array3DModule:ZeroCreate(int,int,int):ref (8 methods)
        -216 (-3.66% of base) : FSharp.Core.dasm - ArrayModule:GetSubArray(ref,int,int):ref (8 methods)
        -216 (-8.26% of base) : System.Numerics.Tensors.dasm - DenseTensor`1:.ctor(Memory`1,ReadOnlySpan`1,bool):this (8 methods)
        -216 (-2.75% of base) : System.Numerics.Tensors.dasm - Tensor`1:CompareTo(Array,IComparer):int:this (8 methods)
        -216 (-2.70% of base) : System.Numerics.Tensors.dasm - Tensor`1:Equals(Array,IEqualityComparer):bool:this (8 methods)
        -200 (-5.08% of base) : FSharp.Core.dasm - Array2DModule:ZeroCreate(int,int):ref (8 methods)
        -169 (-3.30% of base) : FSharp.Core.dasm - ArrayModule:Take(int,ref):ref (8 methods)
        -164 (-2.24% of base) : FSharp.Core.dasm - Windowed@952:GenerateNext(byref):int:this (8 methods)
        -145 (-3.75% of base) : FSharp.Core.dasm - List:init(int,FSharpFunc`2):FSharpList`1 (8 methods)
        -141 (-4.18% of base) : FSharp.Core.dasm - SeqModule:Take(int,IEnumerable`1):IEnumerable`1 (8 methods)
        -136 (-5.38% of base) : FSharp.Core.dasm - Array:init(int,FSharpFunc`2):ref (8 methods)
        -136 (-3.17% of base) : FSharp.Core.dasm - ArrayModule:ChunkBySize(int,ref):ref (8 methods)
        -136 (-5.38% of base) : FSharp.Core.dasm - ArrayModule:Initialize(int,FSharpFunc`2):ref (8 methods)
        -136 (-2.89% of base) : FSharp.Core.dasm - ArrayModule:Pairwise(ref):ref (8 methods)
        -136 (-4.14% of base) : FSharp.Core.dasm - ArrayModule:SplitInto(int,ref):ref (8 methods)
        -136 (-2.55% of base) : FSharp.Core.dasm - ArrayModule:Windowed(int,ref):ref (8 methods)
        -136 (-6.64% of base) : FSharp.Core.dasm - ArrayModule:ZeroCreate(int):ref (8 methods)

Top method regressions (percentages):
          24 ( 0.41% of base) : System.Private.Xml.dasm - XmlSerializationWriterCodeGen:WriteStructMethod(StructMapping):this
          12 ( 0.16% of base) : System.Private.Xml.dasm - XmlSerializationWriterCodeGen:WriteElements(String,String,ref,TextAccessor,ChoiceIdentifierAccessor,String,bool,bool):this

Top method improvements (percentages):
         -37 (-12.76% of base) : System.Private.DataContractSerialization.dasm - XmlJsonWriter:ThrowIfServerTypeWritten(String):this
         -17 (-11.72% of base) : System.Speech.dasm - RecognitionResult:get_Recognizer():IRecognizerInternal:this
         -31 (-10.44% of base) : FSharp.Core.dasm - ArrayModule:Create(int,Nullable`1):ref
         -31 (-10.44% of base) : FSharp.Core.dasm - ArrayModule:Replicate(int,Nullable`1):ref
        -136 (-10.43% of base) : Microsoft.CodeAnalysis.dasm - AsyncQueue`1:Complete():this (8 methods)
         -17 (-10.43% of base) : Microsoft.CodeAnalysis.dasm - AsyncQueue`1:Enqueue(__Canon):this
         -17 (-10.43% of base) : Microsoft.CodeAnalysis.dasm - AsyncQueue`1:Enqueue(int):this
         -17 (-10.43% of base) : Microsoft.CodeAnalysis.dasm - AsyncQueue`1:Enqueue(long):this
         -17 (-10.43% of base) : Microsoft.CodeAnalysis.dasm - AsyncQueue`1:Enqueue(Vector`1):this
         -17 (-10.24% of base) : Microsoft.CodeAnalysis.dasm - AsyncQueue`1:Enqueue(double):this
         -17 (-10.24% of base) : Microsoft.CodeAnalysis.dasm - AsyncQueue`1:Enqueue(ubyte):this
         -17 (-10.18% of base) : Microsoft.CodeAnalysis.dasm - AsyncQueue`1:Enqueue(short):this
         -17 (-10.06% of base) : System.Private.Xml.dasm - FuncUnEntityUri:Invoke(XsltContext,ref,XPathNavigator):Object:this
         -37 (-9.89% of base) : System.Runtime.Serialization.Formatters.dasm - ObjectReader:ParseError(ParseRecord,ParseRecord):this
         -17 (-9.83% of base) : Microsoft.CodeAnalysis.dasm - AsyncQueue`1:Enqueue(Nullable`1):this
         -26 (-9.59% of base) : Microsoft.VisualBasic.Core.dasm - TextFieldParser:ValidateFieldWidthsOnInput(ref):this
         -27 (-8.71% of base) : xunit.core.dasm - ClassDataAttribute:GetData(MethodInfo):IEnumerable`1:this
         -26 (-8.52% of base) : FSharp.Core.dasm - ArrayModule:Create(int,Vector`1):ref
         -26 (-8.52% of base) : FSharp.Core.dasm - ArrayModule:Replicate(int,Vector`1):ref
        -216 (-8.26% of base) : System.Numerics.Tensors.dasm - DenseTensor`1:.ctor(Memory`1,ReadOnlySpan`1,bool):this (8 methods)

217 total methods with Code Size differences (215 improved, 2 regressed), 275906 unchanged.
```