### PR TITLE
Add missing implicit by ref store GLOB_REF

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -165,7 +165,9 @@ public:
                                          // struct promotion.
     unsigned char lvLiveInOutOfHndlr : 1; // The variable is live in or out of an exception handler, and therefore must
                                           // be on the stack (at least at those boundaries.)
-
+#if defined(WINDOWS_AMD64_ABI) || defined(TARGET_ARM64)
+    unsigned char lvIsImplicitByRefArgTemp : 1;
+#endif
     unsigned char m_isSsa : 1; // The variable is in SSA form (set by SsaBuilder)
 
 #ifdef DEBUG
@@ -6787,13 +6789,13 @@ public:
     GenTree* abiNewMultiLoadIndir(GenTree* addr, ssize_t addrOffset, unsigned indirSize);
     GenTree* abiMorphMultiRegCallArg(CallArgInfo* argInfo, GenTreeCall* arg);
 #endif
-#ifndef TARGET_X86
+#if defined(WINDOWS_AMD64_ABI) || defined(TARGET_ARM64) || defined(TARGET_ARM)
     unsigned abiAllocateStructArgTemp(ClassLayout* argLayout);
     void abiFreeAllStructArgTemps();
-#if TARGET_64BIT
+#endif
+#if defined(WINDOWS_AMD64_ABI) || defined(TARGET_ARM64)
     void abiMorphImplicitByRefStructArg(GenTreeCall* call, CallArgInfo* argInfo);
 #endif
-#endif // !TARGET_X86
     void abiMorphStructReturn(GenTreeUnOp* ret, GenTree* val);
 
     bool killGCRefs(GenTree* tree);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4837,7 +4837,7 @@ private:
     GenTree* fgMorphLeaf(GenTree* tree);
     void gtAssignSetVarDef(GenTreeLclVarCommon* dst);
     GenTree* fgMorphInitStruct(GenTreeOp* asg);
-    GenTree* fgMorphPromoteLocalInitStruct(LclVarDsc* destLclVar, GenTree* initVal);
+    GenTree* fgMorphPromoteLocalInitStruct(GenTreeOp* asg, LclVarDsc* destLclVar, GenTree* initVal);
     GenTree* fgMorphInitStructConstant(GenTreeIntCon* initVal,
                                        var_types      type,
                                        bool           extendToActualType,

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4824,6 +4824,7 @@ private:
     GenTree* fgMorphPotentialTailCall(GenTreeCall* call, Statement* stmt);
     GenTree* fgGetStubAddrArg(GenTreeCall* call);
     void fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCall* recursiveTailCall);
+    void fgMorphCreateLclInit(unsigned lclNum, BasicBlock* block, Statement* beforeStmt, IL_OFFSETX ilOffset);
     Statement* fgAssignRecursiveCallArgToCallerParam(GenTree*       arg,
                                                      fgArgTabEntry* argTabEntry,
                                                      BasicBlock*    block,

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -294,7 +294,8 @@ public:
     unsigned char lvDisqualifyAddCopy : 1; // local isn't a candidate for optAddCopies
 #endif
 
-    unsigned char lvEHLive : 1; // local has EH references
+    unsigned char lvHasEHRefs : 1; // local has EH references
+    unsigned char lvHasEHUses : 1; // local has EH uses
 
 #ifndef TARGET_64BIT
     unsigned char lvStructDoubleAlign : 1; // Must we double align this struct?

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4851,6 +4851,10 @@ private:
     GenTree* fgMorphDynBlk(GenTreeDynBlk* dynBlk);
     GenTree* fgMorphBlockAssignment(GenTreeOp* asg);
     GenTree* fgMorphCopyStruct(GenTreeOp* asg);
+    GenTreeOp* fgMorphPromoteStore(GenTreeOp*  store,
+                                   GenTreeOp*  tempStore,
+                                   GenTreeOp** fieldStores,
+                                   unsigned    fieldCount);
     GenTree* fgMorphQmark(GenTreeQmark* qmark, MorphAddrContext* mac = nullptr);
     GenTree* fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac = nullptr);
     GenTree* fgMorphModToSubMulDiv(GenTreeOp* tree);

--- a/src/coreclr/jit/copyprop.cpp
+++ b/src/coreclr/jit/copyprop.cpp
@@ -277,7 +277,7 @@ public:
                 continue;
             }
 
-            if (!lcl->lvEHLive && newLcl->lvEHLive)
+            if (!lcl->lvHasEHRefs && newLcl->lvHasEHRefs)
             {
                 continue;
             }

--- a/src/coreclr/jit/earlyprop.cpp
+++ b/src/coreclr/jit/earlyprop.cpp
@@ -534,14 +534,6 @@ private:
 
     bool CanMoveNullCheckPastTree(GenTree* node, bool isInsideTry)
     {
-        if (node->OperIs(GT_COMMA))
-        {
-            return (!node->AsOp()->GetOp(0)->HasAnySideEffect(GTF_SIDE_EFFECT) ||
-                    CanMoveNullCheckPastTree(node->AsOp()->GetOp(0), isInsideTry)) &&
-                   (!node->AsOp()->GetOp(1)->HasAnySideEffect(GTF_SIDE_EFFECT) ||
-                    CanMoveNullCheckPastTree(node->AsOp()->GetOp(1), isInsideTry));
-        }
-
         if ((node->gtFlags & (GTF_CALL | GTF_EXCEPT)) != 0)
         {
             return false;

--- a/src/coreclr/jit/earlyprop.cpp
+++ b/src/coreclr/jit/earlyprop.cpp
@@ -534,6 +534,14 @@ private:
 
     bool CanMoveNullCheckPastTree(GenTree* node, bool isInsideTry)
     {
+        if (node->OperIs(GT_COMMA))
+        {
+            return (!node->AsOp()->GetOp(0)->HasAnySideEffect(GTF_SIDE_EFFECT) ||
+                    CanMoveNullCheckPastTree(node->AsOp()->GetOp(0), isInsideTry)) &&
+                   (!node->AsOp()->GetOp(1)->HasAnySideEffect(GTF_SIDE_EFFECT) ||
+                    CanMoveNullCheckPastTree(node->AsOp()->GetOp(1), isInsideTry));
+        }
+
         if ((node->gtFlags & (GTF_CALL | GTF_EXCEPT)) != 0)
         {
             return false;

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -3400,14 +3400,7 @@ void Compiler::fgDebugCheckStmtsList(BasicBlock* block, bool morphTrees)
             noway_assert(block->lastStmt() == stmt);
         }
 
-        /* For each statement check that the exception flags are properly set */
-
-        noway_assert(stmt->GetRootNode());
-
-        if (verbose && 0)
-        {
-            gtDispTree(stmt->GetRootNode());
-        }
+        noway_assert(stmt->GetRootNode() != nullptr);
 
         fgDebugCheckFlags(stmt->GetRootNode());
 

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -6663,6 +6663,7 @@ public:
 #endif
         , m_compilerAdded(false)
     {
+        assert(expr != nullptr);
     }
 
     GenTree* GetRootNode() const

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -6660,7 +6660,7 @@ void Compiler::phRemoveRedundantZeroInits()
                                     }
                                 }
 
-                                JITDUMP("Marking L%02u as having an explicit init\n", lclNum);
+                                JITDUMP("Marking V%02u as having an explicit init\n", lclNum);
                             }
                         }
                         break;

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -6052,7 +6052,7 @@ void Compiler::optAddCopies()
         isFloatParam = varDsc->IsParam() && varTypeIsFloating(typ);
 #endif
 
-        if (!isFloatParam && !varDsc->lvEHLive)
+        if (!isFloatParam && !varDsc->lvHasEHRefs)
         {
             continue;
         }
@@ -6185,7 +6185,7 @@ void Compiler::optAddCopies()
         // we require that we have a floating point parameter
         // or an EH live variable that is always reached from the first BB
         // and we have at least one block available in paramImportantUseDom
-        bool doCopy = (isFloatParam || (isDominatedByFirstBB && varDsc->lvEHLive)) &&
+        bool doCopy = (isFloatParam || (isDominatedByFirstBB && varDsc->lvHasEHRefs)) &&
                       !BlockSetOps::IsEmpty(this, paramImportantUseDom);
 
         // Under stress mode we expand the number of candidates

--- a/src/coreclr/jit/optloophoist.cpp
+++ b/src/coreclr/jit/optloophoist.cpp
@@ -885,9 +885,14 @@ public:
             }
             else if (tree->OperIs(GT_ASG))
             {
-                // If the LHS of the assignment has a global reference, then assume it's a global side effect.
-                GenTree* lhs = tree->AsOp()->gtOp1;
-                if (lhs->gtFlags & GTF_GLOB_REF)
+                GenTree* dst = tree->AsOp()->GetOp(0);
+
+                if (dst->HasAnySideEffect(GTF_GLOB_REF)
+#if defined(WINDOWS_AMD64_ABI) || defined(TARGET_ARM64)
+                    && (!dst->OperIs(GT_LCL_FLD, GT_LCL_VAR) ||
+                        !m_compiler->lvaGetDesc(dst->AsLclVarCommon())->lvIsImplicitByRefArgTemp)
+#endif
+                        )
                 {
                     m_beforeSideEffect = false;
                 }

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -6727,7 +6727,7 @@ void ValueNumStore::DumpMemOpaque(const VNFuncApp& memOpaque)
     }
     else
     {
-        printf("MemOpaque:L%02u", loopNum);
+        printf("MemOpaque:" FMT_LP, loopNum);
     }
 }
 


### PR DESCRIPTION
win-x64 pmi diff:
```
Total bytes of base: 60436038
Total bytes of diff: 60435724
Total bytes of delta: -314 (-0.00 % of base)
Total relative delta: -0.35
    diff is an improvement.
    relative diff is an improvement.

Top file regressions (bytes):
           9 : System.Linq.Parallel.dasm (0.00% of base)

Top file improvements (bytes):
        -114 : System.Threading.Tasks.Dataflow.dasm (-0.01% of base)
         -54 : System.Private.CoreLib.dasm (-0.00% of base)
         -29 : Microsoft.CodeAnalysis.dasm (-0.00% of base)
         -17 : System.Diagnostics.DiagnosticSource.dasm (-0.01% of base)
         -16 : System.Data.Common.dasm (-0.00% of base)
         -13 : System.Net.Http.dasm (-0.00% of base)
         -12 : System.Text.Json.dasm (-0.00% of base)
         -10 : System.Text.RegularExpressions.dasm (-0.00% of base)
          -6 : System.Data.OleDb.dasm (-0.00% of base)
          -6 : System.Private.Xml.dasm (-0.00% of base)
          -4 : Microsoft.Extensions.Logging.dasm (-0.01% of base)
          -4 : System.Net.Sockets.dasm (-0.00% of base)
          -4 : System.Diagnostics.Process.dasm (-0.00% of base)
          -4 : System.Data.Odbc.dasm (-0.00% of base)
          -3 : System.Security.Cryptography.Algorithms.dasm (-0.00% of base)
          -3 : System.Security.Cryptography.Cng.dasm (-0.00% of base)
          -3 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00% of base)
          -2 : ILCompiler.TypeSystem.ReadyToRun.dasm (-0.00% of base)
          -2 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
          -2 : System.Diagnostics.PerformanceCounter.dasm (-0.00% of base)

29 total files with Code Size differences (28 improved, 1 regressed), 242 unchanged.

Top method regressions (bytes):
           9 ( 0.10% of base) : System.Linq.Parallel.dasm - AsynchronousChannelMergeEnumerator`1:MoveNextSlowPath():bool:this (8 methods)
           6 ( 1.58% of base) : System.Private.CoreLib.dasm - Array:<IndexOf>g__GenericIndexOf|108_0(Array,Object,int,int):int (6 methods)
           6 ( 1.58% of base) : System.Private.CoreLib.dasm - Array:<LastIndexOf>g__GenericLastIndexOf|114_0(Array,Object,int,int):int (6 methods)
           2 ( 0.05% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:BindDelegateCreationExpression(ObjectCreationExpressionSyntax,NamedTypeSymbol,DiagnosticBag):BoundExpression:this
           2 ( 0.26% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - PENestedNamespaceSymbol:GetDeclaredAccessibilityOfMostAccessibleDescendantType():int:this
           2 ( 0.27% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SemanticModelMapsBuilder:GuardedCacheBoundNodes(BoundNode,MemberSemanticModel,SmallDictionary`2,VisualBasicSyntaxNode)

Top method improvements (bytes):
         -70 (-5.62% of base) : System.Threading.Tasks.Dataflow.dasm - JoinBlockTarget`1:ReleaseReservedMessage():this (8 methods)
         -32 (-1.68% of base) : System.Private.CoreLib.dasm - ConcurrentQueue`1:SnapForObservation(byref,byref,byref,byref):this (8 methods)
         -28 (-0.41% of base) : System.Threading.Tasks.Dataflow.dasm - SourceObservable`1:System.IObservable<TOutput>.Subscribe(IObserver`1):IDisposable:this (8 methods)
         -18 (-3.49% of base) : System.Private.CoreLib.dasm - BinaryReader:InternalReadChars(Span`1):int:this
         -16 (-0.39% of base) : System.Threading.Tasks.Dataflow.dasm - BatchBlockTargetCore:ProcessMessagesLoopCore():this (8 methods)
         -14 (-0.34% of base) : Microsoft.CodeAnalysis.dasm - ConcurrentLruCache`2:get_TestingEnumerable():IEnumerable`1:this (8 methods)
         -10 (-0.49% of base) : System.Text.RegularExpressions.dasm - RegexCache:Add(Key,Regex) (2 methods)
          -8 (-2.57% of base) : System.Diagnostics.DiagnosticSource.dasm - BaggageLinkedList:Remove(String):this
          -6 (-0.98% of base) : System.Private.CoreLib.dasm - <<WaitForCallbackToCompleteAsync>b__12_0>d:MoveNext():this
          -6 (-0.57% of base) : System.Private.Xml.dasm - <ThrowTagMismatchAsync>d__530:MoveNext():this
          -5 (-0.22% of base) : Microsoft.CodeAnalysis.CSharp.dasm - <GetEnumFieldsToEmit>d__66:MoveNext():bool:this
          -5 (-1.38% of base) : System.Diagnostics.DiagnosticSource.dasm - TagsLinkedList:Remove(String):this
          -4 (-0.15% of base) : System.Data.Common.dasm - DataRelation:set_Nested(bool):this
          -4 (-0.64% of base) : System.Diagnostics.DiagnosticSource.dasm - TagsLinkedList:ToString():String:this
          -4 (-0.46% of base) : System.Text.Json.dasm - Utf8JsonWriter:WriteString(ReadOnlySpan`1,String):this (2 methods)
          -4 (-0.12% of base) : System.Text.Json.dasm - Utf8JsonWriter:WriteStringEscapePropertyOrValue(ReadOnlySpan`1,ReadOnlySpan`1,int,int):this (4 methods)
          -3 (-0.21% of base) : Microsoft.CodeAnalysis.dasm - <GetAnalyzerDiagnosticsCoreAsync>d__44:MoveNext():this
          -3 (-0.83% of base) : System.Security.Cryptography.Algorithms.dasm - HashProviderCng:.ctor(String,ReadOnlySpan`1,bool):this
          -3 (-0.83% of base) : System.Security.Cryptography.Cng.dasm - HashProviderCng:.ctor(String,ReadOnlySpan`1,bool):this
          -3 (-0.17% of base) : Microsoft.CodeAnalysis.dasm - PEModule:EnsureForwardTypeToAssemblyMap():this

Top method regressions (percentages):
           6 ( 1.58% of base) : System.Private.CoreLib.dasm - Array:<IndexOf>g__GenericIndexOf|108_0(Array,Object,int,int):int (6 methods)
           6 ( 1.58% of base) : System.Private.CoreLib.dasm - Array:<LastIndexOf>g__GenericLastIndexOf|114_0(Array,Object,int,int):int (6 methods)
           2 ( 0.27% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SemanticModelMapsBuilder:GuardedCacheBoundNodes(BoundNode,MemberSemanticModel,SmallDictionary`2,VisualBasicSyntaxNode)
           2 ( 0.26% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - PENestedNamespaceSymbol:GetDeclaredAccessibilityOfMostAccessibleDescendantType():int:this
           9 ( 0.10% of base) : System.Linq.Parallel.dasm - AsynchronousChannelMergeEnumerator`1:MoveNextSlowPath():bool:this (8 methods)
           2 ( 0.05% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:BindDelegateCreationExpression(ObjectCreationExpressionSyntax,NamedTypeSymbol,DiagnosticBag):BoundExpression:this

Top method improvements (percentages):
         -70 (-5.62% of base) : System.Threading.Tasks.Dataflow.dasm - JoinBlockTarget`1:ReleaseReservedMessage():this (8 methods)
         -18 (-3.49% of base) : System.Private.CoreLib.dasm - BinaryReader:InternalReadChars(Span`1):int:this
          -8 (-2.57% of base) : System.Diagnostics.DiagnosticSource.dasm - BaggageLinkedList:Remove(String):this
          -1 (-2.44% of base) : System.Net.Http.dasm - MultiArrayBuffer:EnsureAvailableSpace(int):this
          -1 (-2.44% of base) : System.Net.Quic.dasm - MultiArrayBuffer:EnsureAvailableSpace(int):this
         -32 (-1.68% of base) : System.Private.CoreLib.dasm - ConcurrentQueue`1:SnapForObservation(byref,byref,byref,byref):this (8 methods)
          -5 (-1.38% of base) : System.Diagnostics.DiagnosticSource.dasm - TagsLinkedList:Remove(String):this
          -2 (-1.13% of base) : System.Private.CoreLib.dasm - ContingentProperties:UnregisterCancellationCallback():this
          -6 (-0.98% of base) : System.Private.CoreLib.dasm - <<WaitForCallbackToCompleteAsync>b__12_0>d:MoveNext():this
          -2 (-0.89% of base) : System.Private.CoreLib.dasm - ConcurrentExclusiveSchedulerPair:Complete():this
          -3 (-0.83% of base) : System.Security.Cryptography.Algorithms.dasm - HashProviderCng:.ctor(String,ReadOnlySpan`1,bool):this
          -3 (-0.83% of base) : System.Security.Cryptography.Cng.dasm - HashProviderCng:.ctor(String,ReadOnlySpan`1,bool):this
          -2 (-0.79% of base) : System.Private.CoreLib.dasm - String:GetNonRandomizedHashCodeOrdinalIgnoreCase():int:this
          -2 (-0.75% of base) : System.Private.CoreLib.dasm - ConcurrentExclusiveTaskScheduler:QueueTask(Task):this
          -4 (-0.64% of base) : System.Diagnostics.DiagnosticSource.dasm - TagsLinkedList:ToString():String:this
          -6 (-0.57% of base) : System.Private.Xml.dasm - <ThrowTagMismatchAsync>d__530:MoveNext():this
          -2 (-0.56% of base) : Microsoft.Extensions.Logging.dasm - LoggerFactory:RefreshFilters(LoggerFilterOptions):this
          -2 (-0.54% of base) : System.Private.CoreLib.dasm - ResourceManager:ReleaseAllResources():this
          -2 (-0.51% of base) : System.Text.Json.dasm - Utf8JsonWriter:WriteBase64String(String,ReadOnlySpan`1):this
         -10 (-0.49% of base) : System.Text.RegularExpressions.dasm - RegexCache:Add(Key,Regex) (2 methods)

74 total methods with Code Size differences (68 improved, 6 regressed), 276049 unchanged.
```
Regressions due to extra loop hoisting and a few NULLCHECKs that were incorrectly eliminated.

PIN: 10,379,984,467 10,337,345,853 -42,638,614 -0.41%
