### PR TITLE
Improve x86 switch codegen

### DIFF
--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -835,6 +835,12 @@ struct BasicBlock : private LIR::Range
     BasicBlock* GetSucc(unsigned i) const;
     BasicBlock* GetSucc(unsigned i, Compiler* comp);
 
+    BBswtDesc& GetSwitchDesc()
+    {
+        assert(bbJumpKind == BBJ_SWITCH);
+        return *bbJumpSwt;
+    }
+
     // SwitchTargets: convenience methods for enabling range-based `for` iteration over a switch block's targets, e.g.:
     //    for (BasicBlock* const bTarget : block->SwitchTargets()) ...
     //

--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -853,8 +853,8 @@ protected:
 #if defined(UNIX_AMD64_ABI) || defined(TARGET_ARM64)
     void GenStructStoreUnrollRegsWB(GenTreeObj* store);
 #endif
-    void GenJmpTable(GenTree* node, BasicBlock* switchBlock);
-    void genTableBasedSwitch(GenTreeOp* tree);
+    void GenJmpTable(GenTree* node, const BBswtDesc& switchDesc);
+    void GenSwitchTable(GenTreeOp* node);
     void genCodeForArrIndex(GenTreeArrIndex* treeNode);
     void genCodeForArrOffset(GenTreeArrOffs* treeNode);
     instruction genGetInsForOper(genTreeOps oper);

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -361,11 +361,11 @@ void CodeGen::GenNode(GenTree* treeNode, BasicBlock* block)
             break;
 
         case GT_JMPTABLE:
-            GenJmpTable(treeNode, block);
+            GenJmpTable(treeNode, block->GetSwitchDesc());
             break;
 
         case GT_SWITCH_TABLE:
-            genTableBasedSwitch(treeNode->AsOp());
+            GenSwitchTable(treeNode->AsOp());
             break;
 
         case GT_ARR_INDEX:

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -3110,6 +3110,12 @@ void CodeGen::GenSwitchTable(GenTreeOp* node)
     }
 #else
     emit.emitIns_R_ARX(INS_mov, EA_4BYTE, baseReg, baseReg, indexReg, 4, 0);
+    // TODO-MIKE-CQ: There should be no need to have 2 LEAs, one for the jump table address
+    // and one for the base label address, we can have one base address and make everything
+    // relative to that. But we may need special reloc support from crossgen to do that, as
+    // we don't know the delta between code and data sections.
+    // Also, is there any point in having a separate JMPTABLE node? It seems like it would
+    // only complicate this further.
     emit.emitIns_R_L(tempReg, compiler->fgFirstBB->emitLabel);
     emit.emitIns_R_R(INS_add, EA_8BYTE, baseReg, tempReg);
     emit.emitIns_R(INS_i_jmp, EA_8BYTE, baseReg);

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -2552,10 +2552,10 @@ unsigned emitter::emitCalculatePaddingForLoopAlignment(insGroup* ig, size_t offs
 void emitter::emitCheckFuncletBranch(instrDescJmp* jmp) const
 {
 #ifdef TARGET_XARCH
-    // An lea of a code address (for constant data stored with the code)
+    // An lea of a code or data address (for constant data stored with the code)
     // is treated like a jump for emission purposes but is not really a jump so
     // we don't have to check anything here.
-    if (jmp->idIns() == INS_lea)
+    if ((jmp->idIns() == INS_lea) || (jmp->idIns() == INS_mov))
     {
         return;
     }

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1124,7 +1124,7 @@ private:
         enum : uintptr_t
         {
             LabelTag = 0,
-#ifdef TARGET_ARM64
+#if defined(TARGET_ARM64) || defined(TARGET_X86)
             RoDataOffsetTag = 1,
 #endif
             InstrCountTag = 2,
@@ -1156,7 +1156,7 @@ private:
             _idAddrUnion.label = reinterpret_cast<uintptr_t>(label);
         }
 
-#ifdef TARGET_ARM64
+#if defined(TARGET_ARM64) || defined(TARGET_X86)
         bool HasRoDataOffset() const
         {
             return (_idAddrUnion.label & TagMask) == RoDataOffsetTag;

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -2861,7 +2861,11 @@ void emitter::emitIns_R_L(RegNum reg, insGroup* label)
     assert(label != nullptr);
 
     instrDescJmp* id = emitNewInstrJmp();
+#ifdef TARGET_X86
+    id->idIns(INS_mov);
+#else
     id->idIns(INS_lea);
+#endif
     id->idOpSize(EA_PTRSIZE);
     id->idInsFmt(IF_RWR_LABEL);
     id->idReg1(reg);
@@ -2869,7 +2873,11 @@ void emitter::emitIns_R_L(RegNum reg, insGroup* label)
     id->idSetIsCnsReloc(emitComp->opts.compReloc AMD64_ONLY(&&InDifferentRegions(emitCurIG, label)));
     INDEBUG(id->idDebugOnlyInfo()->idCatchRet = (codeGen->GetCurrentBlock()->bbJumpKind == BBJ_EHCATCHRET));
 
-    unsigned sz = AMD64_ONLY(1 +) 1 + 1 + 4; // REX 8D RM DISP32
+#ifdef TARGET_X86
+    unsigned sz = 1 + 4; // 0xB8 DISP32
+#else
+    unsigned sz = 1 + 1 + 1 + 4; // REX 0x8D RM DISP32
+#endif
     id->idCodeSize(sz);
     dispIns(id);
     emitCurIGsize += sz;
@@ -2877,7 +2885,11 @@ void emitter::emitIns_R_L(RegNum reg, insGroup* label)
 
 void emitter::emitIns_R_AH(instruction ins, regNumber reg, void* addr)
 {
+#ifdef TARGET_X86
+    assert(ins == INS_mov);
+#else
     assert((ins == INS_mov) || (ins == INS_lea));
+#endif
     assert(genIsValidIntReg(reg));
 
     instrDesc* id = emitNewInstrAmd(reinterpret_cast<ssize_t>(addr));
@@ -7245,7 +7257,6 @@ uint8_t* emitter::emitOutputIV(uint8_t* dst, instrDesc* id)
 
 uint8_t* emitter::emitOutputRL(uint8_t* dst, instrDescJmp* id, insGroup* ig)
 {
-    assert(id->idIns() == INS_lea);
     assert(id->idInsFmt() == IF_RWR_LABEL);
     assert(id->idOpSize() == EA_PTRSIZE);
     assert(id->idGCref() == GCT_NONE);
@@ -7255,15 +7266,31 @@ uint8_t* emitter::emitOutputRL(uint8_t* dst, instrDescJmp* id, insGroup* ig)
     unsigned labelOffs = id->GetLabel()->igOffs;
     uint8_t* labelAddr = emitOffsetToPtr(labelOffs);
 
-    // TODO-MIKE-CQ: For x86 this should really be mov, it can be more efficient.
+#ifdef TARGET_X86
+    assert(id->idIns() == INS_mov);
+    assert((0 <= id->idReg1()) && id->idReg1() <= 7);
+
+    dst += emitOutputByte(dst, 0xB8 + id->idReg1());
+
+    if (id->idIsCnsReloc())
+    {
+        dst += emitOutputLong(dst, 0);
+        emitRecordRelocation(dst - 4, labelAddr, IMAGE_REL_BASED_HIGHLOW);
+    }
+    else
+    {
+        dst += emitOutputLong(dst, reinterpret_cast<size_t>(labelAddr));
+    }
+#else
+    assert(id->idIns() == INS_lea);
+
     code_t code = 0x8D;
     assert(insCodeRM(INS_lea) == code);
-    AMD64_ONLY(code = AddRexWPrefix(code));
+    code = AddRexWPrefix(code);
     code = SetRMReg(INS_lea, id->idReg1(), EA_PTRSIZE, code);
-    AMD64_ONLY(dst += emitOutputRexPrefix(dst, code));
+    dst += emitOutputRexPrefix(dst, code);
     dst += emitOutputWord(dst, code | 0x0500);
 
-#ifdef TARGET_AMD64
     if (id->idIsCnsReloc())
     {
         dst += emitOutputLong(dst, 0);
@@ -7274,16 +7301,6 @@ uint8_t* emitter::emitOutputRL(uint8_t* dst, instrDescJmp* id, insGroup* ig)
         ssize_t distance = labelAddr - instrAddr - id->idCodeSize();
         assert(IsImm32(distance));
         dst += emitOutputLong(dst, distance);
-    }
-#else
-    if (id->idIsCnsReloc())
-    {
-        dst += emitOutputLong(dst, 0);
-        emitRecordRelocation(dst - 4, labelAddr, IMAGE_REL_BASED_HIGHLOW);
-    }
-    else
-    {
-        dst += emitOutputLong(dst, reinterpret_cast<size_t>(labelAddr));
     }
 #endif
 

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -101,6 +101,9 @@ void emitIns_R_C(instruction ins, emitAttr attr, regNumber reg, CORINFO_FIELD_HA
 void emitIns_C_R(instruction ins, emitAttr attr, CORINFO_FIELD_HANDLE field, regNumber reg);
 void emitIns_C_I(instruction ins, emitAttr attr, CORINFO_FIELD_HANDLE field, int32_t imm);
 void emitIns_R_L(RegNum reg, insGroup* label);
+#ifdef TARGET_X86
+void emitIns_R_L(RegNum reg, CORINFO_FIELD_HANDLE field);
+#endif
 void emitIns_R_AH(instruction ins, regNumber ireg, void* addr);
 void emitIns_AR(instruction ins, emitAttr attr, regNumber base, int32_t disp);
 void emitIns_ARX(instruction ins, emitAttr attr, regNumber base, regNumber index, unsigned scaled, int32_t disp);


### PR DESCRIPTION
win-x86 diff:
```
Total bytes of base: 29340801
Total bytes of diff: 29319270
Total bytes of delta: -21531 (-0.07 % of base)
Total relative delta: NaN
    diff is an improvement.
    relative diff is a regression.


Top file improvements (bytes):
       -4091 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.11% of base)
       -2879 : Microsoft.CodeAnalysis.CSharp.dasm (-0.10% of base)
       -2512 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.10% of base)
       -2313 : System.Private.Xml.dasm (-0.10% of base)
       -1264 : System.Linq.Expressions.dasm (-0.09% of base)
       -1072 : System.Private.CoreLib.dasm (-0.04% of base)
        -753 : Microsoft.VisualBasic.Core.dasm (-0.21% of base)
        -640 : Newtonsoft.Json.dasm (-0.14% of base)
        -560 : Microsoft.CodeAnalysis.dasm (-0.06% of base)
        -488 : System.Data.Common.dasm (-0.06% of base)
        -392 : Microsoft.CSharp.dasm (-0.15% of base)
        -356 : FSharp.Core.dasm (-0.06% of base)
        -300 : System.Net.Http.dasm (-0.07% of base)
        -256 : System.Private.DataContractSerialization.dasm (-0.05% of base)
        -224 : System.Text.RegularExpressions.dasm (-0.15% of base)
        -164 : System.Reflection.Metadata.dasm (-0.06% of base)
        -144 : System.Data.OleDb.dasm (-0.07% of base)
        -132 : ILCompiler.TypeSystem.ReadyToRun.dasm (-0.08% of base)
        -132 : Newtonsoft.Json.Bson.dasm (-0.23% of base)
        -128 : System.Data.Odbc.dasm (-0.09% of base)

122 total files with Code Size differences (122 improved, 0 regressed), 149 unchanged.

Top method improvements (bytes):
        -732 (-0.69% of base) : System.Linq.Expressions.dasm - System.Linq.Expressions.Interpreter.CallInstruction:FastCreate(System.Reflection.MethodInfo,System.Reflection.ParameterInfo[]):System.Linq.Expressions.Interpreter.CallInstruction (183 methods)
         -56 (-0.57% of base) : System.Private.CoreLib.dasm - System.ValueTuple`8:GetHashCodeCore(System.Collections.IEqualityComparer):int:this (14 methods)
         -56 (-2.95% of base) : System.Private.CoreLib.dasm - System.ValueTuple`8:System.Runtime.CompilerServices.ITuple.get_Item(int):System.Object:this (14 methods)
         -52 (-0.96% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Binder:FoldNeverOverflowBinaryOperators(int,Microsoft.CodeAnalysis.ConstantValue,Microsoft.CodeAnalysis.ConstantValue):System.Object
         -52 (-1.38% of base) : System.Text.Encoding.CodePages.dasm - System.Text.EncodingNLS:GetLocalizedEncodingNameResource(int):System.String
         -48 (-1.24% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Binder:DoUncheckedConversion(byte,Microsoft.CodeAnalysis.ConstantValue):System.Object
         -48 (-3.36% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.ExpressionLambdaRewriter:GetConversionHelperMethod(byte,byte):Microsoft.CodeAnalysis.VisualBasic.Symbols.MethodSymbol:this
         -44 (-2.59% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.ErrorFacts:GetWarningLevel(int):int
         -44 (-2.71% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.ErrorFacts:IsWarning(int):bool
         -44 (-0.92% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.ExpressionEvaluator:PerformCompileTimeBinaryOperation(ushort,byte,Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.CConst,Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.CConst,Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.ExpressionSyntax):Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.CConst
         -40 (-1.41% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.CodeGen.ILBuilder:EmitNumericConversion(int,int,bool):this
         -36 (-1.45% of base) : System.Net.Http.dasm - System.Net.Http.Headers.KnownHeaders:GetCandidate(System.Net.Http.Headers.KnownHeaders+BytePtrAccessor):System.Net.Http.Headers.KnownHeader
         -36 (-1.37% of base) : System.Net.Http.dasm - System.Net.Http.Headers.KnownHeaders:GetCandidate(System.Net.Http.Headers.KnownHeaders+StringAccessor):System.Net.Http.Headers.KnownHeader
         -32 (-1.57% of base) : Microsoft.VisualBasic.Core.dasm - Microsoft.VisualBasic.CompilerServices.ObjectType:AddObj(System.Object,System.Object):System.Object
         -32 (-1.28% of base) : Microsoft.VisualBasic.Core.dasm - Microsoft.VisualBasic.CompilerServices.ObjectType:IDivObj(System.Object,System.Object):System.Object
         -32 (-1.92% of base) : Microsoft.VisualBasic.Core.dasm - Microsoft.VisualBasic.CompilerServices.ObjectType:MulObj(System.Object,System.Object):System.Object
         -32 (-0.92% of base) : Microsoft.VisualBasic.Core.dasm - Microsoft.VisualBasic.CompilerServices.ObjectType:ObjTst(System.Object,System.Object,bool):int
         -32 (-1.85% of base) : Microsoft.VisualBasic.Core.dasm - Microsoft.VisualBasic.CompilerServices.ObjectType:SubObj(System.Object,System.Object):System.Object
         -31 (-1.10% of base) : Microsoft.VisualBasic.Core.dasm - Microsoft.VisualBasic.CompilerServices.ObjectType:ModObj(System.Object,System.Object):System.Object
         -28 (-0.88% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.LocalRewriter:MakeBinaryOperator(Microsoft.CodeAnalysis.CSharp.BoundBinaryOperator,Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode,int,Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol,Microsoft.CodeAnalysis.CSharp.Symbols.MethodSymbol,bool,bool,Microsoft.CodeAnalysis.CSharp.BoundUnaryOperator):Microsoft.CodeAnalysis.CSharp.BoundExpression:this

Top method improvements (percentages):
          -4 (-9.09% of base) : System.Data.Common.dasm - System.Data.ExpressionParser:IsAlpha(ushort):bool:this
          -4 (-9.09% of base) : System.Text.RegularExpressions.dasm - System.Text.RegularExpressions.RegexCode:OpcodeBacktracks(int):bool
          -4 (-8.70% of base) : System.Private.Xml.dasm - System.Xml.Xsl.IlGen.OptimizerPatterns:GetArgument(int):System.Object:this
          -8 (-8.42% of base) : System.Linq.Expressions.dasm - System.Dynamic.BinaryOperationBinder:OperationIsValid(int):bool
          -4 (-8.33% of base) : FSharp.Core.dasm - ChunkBySize@1469:get_CheckClose():bool:this
          -4 (-8.33% of base) : FSharp.Core.dasm - Distinct@1090:get_CheckClose():bool:this
          -4 (-8.33% of base) : FSharp.Core.dasm - DistinctBy@1098:get_CheckClose():bool:this
          -4 (-8.33% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.SymbolDisplayVisitor:IsEscapable(int):bool
          -4 (-8.33% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.SyntaxFacts:IsKeywordKind(ushort):bool
          -4 (-8.33% of base) : FSharp.Core.dasm - Pairwise@872:get_CheckClose():bool:this
          -4 (-8.33% of base) : FSharp.Core.dasm - SkipWhile@1327:get_CheckClose():bool:this
          -8 (-8.33% of base) : FSharp.Core.dasm - System-Collections-Generic-IReadOnlyDictionary<'Key, 'Value>-get_Keys@716:get_CheckClose():bool:this (2 methods)
          -8 (-8.33% of base) : FSharp.Core.dasm - System-Collections-Generic-IReadOnlyDictionary<'Key, 'Value>-get_Values@720:get_CheckClose():bool:this (2 methods)
          -4 (-8.33% of base) : System.IO.MemoryMappedFiles.dasm - System.IO.MemoryMappedFiles.MemoryMappedFile:GetFileAccess(int):int
          -4 (-8.33% of base) : FSharp.Core.dasm - Tail@1376:get_CheckClose():bool:this
          -4 (-8.33% of base) : FSharp.Core.dasm - TakeWhile@1308:get_CheckClose():bool:this
          -4 (-8.33% of base) : FSharp.Core.dasm - Truncate@863:get_CheckClose():bool:this
          -4 (-8.16% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.MetadataTypeCodeExtensions:HasShortFormSignatureEncoding(byte):bool
         -19 (-7.88% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.OverloadResolution:ResolveNotLiftedIntrinsicUnaryOperator(int,byte):byte
         -16 (-7.88% of base) : System.Linq.Expressions.dasm - System.Dynamic.Utils.TypeUtils:IsImplicitNumericConversion(System.Type,System.Type):bool

4257 total methods with Code Size differences (4257 improved, 0 regressed), 245266 unchanged.
```
win-x86 pmi diff:
```
Total bytes of base: 47174106
Total bytes of diff: 47105801
Total bytes of delta: -68305 (-0.14 % of base)
Total relative delta: -263.17
    diff is an improvement.
    relative diff is an improvement.


Top file improvements (bytes):
      -11478 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.22% of base)
       -8094 : Microsoft.CodeAnalysis.CSharp.dasm (-0.20% of base)
       -7227 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.25% of base)
       -6620 : System.Private.Xml.dasm (-0.21% of base)
       -4150 : System.Private.CoreLib.dasm (-0.09% of base)
       -4018 : FSharp.Core.dasm (-0.13% of base)
       -2086 : Microsoft.VisualBasic.Core.dasm (-0.52% of base)
       -1817 : System.Linq.Expressions.dasm (-0.29% of base)
       -1762 : Newtonsoft.Json.dasm (-0.25% of base)
       -1515 : Microsoft.CodeAnalysis.dasm (-0.10% of base)
       -1328 : System.Data.Common.dasm (-0.10% of base)
       -1083 : Microsoft.CSharp.dasm (-0.34% of base)
        -899 : System.Linq.dasm (-0.10% of base)
        -878 : System.Text.RegularExpressions.dasm (-0.39% of base)
        -720 : System.Private.DataContractSerialization.dasm (-0.11% of base)
        -701 : System.Net.Http.WinHttpHandler.dasm (-0.83% of base)
        -682 : System.Reflection.Metadata.dasm (-0.14% of base)
        -662 : ILCompiler.Reflection.ReadyToRun.dasm (-0.42% of base)
        -651 : System.Net.Http.dasm (-0.10% of base)
        -557 : System.Drawing.Common.dasm (-0.18% of base)

139 total files with Code Size differences (139 improved, 0 regressed), 132 unchanged.

Top method improvements (bytes):
        -285 (-2.37% of base) : ILCompiler.Reflection.ReadyToRun.dasm - <ParsePgoData>d__6`1:MoveNext():bool:this (8 methods)
        -187 (-1.79% of base) : System.Linq.Expressions.dasm - CallInstruction:FastCreate(MethodInfo,ref):CallInstruction (17 methods)
        -176 (-1.10% of base) : System.Collections.Immutable.dasm - Enumerator:MoveNext():bool:this (88 methods)
        -147 (-2.20% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:FoldNeverOverflowBinaryOperators(int,ConstantValue,ConstantValue):Object
        -147 (-4.41% of base) : System.Text.Encoding.CodePages.dasm - EncodingNLS:GetLocalizedEncodingNameResource(int):String
        -132 (-6.32% of base) : System.Private.CoreLib.dasm - Avx2:GatherMaskVector128(Vector128`1,int,Vector128`1,Vector128`1,ubyte):Vector128`1 (12 methods)
        -132 (-6.88% of base) : System.Private.CoreLib.dasm - Avx2:GatherVector128(int,Vector128`1,ubyte):Vector128`1 (12 methods)
        -132 (-2.68% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:DoUncheckedConversion(byte,ConstantValue):Object
        -132 (-8.28% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - ExpressionLambdaRewriter:GetConversionHelperMethod(byte,byte):MethodSymbol:this
        -125 (-7.34% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ErrorFacts:GetWarningLevel(int):int
        -121 (-7.46% of base) : Microsoft.CodeAnalysis.CSharp.dasm - ErrorFacts:IsWarning(int):bool
        -119 (-7.90% of base) : FSharp.Core.dasm - Skip@1316:Close():this (8 methods)
        -119 (-7.90% of base) : FSharp.Core.dasm - Take@686:Close():this (8 methods)
        -114 (-1.86% of base) : Microsoft.CodeAnalysis.dasm - ILBuilder:EmitNumericConversion(int,int,bool):this
        -110 (-2.06% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - ExpressionEvaluator:PerformCompileTimeBinaryOperation(ushort,byte,CConst,CConst,ExpressionSyntax):CConst
         -96 (-1.16% of base) : CommandLine.dasm - <RenderUsageTextAsLines>d__56`1:MoveNext():bool:this (8 methods)
         -96 (-7.05% of base) : System.Linq.dasm - AppendPrepend1Iterator`1:MoveNext():bool:this (8 methods)
         -92 (-6.11% of base) : System.Threading.Tasks.Dataflow.dasm - SendAsyncSource`1:OfferToTarget():this (8 methods)
         -88 (-0.63% of base) : System.Threading.Tasks.Parallel.dasm - <<ForEachAsync>b__54_0>d:MoveNext():this (8 methods)
         -88 (-2.05% of base) : System.Threading.Tasks.Dataflow.dasm - <<ReceiveAllAsync>g__ReceiveAllAsyncCore|43_0>d`1:MoveNext():this (8 methods)

Top method improvements (percentages):
         -67 (-26.07% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - ErrorFacts:IsWarning(int):bool
         -11 (-25.00% of base) : System.Data.Common.dasm - ExpressionParser:IsAlpha(ushort):bool:this
         -22 (-25.00% of base) : System.Text.RegularExpressions.dasm - RegexCode:OpcodeBacktracks(int):bool (2 methods)
         -11 (-23.91% of base) : System.Private.Xml.dasm - OptimizerPatterns:GetArgument(int):Object:this
         -22 (-23.16% of base) : System.Linq.Expressions.dasm - BinaryOperationBinder:OperationIsValid(int):bool
         -11 (-22.92% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AccessorBlockSyntax:GetCachedSlot(int):SyntaxNode:this
         -11 (-22.92% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AccessorBlockSyntax:GetSlot(int):GreenNode:this
         -11 (-22.92% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AnonymousObjectCreationExpressionSyntax:GetSlot(int):GreenNode:this
         -11 (-22.92% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - ArgumentListSyntax:GetSlot(int):GreenNode:this
         -11 (-22.92% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - ArrayRankSpecifierSyntax:GetSlot(int):GreenNode:this
         -11 (-22.92% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AssignmentStatementSyntax:GetSlot(int):GreenNode:this
         -11 (-22.92% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AttributeListSyntax:GetSlot(int):GreenNode:this
         -11 (-22.92% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AttributeSyntax:GetCachedSlot(int):SyntaxNode:this
         -11 (-22.92% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AttributeSyntax:GetSlot(int):GreenNode:this
         -11 (-22.92% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BinaryExpressionSyntax:GetSlot(int):GreenNode:this
         -88 (-22.92% of base) : FSharp.Core.dasm - ChunkBySize@1469:get_CheckClose():bool:this (8 methods)
         -11 (-22.92% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - CollectionInitializerSyntax:GetSlot(int):GreenNode:this
         -11 (-22.92% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - CollectionRangeVariableSyntax:GetCachedSlot(int):SyntaxNode:this
         -11 (-22.92% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - ConditionalAccessExpressionSyntax:GetSlot(int):GreenNode:this
         -11 (-22.92% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - ConstructorBlockSyntax:GetCachedSlot(int):SyntaxNode:this

6366 total methods with Code Size differences (6366 improved, 0 regressed), 268930 unchanged.
```
