### PR TITLE
Track GC spill temps

### DIFF
--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -257,6 +257,12 @@ void CodeGen::genCodeForBBlist()
         }
 #endif
 
+        // TODO-MIKE-Cleanup: We have to do this here rather than in emitAddLabel
+        // partly because emitCreatePlaceholderIG is stealing the insGroup create
+        // by emitAddLabel and partly due to temp labels, which aren't real basic
+        // blocks (and DO NOT kill spill temps).
+        GetEmitter()->emitCurIG->igFlags |= IGF_BASIC_BLOCK;
+
         // Emit poisoning into scratch BB that comes right after prolog.
         // We cannot emit this code in the prolog as it might make the prolog too large.
         if (compiler->compShouldPoisonFrame() && compiler->fgBBisScratch(block))

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -6026,13 +6026,13 @@ const char* emitter::emitOffsetToLabel(unsigned offs)
 
 #endif // DEBUG
 
-void emitter::emitGCvarLiveUpd(int offs, GCtype gcType, BYTE* addr DEBUGARG(unsigned lclNum))
+void emitter::emitGCvarLiveUpd(int offs, GCtype gcType, BYTE* addr DEBUGARG(int varNum))
 {
     assert(emitIssuing);
     assert(gcType != GCT_NONE);
-    assert(emitComp->lvaGetDesc(lclNum)->HasGCSlotLiveness());
+    assert((varNum < 0) || (emitComp->lvaGetDesc(static_cast<unsigned>(varNum))->HasGCSlotLiveness()));
 #if FEATURE_FIXED_OUT_ARGS
-    assert(lclNum != emitComp->lvaOutgoingArgSpaceVar);
+    assert(static_cast<unsigned>(varNum) != emitComp->lvaOutgoingArgSpaceVar);
 #endif
 
     unsigned index = gcInfo.GetTrackedStackSlotIndex(offs);
@@ -6045,11 +6045,11 @@ void emitter::emitGCvarLiveUpd(int offs, GCtype gcType, BYTE* addr DEBUGARG(unsi
 
 #if FEATURE_FIXED_OUT_ARGS
 
-void emitter::emitGCargLiveUpd(int offs, GCtype gcType, BYTE* addr DEBUGARG(unsigned lclNum))
+void emitter::emitGCargLiveUpd(int offs, GCtype gcType, BYTE* addr DEBUGARG(int varNum))
 {
     assert(abs(offs) % REGSIZE_BYTES == 0);
     assert(gcType != GCT_NONE);
-    assert(lclNum == emitComp->lvaOutgoingArgSpaceVar);
+    assert(static_cast<unsigned>(varNum) == emitComp->lvaOutgoingArgSpaceVar);
 
     if (gcInfo.IsFullyInterruptible())
     {

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -1240,6 +1240,9 @@ void emitter::emitCreatePlaceholderIG(insGroupPlaceholderType igType, BasicBlock
         else
         {
             emitCurIG->igFlags |= IGF_EXTEND;
+            // We may be "stealing" the insGroup created for an empty basic
+            // block, to avoid confusion remove the basic block flag.
+            emitCurIG->igFlags &= ~IGF_BASIC_BLOCK;
         }
 
         isLast = igBB->bbNext == nullptr;
@@ -2527,6 +2530,12 @@ void emitter::emitDispIG(insGroup* ig, insGroup* igPrev, bool verbose)
         separator = ',';
     }
 #endif
+
+    if ((flags & IGF_BASIC_BLOCK) != 0)
+    {
+        printf("%c block", separator);
+        separator = ',';
+    }
 
     if (flags & IGF_PLACEHOLDER)
     {
@@ -4646,7 +4655,16 @@ unsigned emitter::emitEndCodeGen(unsigned* prologSize,
 
         if (((ig->igFlags & IGF_EXTEND) == 0) && (ig != GetProlog()))
         {
-            gcInfo.SetLiveStackSlots(ig->GetGCLcls(), codeOffs);
+            gcInfo.SetLiveLclStackSlots(ig->GetGCLcls(), codeOffs);
+
+            if (ig->IsBasicBlock() && codeGen->spillTemps.TrackGCSpillTemps())
+            {
+                // This is an approximation, all spill temps are definitely dead at the start of a block
+                // but we don't always create an insGroup when we fall through from one block to the next.
+                // Still, it's better than just keeping spill temps alive until the end of the method and
+                // is consistent with the way GC locals are handled.
+                gcInfo.KillTrackedSpillTemps(codeOffs);
+            }
 
             regMaskTP refRegs = ig->GetRefRegs();
 
@@ -6115,7 +6133,7 @@ size_t emitter::emitRecordGCCall(instrDesc* id, uint8_t* callAddr, uint8_t* call
         // the call is CORINFO_HELP_THROW.
         // If we ever track aliased locals (which could be used by the call), we
         // would have to keep the corresponding stack slots alive past the call.
-        gcInfo.SetLiveStackSlots(gcLcls, callOffs);
+        gcInfo.SetLiveLclStackSlots(gcLcls, callOffs);
 
 #ifdef DEBUG
         // And we have to dump the delta here, so it appears before the call instruction

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1848,9 +1848,9 @@ public:
 #endif
 
 #if FEATURE_FIXED_OUT_ARGS
-    void emitGCargLiveUpd(int offs, GCtype gcType, BYTE* addr DEBUGARG(unsigned lclNum));
+    void emitGCargLiveUpd(int offs, GCtype gcType, BYTE* addr DEBUGARG(int varNum));
 #endif
-    void emitGCvarLiveUpd(int slotOffs, GCtype gcType, BYTE* addr DEBUGARG(unsigned lclNum));
+    void emitGCvarLiveUpd(int slotOffs, GCtype gcType, BYTE* addr DEBUGARG(int varNum));
 
     /************************************************************************/
     /*      The following logic keeps track of initialized data sections    */

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -136,6 +136,7 @@ struct insPlaceholderGroupData
     }
 };
 
+#define IGF_BASIC_BLOCK 0x0001
 #define IGF_FUNCLET_PROLOG 0x0002 // this group belongs to a funclet prolog
 #define IGF_FUNCLET_EPILOG 0x0004 // this group belongs to a funclet epilog.
 #define IGF_EPILOG 0x0008         // this group belongs to a main function epilog
@@ -238,6 +239,11 @@ struct insGroup
 #else
         return false;
 #endif
+    }
+
+    bool IsBasicBlock() const
+    {
+        return (igFlags & IGF_BASIC_BLOCK) != 0;
     }
 };
 

--- a/src/coreclr/jit/emitarm.cpp
+++ b/src/coreclr/jit/emitarm.cpp
@@ -3802,11 +3802,16 @@ void emitter::Ins_R_S(instruction ins, emitAttr attr, regNumber reg, int varNum,
     id->idReg2(baseReg);
     id->SetVarAddr(varNum, varOffs);
 
-    if ((varNum >= 0) && (ins == INS_str) && EA_IS_GCREF_OR_BYREF(attr))
+    if ((ins == INS_str) && EA_IS_GCREF_OR_BYREF(attr))
     {
         id->idAddr()->lclOffset = baseOffset;
 
-        if (static_cast<unsigned>(varNum) == emitComp->lvaOutgoingArgSpaceVar)
+        if (varNum < 0)
+        {
+            assert(varOffs == 0);
+            id->idAddr()->isTrackedGCSlotStore = codeGen->spillTemps.TrackGCSpillTemps();
+        }
+        else if (static_cast<unsigned>(varNum) == emitComp->lvaOutgoingArgSpaceVar)
         {
             id->idAddr()->isGCArgStore = true;
         }
@@ -6140,15 +6145,15 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
     {
         bool isArg = id->idAddr()->isGCArgStore;
         int  adr   = id->idAddr()->lclOffset;
-        INDEBUG(unsigned lclNum = id->idDebugOnlyInfo()->varNum);
+        INDEBUG(unsigned varNum = id->idDebugOnlyInfo()->varNum);
 
         if (isArg)
         {
-            emitGCargLiveUpd(adr, id->idGCref(), dst DEBUGARG(lclNum));
+            emitGCargLiveUpd(adr, id->idGCref(), dst DEBUGARG(varNum));
         }
         else
         {
-            emitGCvarLiveUpd(adr, id->idGCref(), dst DEBUGARG(lclNum));
+            emitGCvarLiveUpd(adr, id->idGCref(), dst DEBUGARG(varNum));
         }
     }
 

--- a/src/coreclr/jit/gcencode.cpp
+++ b/src/coreclr/jit/gcencode.cpp
@@ -4027,7 +4027,7 @@ private:
 #ifdef TARGET_ARMARCH
                 printf("Defining [%s,#%d] slot live ranges:\n", baseName, slot.offset);
 #else
-                printf("Defining [%s%c%x] slot live ranges:\n", baseName, slot.offset < 0 ? '-' : '+',
+                printf("Defining [%s%c%02XH] slot live ranges:\n", baseName, slot.offset < 0 ? '-' : '+',
                        abs(slot.offset));
 #endif
 

--- a/src/coreclr/jit/gcencode.cpp
+++ b/src/coreclr/jit/gcencode.cpp
@@ -382,29 +382,32 @@ unsigned GCEncoder::GetUntrackedStackSlotCount()
         }
     }
 
-    for (SpillTemp& temp : compiler->codeGen->spillTemps)
+    if (!compiler->codeGen->spillTemps.TrackGCSpillTemps())
     {
-        if (!varTypeIsGC(temp.GetType()))
+        for (SpillTemp& temp : compiler->codeGen->spillTemps)
         {
-            continue;
-        }
-
-#ifdef DEBUG
-        if (compiler->verbose)
-        {
-            printf("GCINFO: untracked %s slot at [%s", varTypeName(temp.GetType()),
-                   compiler->GetEmitter()->emitGetFrameReg());
-
-            if (temp.GetOffset() != 0)
+            if (!varTypeIsGC(temp.GetType()))
             {
-                printf("%c%02XH", temp.GetOffset() < 0 ? '-' : '+', abs(temp.GetOffset()));
+                continue;
             }
 
-            printf("]\n");
-        }
+#ifdef DEBUG
+            if (compiler->verbose)
+            {
+                printf("GCINFO: untracked %s slot at [%s", varTypeName(temp.GetType()),
+                       compiler->GetEmitter()->emitGetFrameReg());
+
+                if (temp.GetOffset() != 0)
+                {
+                    printf("%c%02XH", temp.GetOffset() < 0 ? '-' : '+', abs(temp.GetOffset()));
+                }
+
+                printf("]\n");
+            }
 #endif
 
-        untrackedCount++;
+            untrackedCount++;
+        }
     }
 
     JITDUMP("GCINFO: untrckVars = %u\n", untrackedCount);
@@ -2369,32 +2372,35 @@ unsigned GCEncoder::AddUntrackedStackSlots(uint8_t* dest, const int mask)
         }
     }
 
-    for (SpillTemp& temp : compiler->codeGen->spillTemps)
+    if (!compiler->codeGen->spillTemps.TrackGCSpillTemps())
     {
-        if (!varTypeIsGC(temp.GetType()))
+        for (SpillTemp& temp : compiler->codeGen->spillTemps)
         {
-            continue;
-        }
+            if (!varTypeIsGC(temp.GetType()))
+            {
+                continue;
+            }
 
-        int offset = temp.GetOffset();
+            int offset = temp.GetOffset();
 
-        if (temp.GetType() == TYP_BYREF)
-        {
-            offset |= byref_OFFSET_FLAG;
-        }
+            if (temp.GetType() == TYP_BYREF)
+            {
+                offset |= byref_OFFSET_FLAG;
+            }
 
-        int offsetDelta = lastoffset - offset;
-        lastoffset      = offset;
+            int offsetDelta = lastoffset - offset;
+            lastoffset      = offset;
 
-        if (mask == 0)
-        {
-            totalSize += encodeSigned(nullptr, offsetDelta);
-        }
-        else
-        {
-            unsigned size = encodeSigned(dest, offsetDelta);
-            dest += size;
-            totalSize += size;
+            if (mask == 0)
+            {
+                totalSize += encodeSigned(nullptr, offsetDelta);
+            }
+            else
+            {
+                unsigned size = encodeSigned(dest, offsetDelta);
+                dest += size;
+                totalSize += size;
+            }
         }
     }
 
@@ -4293,21 +4299,24 @@ void GCEncoder::AddUntrackedStackSlots()
 
     GcStackSlotBase slotBase = compiler->codeGen->isFramePointerUsed() ? GC_FRAMEREG_REL : GC_SP_REL;
 
-    for (const SpillTemp& temp : compiler->codeGen->spillTemps)
+    if (!compiler->codeGen->spillTemps.TrackGCSpillTemps())
     {
-        if (!varTypeIsGC(temp.GetType()))
+        for (const SpillTemp& temp : compiler->codeGen->spillTemps)
         {
-            continue;
+            if (!varTypeIsGC(temp.GetType()))
+            {
+                continue;
+            }
+
+            GcSlotFlags slotFlags = GC_SLOT_UNTRACKED;
+
+            if (temp.GetType() == TYP_BYREF)
+            {
+                slotFlags = static_cast<GcSlotFlags>(slotFlags | GC_SLOT_INTERIOR);
+            }
+
+            GetStackSlotId(temp.GetOffset(), slotFlags, slotBase);
         }
-
-        GcSlotFlags slotFlags = GC_SLOT_UNTRACKED;
-
-        if (temp.GetType() == TYP_BYREF)
-        {
-            slotFlags = static_cast<GcSlotFlags>(slotFlags | GC_SLOT_INTERIOR);
-        }
-
-        GetStackSlotId(temp.GetOffset(), slotFlags, slotBase);
     }
 
     if (compiler->lvaKeepAliveAndReportThis())

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -10869,7 +10869,7 @@ void Importer::impImportBlockCode(BasicBlock* block)
                     assert((fieldInfo.fieldAccessor == CORINFO_FIELD_INSTANCE) ||
                            (fieldInfo.fieldAccessor == CORINFO_FIELD_INSTANCE_WITH_BASE));
 
-                    if (!varTypeGCtype(obj->GetType()) && tiObj.IsType(TI_STRUCT))
+                    if (!varTypeIsGC(obj->GetType()) && tiObj.IsType(TI_STRUCT))
                     {
                         // If the object is a struct, what we really want is
                         // for the field to operate on the address of the struct.

--- a/src/coreclr/jit/jitgcinfo.h
+++ b/src/coreclr/jit/jitgcinfo.h
@@ -279,7 +279,8 @@ public:
 
     void BeginStackSlotLifetime(GCtype type, unsigned index, unsigned codeOffs, int slotOffs);
     void EndStackSlotLifetime(unsigned index, unsigned codeOffs DEBUGARG(int slotOffs));
-    void SetLiveStackSlots(VARSET_TP newLiveLcls, unsigned codeOffs);
+    void SetLiveLclStackSlots(VARSET_TP newLiveLcls, unsigned codeOffs);
+    void KillTrackedSpillTemps(unsigned codeOffs);
 
     void AddLiveReg(GCtype type, regNumber reg, unsigned codeOffs);
     void SetLiveRegs(GCtype type, regMaskTP regs, unsigned codeOffs);

--- a/src/coreclr/jit/regset.cpp
+++ b/src/coreclr/jit/regset.cpp
@@ -4,6 +4,11 @@
 #include "jitpch.h"
 #include "emit.h"
 
+bool SpillTempSet::TrackGCSpillTemps() const
+{
+    return !compiler->opts.MinOpts();
+}
+
 var_types SpillTempSet::GetTempType(var_types type)
 {
 #ifdef FEATURE_SIMD

--- a/src/coreclr/jit/regset.h
+++ b/src/coreclr/jit/regset.h
@@ -87,6 +87,8 @@ public:
     {
     }
 
+    bool TrackGCSpillTemps() const;
+
     static var_types GetTempType(var_types type);
     void PreAllocateTemps(const unsigned* typeSpillCounts);
     SpillTemp* FindTempByNum(int num) const;

--- a/src/coreclr/jit/vartype.h
+++ b/src/coreclr/jit/vartype.h
@@ -186,7 +186,8 @@ inline unsigned varTypeGCtype(T vt)
 template <class T>
 inline bool varTypeIsGC(T vt)
 {
-    return (varTypeGCtype(vt) != 0);
+    var_types type = TypeGet(vt);
+    return (type == TYP_REF) || (type == TYP_BYREF);
 }
 
 template <class T>


### PR DESCRIPTION
win-x64 crossgen diff:
```
Total bytes of base: 37468947
Total bytes of diff: 37461526
Total bytes of delta: -7421 (-0.02 % of base)

Top file regressions (bytes):
           7 : Microsoft.Win32.SystemEvents.dasm (0.05% of base)

Top file improvements (bytes):
       -1666 : System.Private.CoreLib.dasm (-0.05% of base)
       -1336 : System.Private.DataContractSerialization.dasm (-0.19% of base)
       -1003 : Microsoft.CodeAnalysis.dasm (-0.08% of base)
        -622 : System.Private.Xml.dasm (-0.02% of base)
        -240 : System.Linq.Expressions.dasm (-0.01% of base)
        -164 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.00% of base)
        -110 : System.Security.Cryptography.Algorithms.dasm (-0.04% of base)
        -108 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00% of base)
         -87 : Newtonsoft.Json.dasm (-0.01% of base)
         -87 : System.ComponentModel.Composition.dasm (-0.04% of base)
         -83 : System.Runtime.Serialization.Formatters.dasm (-0.09% of base)
         -80 : Microsoft.VisualBasic.Core.dasm (-0.02% of base)
         -77 : System.Data.Common.dasm (-0.01% of base)
         -74 : System.Configuration.ConfigurationManager.dasm (-0.02% of base)
         -72 : System.Linq.Parallel.dasm (-0.02% of base)
         -70 : System.Composition.Hosting.dasm (-0.28% of base)
         -69 : Microsoft.CSharp.dasm (-0.02% of base)
         -66 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
         -60 : xunit.execution.dotnet.dasm (-0.03% of base)
         -59 : System.Net.HttpListener.dasm (-0.03% of base)

94 total files with Code Size differences (93 improved, 1 regressed), 177 unchanged.

Top method regressions (bytes):
          23 ( 0.06% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.DesktopAssemblyIdentityComparer:.cctor()
          23 ( 0.51% of base) : System.Private.CoreLib.dasm - System.Diagnostics.Tracing.EventSource:CreateManifestAndDescriptors(System.Type,System.String,System.Diagnostics.Tracing.EventSource,int):System.Byte[]
          23 ( 3.41% of base) : System.Security.Cryptography.Algorithms.dasm - System.Security.Cryptography.DSAKeyFormatHelper:ReadDsaPublicKey(System.ReadOnlyMemory`1[System.Byte],byref,byref)
          18 ( 0.63% of base) : System.Net.Mail.dasm - System.Net.Mail.MailHeaderInfo:.cctor()
           9 ( 0.29% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - InferenceGraph:InferTypeArgumentsFromLambdaArgument(Microsoft.CodeAnalysis.VisualBasic.BoundExpression,Microsoft.CodeAnalysis.VisualBasic.Symbols.TypeSymbol,Microsoft.CodeAnalysis.VisualBasic.Symbols.ParameterSymbol):bool:this
           9 ( 0.56% of base) : System.Private.CoreLib.dasm - System.Reflection.CustomAttribute:AddCustomAttributes(byref,System.Reflection.RuntimeModule,int,System.RuntimeType,bool,System.RuntimeType+ListBuilder`1[System.Object])
           7 ( 0.32% of base) : System.Net.HttpListener.dasm - <CloseOutputAsyncCore>d__48:MoveNext():this
           7 ( 0.17% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindLambdaBody(Microsoft.CodeAnalysis.VisualBasic.Symbols.LambdaSymbol,Microsoft.CodeAnalysis.DiagnosticBag,byref):Microsoft.CodeAnalysis.VisualBasic.BoundBlock:this
           7 ( 1.10% of base) : Microsoft.Win32.SystemEvents.dasm - Microsoft.Win32.SystemEvents:Initialize():this
           7 ( 0.69% of base) : System.Net.Quic.dasm - System.Net.Quic.Implementations.MsQuic.MsQuicStream:SendReadOnlySequenceAsync(System.Buffers.ReadOnlySequence`1[System.Byte],int):System.Threading.Tasks.ValueTask:this
           6 ( 0.09% of base) : System.Private.CoreLib.dasm - System.Number:NumberToStringFormat(byref,byref,System.ReadOnlySpan`1[System.Char],System.Globalization.NumberFormatInfo)
           3 ( 0.02% of base) : FSharp.Core.dasm - <StartupCode$FSharp-Core>.$Linq:.cctor()
           3 ( 0.37% of base) : System.Collections.Immutable.dasm - Enumerator:.ctor(System.Collections.Immutable.ImmutableList`1+Node[System.__Canon],System.Collections.Immutable.ImmutableList`1+Builder[System.__Canon],int,int,bool):this
           2 ( 0.14% of base) : Microsoft.CodeAnalysis.dasm - <ProcessCompilationEventsAsync>d__58:MoveNext():this
           2 ( 0.01% of base) : FSharp.Core.dasm - <StartupCode$FSharp-Core>.$Query:.cctor()
           2 ( 0.07% of base) : FSharp.Core.dasm - <StartupCode$FSharp-Core>.$QueryExtensions:.cctor()
           2 ( 0.42% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.DesktopStrongNameProvider:GetPublicKey(System.Byte[]):System.Collections.Immutable.ImmutableArray`1[System.Byte]:this
           2 ( 0.40% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.Diagnostics.AnalyzerExecutor:ExecuteSemanticModelActionsCore(System.Collections.Immutable.ImmutableArray`1[Microsoft.CodeAnalysis.Diagnostics.SemanticModelAnalyzerAction],Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer,Microsoft.CodeAnalysis.SemanticModel,Microsoft.CodeAnalysis.Diagnostics.AnalysisState+AnalyzerStateData):this
           2 ( 0.41% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.Diagnostics.AnalyzerExecutor:ExecuteSyntaxTreeActionsCore(System.Collections.Immutable.ImmutableArray`1[Microsoft.CodeAnalysis.Diagnostics.SyntaxTreeAnalyzerAction],Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer,Microsoft.CodeAnalysis.SyntaxTree,Microsoft.CodeAnalysis.Diagnostics.AnalysisState+AnalyzerStateData):this
           2 ( 0.49% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Reader:TryTakeOldNodeOrToken(bool,byref):bool:this

Top method improvements (bytes):
        -266 (-12.27% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.ArrayBuilder`1:.cctor() (38 methods)
        -182 (-13.30% of base) : System.Private.CoreLib.dasm - EmptyArray`1:.cctor() (26 methods)
        -168 (-14.31% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.Collections.PooledHashSet`1:.cctor() (24 methods)
        -133 (-9.35% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.EqualityComparer`1:.cctor() (19 methods)
        -119 (-9.33% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Comparer`1:.cctor() (17 methods)
         -98 (-14.12% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.ArraySortHelper`1:.cctor() (14 methods)
         -77 (-14.00% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.ArraySortHelper`2:.cctor() (11 methods)
         -72 (-1.53% of base) : System.Linq.Parallel.dasm - System.Linq.Parallel.QueryOpeningEnumerator`1:OpenQuery():this (12 methods)
         -56 (-11.97% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.List`1:.cctor() (8 methods)
         -42 (-12.57% of base) : Microsoft.CodeAnalysis.dasm - Array`1:.cctor() (6 methods)
         -35 (-5.68% of base) : System.Private.CoreLib.dasm - StateMachineBox`1:.cctor() (5 methods)
         -35 (-4.32% of base) : System.Private.CoreLib.dasm - StateMachineBox`1:get_PerCoreCacheSlot():byref (5 methods)
         -35 (-12.32% of base) : System.Private.CoreLib.dasm - System.Threading.Tasks.Task`1:.cctor() (5 methods)
         -28 (-6.25% of base) : Microsoft.CodeAnalysis.dasm - Roslyn.Utilities.ValueTuple`2:.cctor() (4 methods)
         -24 (-0.77% of base) : System.Linq.Expressions.dasm - System.Linq.Expressions.Interpreter.LightCompiler:CompileTryExpression(System.Linq.Expressions.Expression):this
         -21 (-0.20% of base) : System.Net.Security.dasm - <ForceAuthenticationAsync>d__173`1:MoveNext():this (3 methods)
         -21 (-11.17% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.Collections.PooledDictionary`2:.cctor() (3 methods)
         -19 (-2.45% of base) : Microsoft.Extensions.Http.dasm - Log:.cctor() (3 methods)
         -17 (-0.92% of base) : System.Configuration.ConfigurationManager.dasm - System.Configuration.BaseConfigurationRecord:Evaluate(System.Configuration.FactoryRecord,System.Configuration.SectionRecord,System.Object,bool,bool,byref,byref):bool:this
         -17 (-2.85% of base) : System.Private.Xml.dasm - System.Xml.CharEntityEncoderFallbackBuffer:Fallback(ushort,ushort,int):bool:this

Top method regressions (percentages):
          23 ( 3.41% of base) : System.Security.Cryptography.Algorithms.dasm - System.Security.Cryptography.DSAKeyFormatHelper:ReadDsaPublicKey(System.ReadOnlyMemory`1[System.Byte],byref,byref)
           7 ( 1.10% of base) : Microsoft.Win32.SystemEvents.dasm - Microsoft.Win32.SystemEvents:Initialize():this
           2 ( 0.79% of base) : System.Private.CoreLib.dasm - System.Reflection.RuntimeCustomAttributeData:Init(System.Object):this
           7 ( 0.69% of base) : System.Net.Quic.dasm - System.Net.Quic.Implementations.MsQuic.MsQuicStream:SendReadOnlySequenceAsync(System.Buffers.ReadOnlySequence`1[System.Byte],int):System.Threading.Tasks.ValueTask:this
          18 ( 0.63% of base) : System.Net.Mail.dasm - System.Net.Mail.MailHeaderInfo:.cctor()
           2 ( 0.58% of base) : System.Net.Security.dasm - System.Net.Security.SslApplicationProtocol:.cctor()
           9 ( 0.56% of base) : System.Private.CoreLib.dasm - System.Reflection.CustomAttribute:AddCustomAttributes(byref,System.Reflection.RuntimeModule,int,System.RuntimeType,bool,System.RuntimeType+ListBuilder`1[System.Object])
          23 ( 0.51% of base) : System.Private.CoreLib.dasm - System.Diagnostics.Tracing.EventSource:CreateManifestAndDescriptors(System.Type,System.String,System.Diagnostics.Tracing.EventSource,int):System.Byte[]
           2 ( 0.49% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Reader:TryTakeOldNodeOrToken(bool,byref):bool:this
           2 ( 0.42% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.DesktopStrongNameProvider:GetPublicKey(System.Byte[]):System.Collections.Immutable.ImmutableArray`1[System.Byte]:this
           2 ( 0.41% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.Diagnostics.AnalyzerExecutor:ExecuteSyntaxTreeActionsCore(System.Collections.Immutable.ImmutableArray`1[Microsoft.CodeAnalysis.Diagnostics.SyntaxTreeAnalyzerAction],Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer,Microsoft.CodeAnalysis.SyntaxTree,Microsoft.CodeAnalysis.Diagnostics.AnalysisState+AnalyzerStateData):this
           2 ( 0.40% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.Diagnostics.AnalyzerExecutor:ExecuteSemanticModelActionsCore(System.Collections.Immutable.ImmutableArray`1[Microsoft.CodeAnalysis.Diagnostics.SemanticModelAnalyzerAction],Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer,Microsoft.CodeAnalysis.SemanticModel,Microsoft.CodeAnalysis.Diagnostics.AnalysisState+AnalyzerStateData):this
           2 ( 0.38% of base) : System.ComponentModel.Composition.dasm - System.ComponentModel.Composition.MetadataViewGenerator:.cctor()
           3 ( 0.37% of base) : System.Collections.Immutable.dasm - Enumerator:.ctor(System.Collections.Immutable.ImmutableList`1+Node[System.__Canon],System.Collections.Immutable.ImmutableList`1+Builder[System.__Canon],int,int,bool):this
           7 ( 0.32% of base) : System.Net.HttpListener.dasm - <CloseOutputAsyncCore>d__48:MoveNext():this
           9 ( 0.29% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - InferenceGraph:InferTypeArgumentsFromLambdaArgument(Microsoft.CodeAnalysis.VisualBasic.BoundExpression,Microsoft.CodeAnalysis.VisualBasic.Symbols.TypeSymbol,Microsoft.CodeAnalysis.VisualBasic.Symbols.ParameterSymbol):bool:this
           2 ( 0.23% of base) : System.Security.Cryptography.Algorithms.dasm - System.Security.Cryptography.DSAKeyFormatHelper:ReadDsaPrivateKey(System.ReadOnlyMemory`1[System.Byte],byref,byref)
           7 ( 0.17% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindLambdaBody(Microsoft.CodeAnalysis.VisualBasic.Symbols.LambdaSymbol,Microsoft.CodeAnalysis.DiagnosticBag,byref):Microsoft.CodeAnalysis.VisualBasic.BoundBlock:this
           2 ( 0.14% of base) : Microsoft.CodeAnalysis.dasm - <ProcessCompilationEventsAsync>d__58:MoveNext():this
           6 ( 0.09% of base) : System.Private.CoreLib.dasm - System.Number:NumberToStringFormat(byref,byref,System.ReadOnlySpan`1[System.Char],System.Globalization.NumberFormatInfo)

Top method improvements (percentages):
          -7 (-14.58% of base) : System.Security.Cryptography.Algorithms.dasm - BCryptAlgorithmCache:.cctor()
          -7 (-14.58% of base) : System.Security.Cryptography.Cng.dasm - BCryptAlgorithmCache:.cctor()
        -168 (-14.31% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.Collections.PooledHashSet`1:.cctor() (24 methods)
         -98 (-14.12% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.ArraySortHelper`1:.cctor() (14 methods)
          -7 (-14.00% of base) : xunit.runner.utility.netcoreapp10.dasm - CommonTasks:.cctor()
          -7 (-14.00% of base) : xunit.execution.dotnet.dasm - CommonTasks:.cctor()
         -77 (-14.00% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.ArraySortHelper`2:.cctor() (11 methods)
          -7 (-13.46% of base) : System.Security.Cryptography.Algorithms.dasm - Internal.Cryptography.HashAlgorithmNames:.cctor()
          -7 (-13.46% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.LookupResult:.cctor()
          -7 (-13.46% of base) : Microsoft.Extensions.DependencyModel.dasm - Microsoft.Extensions.DependencyModel.DependencyContextPaths:.cctor()
          -7 (-13.46% of base) : System.Formats.Cbor.dasm - System.Formats.Cbor.CborWriter:.cctor()
          -7 (-13.46% of base) : System.Diagnostics.Process.dasm - System.Runtime.Serialization.SerializationGuard:.cctor()
          -7 (-13.46% of base) : System.Security.Cryptography.Primitives.dasm - System.Security.Cryptography.CryptoConfigForwarder:.cctor()
          -7 (-13.46% of base) : System.Data.Common.dasm - System.Xml.XPathNodePointer:.cctor()
        -182 (-13.30% of base) : System.Private.CoreLib.dasm - EmptyArray`1:.cctor() (26 methods)
          -7 (-12.96% of base) : xunit.console.dasm - Internal.Microsoft.Extensions.DependencyModel.DependencyContextJsonReader:.cctor()
          -7 (-12.96% of base) : ILCompiler.TypeSystem.ReadyToRun.dasm - Internal.TypeSystem.FieldDesc:.cctor()
          -7 (-12.96% of base) : ILCompiler.TypeSystem.ReadyToRun.dasm - Internal.TypeSystem.MethodDesc:.cctor()
          -7 (-12.96% of base) : ILCompiler.TypeSystem.ReadyToRun.dasm - Internal.TypeSystem.TypeDesc:.cctor()
          -7 (-12.96% of base) : xunit.execution.dotnet.dasm - Xunit.Sdk.XunitTheoryTestCaseRunner:.cctor()

935 total methods with Code Size differences (911 improved, 24 regressed), 248576 unchanged.
```
win-x64 pmi diff:
```
Total bytes of base: 60438627
Total bytes of diff: 60436843
Total bytes of delta: -1784 (-0.00 % of base)

Top file regressions (bytes):
          17 : System.ComponentModel.Composition.dasm (0.00% of base)
          16 : ILCompiler.TypeSystem.ReadyToRun.dasm (0.01% of base)
          15 : System.Runtime.Numerics.dasm (0.02% of base)

Top file improvements (bytes):
        -441 : System.Security.Cryptography.Algorithms.dasm (-0.12% of base)
        -340 : FSharp.Core.dasm (-0.01% of base)
        -136 : System.Numerics.Tensors.dasm (-0.05% of base)
        -109 : System.Private.CoreLib.dasm (-0.00% of base)
         -79 : System.Runtime.Serialization.Formatters.dasm (-0.08% of base)
         -70 : System.Private.Xml.dasm (-0.00% of base)
         -54 : System.Data.Common.dasm (-0.00% of base)
         -48 : System.Linq.Parallel.dasm (-0.00% of base)
         -43 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
         -38 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00% of base)
         -35 : System.Security.Cryptography.Cng.dasm (-0.02% of base)
         -35 : System.DirectoryServices.dasm (-0.01% of base)
         -31 : System.Net.Quic.dasm (-0.03% of base)
         -27 : System.Collections.dasm (-0.00% of base)
         -22 : System.Net.HttpListener.dasm (-0.01% of base)
         -22 : xunit.console.dasm (-0.02% of base)
         -22 : System.Linq.Expressions.dasm (-0.00% of base)
         -21 : Microsoft.CSharp.dasm (-0.01% of base)
         -21 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.00% of base)
         -20 : System.IO.Packaging.dasm (-0.02% of base)

42 total files with Code Size differences (39 improved, 3 regressed), 229 unchanged.

Top method regressions (bytes):
          17 ( 0.82% of base) : System.ComponentModel.Composition.dasm - AttributedPartCreationInfo:GetExportDefinitions():IEnumerable`1:this
          16 ( 0.37% of base) : ILCompiler.TypeSystem.ReadyToRun.dasm - MetadataFieldLayoutAlgorithm:ComputeAutoFieldLayout(MetadataType,int):ComputedInstanceFieldLayout:this
          15 ( 0.23% of base) : System.Runtime.Numerics.dasm - Number:NumberToStringFormat(byref,byref,ReadOnlySpan`1,NumberFormatInfo)
           6 ( 0.09% of base) : System.Private.CoreLib.dasm - Number:NumberToStringFormat(byref,byref,ReadOnlySpan`1,NumberFormatInfo)
           2 ( 0.03% of base) : System.Collections.Immutable.dasm - Enumerator:.ctor(Node,Builder,int,int,bool):this (8 methods)
           1 ( 0.09% of base) : System.Security.Cryptography.Algorithms.dasm - DSAKeyFormatHelper:ReadDsaPrivateKey(ReadOnlyMemory`1,byref,byref)
           1 ( 0.11% of base) : System.Security.Cryptography.Algorithms.dasm - DSAKeyFormatHelper:ReadDsaPublicKey(ReadOnlyMemory`1,byref,byref)

Top method improvements (bytes):
         -96 (-3.03% of base) : System.Numerics.Tensors.dasm - Tensor`1:.ctor(ReadOnlySpan`1,bool):this (8 methods)
         -80 (-1.37% of base) : FSharp.Core.dasm - OperatorIntrinsics:GetArraySlice4DFixedSingle1(ref,int,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1):ref (8 methods)
         -80 (-1.38% of base) : FSharp.Core.dasm - OperatorIntrinsics:GetArraySlice4DFixedSingle2(ref,FSharpOption`1,FSharpOption`1,int,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1):ref (8 methods)
         -64 (-0.59% of base) : System.Private.CoreLib.dasm - DefaultBinder:BindToMethod(int,ref,byref,ref,CultureInfo,ref,byref):MethodBase:this
         -55 (-0.97% of base) : FSharp.Core.dasm - OperatorIntrinsics:GetArraySlice4DFixedSingle3(ref,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,int,FSharpOption`1,FSharpOption`1):ref (8 methods)
         -55 (-0.97% of base) : FSharp.Core.dasm - OperatorIntrinsics:GetArraySlice4DFixedSingle4(ref,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,int):ref (8 methods)
         -48 (-1.36% of base) : System.Linq.Parallel.dasm - QueryOpeningEnumerator`1:OpenQuery():this (8 methods)
         -40 (-1.46% of base) : System.Numerics.Tensors.dasm - Tensor`1:.ctor(Array,bool):this (8 methods)
         -35 (-1.81% of base) : FSharp.Core.dasm - Array2DModule:InitializeBased(int,int,int,int,FSharpFunc`2):ref (8 methods)
         -35 (-1.24% of base) : FSharp.Core.dasm - Array3DModule:Initialize(int,int,int,FSharpFunc`2):ref (8 methods)
         -22 (-1.01% of base) : xunit.console.dasm - DependencyContextAssemblyCache:ResolveUnmanagedLibrary(String):String:this
         -19 (-3.09% of base) : System.Security.Cryptography.Algorithms.dasm - AesImplementation:TryDecryptCfbCore(ReadOnlySpan`1,ReadOnlySpan`1,Span`1,int,int,byref):bool:this
         -19 (-3.09% of base) : System.Security.Cryptography.Algorithms.dasm - AesImplementation:TryEncryptCfbCore(ReadOnlySpan`1,ReadOnlySpan`1,Span`1,int,int,byref):bool:this
         -19 (-3.16% of base) : System.Security.Cryptography.Algorithms.dasm - DesImplementation:TryDecryptCfbCore(ReadOnlySpan`1,ReadOnlySpan`1,Span`1,int,int,byref):bool:this
         -19 (-3.16% of base) : System.Security.Cryptography.Algorithms.dasm - DesImplementation:TryEncryptCfbCore(ReadOnlySpan`1,ReadOnlySpan`1,Span`1,int,int,byref):bool:this
         -19 (-3.16% of base) : System.Security.Cryptography.Algorithms.dasm - TripleDesImplementation:TryDecryptCfbCore(ReadOnlySpan`1,ReadOnlySpan`1,Span`1,int,int,byref):bool:this
         -19 (-3.16% of base) : System.Security.Cryptography.Algorithms.dasm - TripleDesImplementation:TryEncryptCfbCore(ReadOnlySpan`1,ReadOnlySpan`1,Span`1,int,int,byref):bool:this
         -18 (-3.09% of base) : System.Security.Cryptography.Algorithms.dasm - AesImplementation:TryDecryptCbcCore(ReadOnlySpan`1,ReadOnlySpan`1,Span`1,int,byref):bool:this
         -18 (-3.50% of base) : System.Security.Cryptography.Algorithms.dasm - AesImplementation:TryDecryptEcbCore(ReadOnlySpan`1,Span`1,int,byref):bool:this
         -18 (-3.09% of base) : System.Security.Cryptography.Algorithms.dasm - AesImplementation:TryEncryptCbcCore(ReadOnlySpan`1,ReadOnlySpan`1,Span`1,int,byref):bool:this

Top method regressions (percentages):
          17 ( 0.82% of base) : System.ComponentModel.Composition.dasm - AttributedPartCreationInfo:GetExportDefinitions():IEnumerable`1:this
          16 ( 0.37% of base) : ILCompiler.TypeSystem.ReadyToRun.dasm - MetadataFieldLayoutAlgorithm:ComputeAutoFieldLayout(MetadataType,int):ComputedInstanceFieldLayout:this
          15 ( 0.23% of base) : System.Runtime.Numerics.dasm - Number:NumberToStringFormat(byref,byref,ReadOnlySpan`1,NumberFormatInfo)
           1 ( 0.11% of base) : System.Security.Cryptography.Algorithms.dasm - DSAKeyFormatHelper:ReadDsaPublicKey(ReadOnlyMemory`1,byref,byref)
           1 ( 0.09% of base) : System.Security.Cryptography.Algorithms.dasm - DSAKeyFormatHelper:ReadDsaPrivateKey(ReadOnlyMemory`1,byref,byref)
           6 ( 0.09% of base) : System.Private.CoreLib.dasm - Number:NumberToStringFormat(byref,byref,ReadOnlySpan`1,NumberFormatInfo)
           2 ( 0.03% of base) : System.Collections.Immutable.dasm - Enumerator:.ctor(Node,Builder,int,int,bool):this (8 methods)

Top method improvements (percentages):
         -10 (-9.80% of base) : System.Security.Cryptography.Algorithms.dasm - AesCcm:.ctor(ReadOnlySpan`1):this
         -10 (-9.80% of base) : System.Security.Cryptography.Algorithms.dasm - AesGcm:.ctor(ReadOnlySpan`1):this
         -10 (-9.35% of base) : System.Security.Cryptography.Algorithms.dasm - ChaCha20Poly1305:.ctor(ReadOnlySpan`1):this
          -7 (-6.09% of base) : Microsoft.CSharp.dasm - NamespaceSymbol:GetRootNamespaceSymbol():NamespaceSymbol
         -10 (-6.06% of base) : System.Security.Cryptography.Algorithms.dasm - AesCcm:.ctor(ref):this
         -10 (-6.06% of base) : System.Security.Cryptography.Algorithms.dasm - AesGcm:.ctor(ref):this
          -7 (-5.98% of base) : System.DirectoryServices.dasm - ReplicationCursor:get_SourceServer():String:this
         -10 (-5.88% of base) : System.Security.Cryptography.Algorithms.dasm - ChaCha20Poly1305:.ctor(ref):this
          -7 (-5.56% of base) : System.Private.Xml.dasm - XmlSqlBinaryReader:ImplReadPI():this
          -7 (-4.86% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - TraceEventCounts:get_Template():TraceEvent:this
          -7 (-4.70% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - TraceGC:get_GlobalCondemnedReasons():GCCondemnedReasons:this
         -10 (-4.57% of base) : System.Private.Xml.dasm - IdIterator:Create(XPathNavigator,String):this
         -10 (-3.82% of base) : System.Collections.dasm - TreeSubSet:.ctor(SortedSet`1,Vector`1,Vector`1,bool,bool):this
         -18 (-3.59% of base) : System.Security.Cryptography.Algorithms.dasm - TripleDesImplementation:TryDecryptEcbCore(ReadOnlySpan`1,Span`1,int,byref):bool:this
         -18 (-3.59% of base) : System.Security.Cryptography.Algorithms.dasm - TripleDesImplementation:TryEncryptEcbCore(ReadOnlySpan`1,Span`1,int,byref):bool:this
         -18 (-3.50% of base) : System.Security.Cryptography.Algorithms.dasm - AesImplementation:TryDecryptEcbCore(ReadOnlySpan`1,Span`1,int,byref):bool:this
         -18 (-3.50% of base) : System.Security.Cryptography.Algorithms.dasm - AesImplementation:TryEncryptEcbCore(ReadOnlySpan`1,Span`1,int,byref):bool:this
         -18 (-3.33% of base) : System.Security.Cryptography.Algorithms.dasm - DesImplementation:TryDecryptEcbCore(ReadOnlySpan`1,Span`1,int,byref):bool:this
         -18 (-3.33% of base) : System.Security.Cryptography.Algorithms.dasm - DesImplementation:TryEncryptEcbCore(ReadOnlySpan`1,Span`1,int,byref):bool:this
         -18 (-3.17% of base) : System.Security.Cryptography.Algorithms.dasm - TripleDesImplementation:TryDecryptCbcCore(ReadOnlySpan`1,ReadOnlySpan`1,Span`1,int,byref):bool:this

152 total methods with Code Size differences (145 improved, 7 regressed), 275971 unchanged.
```
Regressions caused by changes in prolog block init code.
