### PR TITLE
Remove ASG from SSA

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3141,26 +3141,37 @@ private:
                 // can be done when the struct fits in a register. Otherwise we may
                 // need a STRUCT typed constant node instead of abusing GT_CNS_INT.
 
-                if ((user != nullptr) &&
-                    ((user->OperIs(GT_ASG) && (user->AsOp()->GetOp(1) == tree)) || user->IsInsert()) &&
-                    ((tree->gtFlags & GTF_SIDE_EFFECT) == 0) &&
+                if ((user != nullptr) && ((tree->gtFlags & GTF_SIDE_EFFECT) == 0) &&
                     (m_vnStore->ExtractValue(tree->GetConservativeVN()) == m_vnStore->ZeroMapVN()))
                 {
                     if (user->OperIs(GT_ASG))
                     {
-                        user->AsOp()->SetOp(1, m_compiler->gtNewIconNode(0));
+                        if (user->AsOp()->GetOp(1) == tree)
+                        {
+                            user->AsOp()->SetOp(1, m_compiler->gtNewIconNode(0));
+                            m_stmtMorphPending = true;
+                        }
                     }
-                    else if (user->AsInsert()->GetStructValue() == tree)
+                    else if (user->OperIs(GT_STORE_LCL_VAR, GT_STORE_LCL_FLD))
                     {
-                        user->AsInsert()->SetStructValue(m_compiler->gtNewIconNode(0));
+                        assert(user->AsLclVarCommon()->GetOp(0) == tree);
+                        user->AsOp()->SetOp(0, m_compiler->gtNewIconNode(0));
+                        m_stmtMorphPending = true;
                     }
-                    else
+                    else if (GenTreeInsert* insert = user->IsInsert())
                     {
-                        assert(user->AsInsert()->GetFieldValue() == tree);
-                        user->AsInsert()->SetFieldValue(m_compiler->gtNewIconNode(0));
+                        if (user->AsInsert()->GetStructValue() == tree)
+                        {
+                            user->AsInsert()->SetStructValue(m_compiler->gtNewIconNode(0));
+                            m_stmtMorphPending = true;
+                        }
+                        else
+                        {
+                            assert(user->AsInsert()->GetFieldValue() == tree);
+                            user->AsInsert()->SetFieldValue(m_compiler->gtNewIconNode(0));
+                            m_stmtMorphPending = true;
+                        }
                     }
-
-                    m_stmtMorphPending = true;
                 }
 
                 return Compiler::WALK_CONTINUE;

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -654,10 +654,11 @@ void CodeGen::SpillRegCandidateLclVar(GenTreeLclVar* lclVar)
     LclVarDsc* lcl = compiler->lvaGetDesc(lclVar);
 
     assert(lcl->IsRegCandidate());
+    assert(lclVar->OperIs(GT_LCL_VAR, GT_STORE_LCL_VAR));
     assert(lclVar->IsRegSpill(0));
 
     // We don't actually need to spill if it is already living in memory
-    bool needsSpill = ((lclVar->gtFlags & GTF_VAR_DEF) == 0) && (lcl->GetRegNum() != REG_STK);
+    bool needsSpill = lclVar->OperIs(GT_LCL_VAR) && (lcl->GetRegNum() != REG_STK);
 
     if (needsSpill)
     {
@@ -699,7 +700,7 @@ void CodeGen::SpillRegCandidateLclVar(GenTreeLclVar* lclVar)
     {
         // We only have SPILL and SPILLED on a def of a write-thru lclVar
         // or a single-def var that is to be spilled at its definition.
-        assert(lcl->IsAlwaysAliveInMemory() && ((lclVar->gtFlags & GTF_VAR_DEF) != 0));
+        assert(lcl->IsAlwaysAliveInMemory() && lclVar->OperIs(GT_STORE_LCL_VAR));
     }
 
 #ifdef USING_VARIABLE_LIVE_RANGE

--- a/src/coreclr/jit/earlyprop.cpp
+++ b/src/coreclr/jit/earlyprop.cpp
@@ -511,11 +511,6 @@ private:
 
         if ((node->gtFlags & GTF_ASG) != 0)
         {
-            if (node->OperIs(GT_ASG))
-            {
-                return false;
-            }
-
             if (node->OperIs(GT_STORE_LCL_VAR, GT_STORE_LCL_FLD))
             {
                 return CanMoveNullCheckPastLclStore(node->AsLclVarCommon(), isInsideTry);
@@ -540,16 +535,6 @@ private:
         }
 
         assert((node->gtFlags & GTF_ASG) != 0);
-
-        if (node->OperIs(GT_ASG))
-        {
-            if ((node->AsOp()->GetOp(1)->gtFlags & GTF_ASG) != 0)
-            {
-                return false;
-            }
-
-            return false;
-        }
 
         if (node->OperIs(GT_STORE_LCL_VAR, GT_STORE_LCL_FLD))
         {

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2823,33 +2823,6 @@ void Compiler::fgDebugCheckFlags(GenTree* tree)
         GenTree* op1 = tree->AsOp()->gtOp1;
         GenTree* op2 = tree->gtGetOp2IfPresent();
 
-        // During GS work, we make shadow copies for params.
-        // In gsParamsToShadows(), we create a shadow var of TYP_INT for every small type param.
-        // Then in gsReplaceShadowParams(), we change the gtLclNum to the shadow var.
-        // We also change the types of the local var tree and the assignment tree to TYP_INT if necessary.
-        // However, since we don't morph the tree at this late stage. Manually propagating
-        // TYP_INT up to the GT_ASG tree is only correct if we don't need to propagate the TYP_INT back up.
-        // The following checks will ensure this.
-
-        // Is the left child of "tree" a GT_ASG?
-        //
-        // If parent is a TYP_VOID, we don't no need to propagate TYP_INT up. We are fine.
-        // (or) If GT_ASG is the left child of a GT_COMMA, the type of the GT_COMMA node will
-        // be determined by its right child. So we don't need to propagate TYP_INT up either. We are fine.
-        if (op1 && op1->gtOper == GT_ASG)
-        {
-            assert(tree->gtType == TYP_VOID || tree->gtOper == GT_COMMA);
-        }
-
-        // Is the right child of "tree" a GT_ASG?
-        //
-        // If parent is a TYP_VOID, we don't no need to propagate TYP_INT up. We are fine.
-        if (op2 && op2->gtOper == GT_ASG)
-        {
-            // We can have ASGs on the RHS of COMMAs in setup arguments to a call.
-            assert(tree->gtType == TYP_VOID || tree->gtOper == GT_COMMA);
-        }
-
         switch (oper)
         {
             case GT_QMARK:

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2823,6 +2823,8 @@ void Compiler::fgDebugCheckFlags(GenTree* tree)
         GenTree* op1 = tree->AsOp()->gtOp1;
         GenTree* op2 = tree->gtGetOp2IfPresent();
 
+        assert(!tree->IsReverseOp() || ((op1 != nullptr) && (op2 != nullptr)));
+
         switch (oper)
         {
             case GT_QMARK:
@@ -2937,41 +2939,6 @@ void Compiler::fgDebugCheckFlags(GenTree* tree)
         if (op2)
         {
             chkFlags |= (op2->gtFlags & GTF_ALL_EFFECT);
-        }
-
-        // We reuse the value of GTF_REVERSE_OPS for a GT_IND-specific flag,
-        // so exempt that (unary) operator.
-        if (tree->OperGet() != GT_IND && tree->gtFlags & GTF_REVERSE_OPS)
-        {
-            /* Must have two operands if GTF_REVERSE is set */
-            noway_assert(op1 && op2);
-
-            /* Make sure that the order of side effects has not been swapped. */
-
-            /* However CSE may introduce an assignment after the reverse flag
-               was set and thus GTF_ASG cannot be considered here. */
-
-            /* For a GT_ASG(GT_IND(x), y) we are interested in the side effects of x */
-            GenTree* op1p;
-            if ((oper == GT_ASG) && (op1->gtOper == GT_IND))
-            {
-                op1p = op1->AsOp()->gtOp1;
-            }
-            else
-            {
-                op1p = op1;
-            }
-
-            /* This isn't true any more with the sticky GTF_REVERSE */
-            /*
-            // if op1p has side effects, then op2 cannot have side effects
-            if (op1p->gtFlags & (GTF_SIDE_EFFECT & ~GTF_ASG))
-            {
-                if (op2->gtFlags & (GTF_SIDE_EFFECT & ~GTF_ASG))
-                    gtDispTree(tree);
-                noway_assert(!(op2->gtFlags & (GTF_SIDE_EFFECT & ~GTF_ASG)));
-            }
-            */
         }
 
         if (tree->OperRequiresAsgFlag())

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2797,6 +2797,11 @@ void Compiler::fgDebugCheckFlags(GenTree* tree)
         chkFlags |= GTF_CALL;
     }
 
+    if (tree->OperRequiresAsgFlag())
+    {
+        chkFlags |= GTF_ASG;
+    }
+
     /* Is this a leaf node? */
 
     if (kind & GTK_LEAF)
@@ -2940,11 +2945,6 @@ void Compiler::fgDebugCheckFlags(GenTree* tree)
         {
             chkFlags |= (op2->gtFlags & GTF_ALL_EFFECT);
         }
-
-        if (tree->OperRequiresAsgFlag())
-        {
-            chkFlags |= GTF_ASG;
-        }
     }
 
     /* See what kind of a special operator we have here */
@@ -3061,10 +3061,6 @@ void Compiler::fgDebugCheckFlags(GenTree* tree)
 
 #ifdef FEATURE_HW_INTRINSICS
             case GT_HWINTRINSIC:
-                if (tree->OperRequiresAsgFlag())
-                {
-                    chkFlags |= GTF_ASG;
-                }
                 for (GenTreeHWIntrinsic::Use& use : tree->AsHWIntrinsic()->Uses())
                 {
                     fgDebugCheckFlags(use.GetNode());

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -1067,8 +1067,6 @@ AGAIN:
         return false;
     }
 
-    /* Is this a leaf node? */
-
     if (kind & GTK_LEAF)
     {
         switch (oper)
@@ -1090,8 +1088,6 @@ AGAIN:
 
         return false;
     }
-
-    /* Is it a 'simple' unary/binary operator? */
 
     if (kind & GTK_UNOP)
     {
@@ -1222,8 +1218,6 @@ AGAIN:
             goto AGAIN;
         }
     }
-
-    /* See what kind of a special operator we have here */
 
     switch (oper)
     {
@@ -1390,8 +1384,6 @@ AGAIN:
         goto DONE;
     }
 
-    /* Is it a 'simple' unary/binary operator? */
-
     GenTree* op1;
 
     if (kind & GTK_UNOP)
@@ -1516,7 +1508,6 @@ AGAIN:
         goto AGAIN;
     }
 
-    /* See what kind of a special operator we have here */
     switch (tree->gtOper)
     {
         case GT_ARR_ELEM:
@@ -2409,8 +2400,6 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
         goto DONE;
     }
 
-    /* Is it a 'simple' unary/binary operator? */
-
     if (kind & GTK_SMPOP)
     {
         int      lvlb; // preference for op2
@@ -3242,8 +3231,6 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
 
         goto DONE;
     }
-
-    /* See what kind of a special operator we have here */
 
     switch (oper)
     {
@@ -5511,8 +5498,6 @@ GenTree* Compiler::gtCloneExpr(
 
         goto DONE;
     }
-
-    /* See what kind of a special operator we have here */
 
     switch (oper)
     {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -3729,31 +3729,24 @@ bool GenTree::OperIsImplicitIndir() const
 {
     switch (gtOper)
     {
-        case GT_LOCKADD:
-        case GT_XORR:
-        case GT_XAND:
-        case GT_XADD:
-        case GT_XCHG:
-        case GT_CMPXCHG:
-        case GT_BLK:
-        case GT_OBJ:
-        case GT_STORE_BLK:
-        case GT_STORE_OBJ:
         case GT_COPY_BLK:
         case GT_INIT_BLK:
-        case GT_BOX:
+        // TODO-MIKE-Review: Are these needed? The actual element load/store is a separate
+        // node, these just compute the address/offset of an element. They do load the array
+        // bounds from memory but those are invariant and can probably be ignored. They're
+        // similar to ARR_LEN in this regard, which is already ignored.
         case GT_ARR_INDEX:
         case GT_ARR_ELEM:
         case GT_ARR_OFFSET:
             return true;
+
 #ifdef FEATURE_HW_INTRINSICS
         case GT_HWINTRINSIC:
-        {
             return AsHWIntrinsic()->OperIsMemoryLoadOrStore();
-        }
-#endif // FEATURE_HW_INTRINSICS
+#endif
+
         default:
-            return false;
+            return OperIsAtomicOp(gtOper);
     }
 }
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2857,11 +2857,6 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
 
                 goto DONE;
 
-            case GT_LCL_DEF:
-                costEx = 0;
-                costSz = 0;
-                break;
-
             case GT_ASG:
                 /* Assignments need a bit of special handling */
                 /* Process the target */

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2926,23 +2926,7 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                         case GT_IND:
                         case GT_BLK:
                         case GT_OBJ:
-                            // In an indirection, the destination address is evaluated prior to the source.
-                            // If we have any side effects on the target indirection,
-                            // we have to evaluate op1 first.
-                            // However, if the LHS is a lclVar address, SSA relies on using evaluation order for its
-                            // renaming, and therefore the RHS must be evaluated first.
-                            // If we have an assignment involving a lclVar address, the LHS may be marked as having
-                            // side-effects.
-                            // However the side-effects won't require that we evaluate the LHS address first:
-                            // - The GTF_GLOB_REF might have been conservatively set on a field of a local.
-                            // - The local might be address-exposed, but that side-effect happens at the actual
-                            // assignment (not
-                            //   when its address is "evaluated") so it doesn't change the side effect to "evaluate" the
-                            //   address
-                            //   after the RHS (note that in this case it won't be renamed by SSA anyway, but the
-                            //   reordering is
-                            //   safe).
-
+                            // TODO-MIKE-Cleanup: This stuff is a complete mess.
                             if (!op1->AsIndir()->GetAddr()->IsLocalAddrExpr() &&
                                 (op1->AsIndir()->GetAddr()->HasAnySideEffect(GTF_ALL_EFFECT) ||
                                  op2->HasAnySideEffect(GTF_ASG) || op2->OperIsLeaf()))

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -3803,14 +3803,14 @@ bool GenTree::OperMayThrow(Compiler* comp)
 
         case GT_STORE_BLK:
         case GT_STORE_OBJ:
+        case GT_IND:
+        case GT_BLK:
             if (AsBlk()->GetLayout()->GetSize() == 0)
             {
                 return false;
             }
             FALLTHROUGH;
         case GT_STOREIND:
-        case GT_IND:
-        case GT_BLK:
         case GT_OBJ:
         case GT_NULLCHECK:
             return (((gtFlags & GTF_IND_NONFAULTING) == 0) && comp->fgAddrCouldBeNull(AsIndir()->Addr()));

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -11748,7 +11748,7 @@ bool GenTree::IsPhiDef() const
 
 bool GenTree::IsPartialLclFld(Compiler* comp)
 {
-    if (gtOper != GT_LCL_FLD)
+    if ((gtOper != GT_LCL_FLD) && (gtOper != GT_STORE_LCL_FLD))
     {
         return false;
     }

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -7508,71 +7508,25 @@ inline GenTree* GenTree::gtGetOp1() const
 }
 
 #ifdef DEBUG
-/* static */
 inline bool GenTree::RequiresNonNullOp2(genTreeOps oper)
 {
-    switch (oper)
-    {
-        case GT_FADD:
-        case GT_FSUB:
-        case GT_FMUL:
-        case GT_FDIV:
-        case GT_FMOD:
-        case GT_ADD:
-        case GT_SUB:
-        case GT_MUL:
-        case GT_DIV:
-        case GT_MOD:
-        case GT_UDIV:
-        case GT_UMOD:
-        case GT_OR:
-        case GT_XOR:
-        case GT_AND:
-        case GT_LSH:
-        case GT_RSH:
-        case GT_RSZ:
-        case GT_ROL:
-        case GT_ROR:
-        case GT_INDEX_ADDR:
-        case GT_ASG:
-        case GT_EQ:
-        case GT_NE:
-        case GT_LT:
-        case GT_LE:
-        case GT_GE:
-        case GT_GT:
-        case GT_COMMA:
-        case GT_MKREFANY:
-            return true;
-        default:
-            return false;
-    }
+    return GenTree::OperIsBinary(oper) && (oper != GT_LEA) && (oper != GT_INTRINSIC);
 }
-#endif // DEBUG
+#endif
 
 inline GenTree* GenTree::gtGetOp2() const
 {
     assert(OperIsBinary());
 
     GenTree* op2 = AsOp()->gtOp2;
-
-    // Only allow null op2 if the node type allows it, e.g. GT_LEA.
     assert((op2 != nullptr) || !RequiresNonNullOp2(gtOper));
-
     return op2;
 }
 
 inline GenTree* GenTree::gtGetOp2IfPresent() const
 {
-    /* AsOp()->gtOp2 is only valid for GTK_BINOP nodes. */
-
     GenTree* op2 = OperIsBinary() ? AsOp()->gtOp2 : nullptr;
-
-    // This documents the genTreeOps for which AsOp()->gtOp2 cannot be nullptr.
-    // This helps prefix in its analysis of code which calls gtGetOp2()
-
     assert((op2 != nullptr) || !RequiresNonNullOp2(gtOper));
-
     return op2;
 }
 

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1625,11 +1625,11 @@ public:
     // Returns true if it is a GT_COPY or GT_RELOAD of a multi-reg call node
     inline bool IsCopyOrReloadOfMultiRegCall() const;
 
-    bool OperRequiresAsgFlag();
+    bool OperRequiresAsgFlag() const;
 
-    bool OperRequiresCallFlag(Compiler* comp);
+    bool OperRequiresCallFlag(Compiler* comp) const;
 
-    bool OperMayThrow(Compiler* comp);
+    bool OperMayThrow(Compiler* comp) const;
 
     size_t GetNodeSize() const;
 
@@ -5314,7 +5314,7 @@ public:
     {
     }
 
-    NamedIntrinsic GetIntrinsic()
+    NamedIntrinsic GetIntrinsic() const
     {
         return m_intrinsicName;
     }

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -375,6 +375,8 @@ enum GenTreeFlags : unsigned
     GTF_USE_FLAGS             = 0x00004000, // Generated instruction uses the condition flags
     GTF_COMMON_MASK           = 0x0000FFFF, // Mask of all the flags above
 
+    GTF_SPECIFIC_MASK         = 0xFFFF0000, // Mask of all the flags below
+
     // LCL_VAR & co. specific flags
                               
     GTF_VAR_DEF               = 0x80000000, // Definition of a local (LCL_VAR|FLD ASG LHS or STORE_LCL_VAR|FLD)
@@ -386,7 +388,7 @@ enum GenTreeFlags : unsigned
     GTF_VAR_MULTIREG          = 0x02000000, // Struct or (on 32-bit platforms) LONG local store with a multireg source
                                             // (CALLs and some LONG operations on 32 bit - MUL_LONG, BITCAST)
                                             // returns its result in multiple registers such as a long multiply)
-    GTF_VAR_CLONED            = 0x00400000, // Node has been cloned (used by inlined to detect single use params)
+    GTF_VAR_CLONED            = 0x00400000, // Node has been cloned (used by inliner to detect single use params)
     GTF_VAR_CONTEXT           = 0x00200000, // Node is part of a runtime lookup tree (LCL_VAR)
                               
     // CALL specific flags

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -3042,7 +3042,7 @@ void Compiler::fgMorphArgs(GenTreeCall* const call)
 
         if (argInfo->HasLateUse())
         {
-            assert(arg->OperIs(GT_ARGPLACE, GT_ASG, GT_LCL_DEF, GT_STORE_LCL_VAR) ||
+            assert(arg->OperIs(GT_ARGPLACE, GT_ASG, GT_LCL_DEF, GT_STORE_LCL_VAR, GT_STORE_LCL_FLD) ||
                    (arg->OperIs(GT_COMMA) && arg->TypeIs(TYP_VOID)));
 
             argsSideEffects |= arg->gtFlags;

--- a/src/coreclr/jit/optloophoist.cpp
+++ b/src/coreclr/jit/optloophoist.cpp
@@ -891,7 +891,7 @@ public:
                     m_beforeSideEffect = false;
                 }
             }
-            else if (tree->OperIs(GT_XADD, GT_XORR, GT_XAND, GT_XCHG, GT_LOCKADD, GT_CMPXCHG, GT_MEMORYBARRIER))
+            else if (tree->OperIsAtomicOp() || tree->OperIs(GT_MEMORYBARRIER))
             {
                 // If this node is a MEMORYBARRIER or an Atomic operation
                 // then don't hoist and stop any further hoisting after this node

--- a/src/coreclr/jit/optloophoist.cpp
+++ b/src/coreclr/jit/optloophoist.cpp
@@ -105,7 +105,7 @@ void LoopHoist::HoistExpr(GenTree* expr, unsigned loopNum)
                 expr->GetID(), loopNum, loopTable[loopNum].lpFirst->bbNum, loopTable[loopNum].lpBottom->bbNum);
     JITDUMP("\n");
 
-    assert(!expr->OperIs(GT_ASG, GT_LCL_DEF, GT_STORE_LCL_VAR, GT_STORE_LCL_FLD));
+    assert(!expr->OperIs(GT_LCL_DEF, GT_STORE_LCL_VAR, GT_STORE_LCL_FLD, GT_STOREIND, GT_STORE_OBJ, GT_STORE_BLK));
 
     // Create a copy of the expression and mark it for CSE's.
     GenTree* hoistExpr = compiler->gtCloneExpr(expr, GTF_MAKE_CSE);
@@ -874,14 +874,9 @@ public:
                     }
                 }
             }
-            else if (tree->OperIs(GT_ASG))
+            else if (tree->OperIs(GT_STOREIND, GT_STORE_OBJ, GT_STORE_BLK))
             {
-                // If the LHS of the assignment has a global reference, then assume it's a global side effect.
-                GenTree* lhs = tree->AsOp()->gtOp1;
-                if (lhs->gtFlags & GTF_GLOB_REF)
-                {
-                    m_beforeSideEffect = false;
-                }
+                m_beforeSideEffect = false;
             }
             else if (tree->OperIs(GT_STORE_LCL_VAR, GT_STORE_LCL_FLD))
             {

--- a/src/coreclr/jit/ssabuilder.cpp
+++ b/src/coreclr/jit/ssabuilder.cpp
@@ -837,6 +837,8 @@ void SsaRenameDomTreeVisitor::RenameDef(GenTreeOp* asgNode, BasicBlock* block)
 
     GenTree* dst = asgNode->GetOp(0);
 
+    assert(!dst->OperIs(GT_COMMA));
+
     if (dst->OperIs(GT_LCL_VAR, GT_LCL_FLD))
     {
         GenTreeLclVarCommon* lclNode = dst->AsLclVarCommon();

--- a/src/coreclr/jit/treelifeupdater.cpp
+++ b/src/coreclr/jit/treelifeupdater.cpp
@@ -258,7 +258,7 @@ void CodeGenLivenessUpdater::UpdateLife(CodeGen* codeGen, GenTreeLclVarCommon* l
 
     if (spill)
     {
-        // TODO-MIKE-Review: There's somehting dubious going on here, or perhaps in LSRA. On ARM64 a last-use
+        // TODO-MIKE-Review: There's something dubious going on here, or perhaps in LSRA. On ARM64 a last-use
         // gets spilled and that results in an assert in "variable range". The range was already closed above
         // and SpillRegCandidateLclVar tries to update it for spill. It may be that SpillRegCandidateLclVar
         // needs to use siStartOrCloseVariableLiveRange instead of siUpdateVariableLiveRange in this case but

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -3937,7 +3937,7 @@ void ValueNumbering::NumberComma(GenTreeOp* comma)
 
 void ValueNumbering::SummarizeLoopAssignmentMemoryStores(GenTreeOp* asg, VNLoopMemorySummary& summary)
 {
-    GenTree* store = asg->GetOp(0)->SkipComma();
+    GenTree* store = asg->GetOp(0);
 
     if (store->OperIs(GT_LCL_VAR, GT_LCL_FLD))
     {
@@ -3958,11 +3958,6 @@ void ValueNumbering::NumberAssignment(GenTreeOp* asg)
 
     GenTree* store = asg->GetOp(0);
     GenTree* value = asg->GetOp(1);
-
-    for (; store->OperIs(GT_COMMA); store = store->AsOp()->GetOp(1))
-    {
-        store->SetVNP(ValueNumStore::VoidVNP());
-    }
 
     if (store->OperIs(GT_LCL_VAR))
     {

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -7645,17 +7645,11 @@ void ValueNumbering::NumberNode(GenTree* node)
             break;
 
         case GT_LCL_VAR:
-            if ((node->gtFlags & GTF_VAR_DEF) == 0)
-            {
-                NumberLclLoad(node->AsLclVar());
-            }
+            NumberLclLoad(node->AsLclVar());
             break;
 
         case GT_LCL_FLD:
-            if ((node->gtFlags & GTF_VAR_DEF) == 0)
-            {
-                NumberLclFldLoad(node->AsLclFld());
-            }
+            NumberLclFldLoad(node->AsLclFld());
             break;
 
         case GT_LCL_DEF:
@@ -7716,14 +7710,11 @@ void ValueNumbering::NumberNode(GenTree* node)
         case GT_IND:
         case GT_OBJ:
         case GT_BLK:
-            if ((node->gtFlags & GTF_IND_ASG_LHS) == 0)
-            {
-                NumberIndirLoad(node->AsIndir());
+            NumberIndirLoad(node->AsIndir());
 
-                if (node->OperMayThrow(compiler))
-                {
-                    AddNullRefExset(node, node->AsIndir()->GetAddr());
-                }
+            if (node->OperMayThrow(compiler))
+            {
+                AddNullRefExset(node, node->AsIndir()->GetAddr());
             }
             break;
 

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -7685,6 +7685,7 @@ void ValueNumbering::NumberNode(GenTree* node)
 
         case GT_COPY_BLK:
         case GT_INIT_BLK:
+            // TODO-MIKE-Review: These are missing exceptions, both from operands and NullRefException as well.
             ClearMemory(node DEBUGARG("dynamic sized init/copy block"));
             FALLTHROUGH;
         case GT_ARGPLACE:


### PR DESCRIPTION
pin: 10,335,650,745 10,293,131,007 -42,519,738 -0.41%

win-x64 pmi diff:
```
Total bytes of base: 60503972
Total bytes of diff: 60504007
Total bytes of delta: 35 (0.00 % of base)
Total relative delta: 0.15
    diff is a regression.
    relative diff is a regression.

Top file regressions (bytes):
          14 : System.Security.Cryptography.Csp.dasm (0.02% of base)
          12 : System.Private.Xml.dasm (0.00% of base)
           9 : System.Private.CoreLib.dasm (0.00% of base)

3 total files with Code Size differences (0 improved, 3 regressed), 268 unchanged.

Top method regressions (bytes):
          14 ( 4.28% of base) : System.Security.Cryptography.Csp.dasm - PasswordDeriveBytes:HashPrefix(CryptoStream):this
           9 ( 3.49% of base) : System.Private.CoreLib.dasm - HebrewNumber:ParseByChar(ushort,byref):int
           8 ( 4.17% of base) : System.Private.Xml.dasm - BigInteger:ShiftRight(int):this
           3 ( 2.70% of base) : System.Private.Xml.dasm - BitSet:Or(BitSet):this
           1 ( 0.66% of base) : System.Private.Xml.dasm - BitSet:And(BitSet):this

Top method regressions (percentages):
          14 ( 4.28% of base) : System.Security.Cryptography.Csp.dasm - PasswordDeriveBytes:HashPrefix(CryptoStream):this
           8 ( 4.17% of base) : System.Private.Xml.dasm - BigInteger:ShiftRight(int):this
           9 ( 3.49% of base) : System.Private.CoreLib.dasm - HebrewNumber:ParseByChar(ushort,byref):int
           3 ( 2.70% of base) : System.Private.Xml.dasm - BitSet:Or(BitSet):this
           1 ( 0.66% of base) : System.Private.Xml.dasm - BitSet:And(BitSet):this

5 total methods with Code Size differences (0 improved, 5 regressed), 276118 unchanged.
```
Diffs due to old code mishandling indirect assignment side effects.