### PR TITLE
Do not use LEA for static fields on x86

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -881,6 +881,7 @@ protected:
     void genEHCatchRet(BasicBlock* block);
 #else
     void genEHFinallyOrFilterRet(BasicBlock* block);
+    void GenEndLFin(GenTreeEndLFin* node);
 #endif
 
 #ifndef WINDOWS_AMD64_ABI

--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -486,6 +486,8 @@ protected:
     unsigned           genTrnslLocalVarCount = 0;
 #endif
 
+    void GenClsVarAddr(GenTreeClsVar* node);
+
 #ifdef TARGET_XARCH
     void GenIntCon(GenTreeIntCon* node, regNumber reg, var_types type);
     void GenDblCon(GenTreeDblCon* node, regNumber reg, var_types type);

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -101,6 +101,14 @@ void CodeGen::genMov32RelocatableDataLabel(unsigned value, regNumber reg)
     }
 }
 
+void CodeGen::GenClsVarAddr(GenTreeClsVar* node)
+{
+    void* addr = compiler->info.compCompHnd->getFieldAddress(node->GetFieldHandle(), nullptr);
+    noway_assert(addr != nullptr);
+    instGen_Set_Reg_To_Addr(node->GetRegNum(), addr);
+    DefReg(node);
+}
+
 void CodeGen::instGen_Set_Reg_To_Zero(emitAttr size, regNumber reg)
 {
     GetEmitter()->emitIns_R_I(INS_mov, size, reg, 0);

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -1438,6 +1438,12 @@ void CodeGen::genEHCatchRet(BasicBlock* block)
     GetEmitter()->emitIns_R_L(REG_INTRET, block->bbJumpDest->emitLabel);
 }
 
+void CodeGen::GenClsVarAddr(GenTreeClsVar* node)
+{
+    GetEmitter()->emitIns_R_C(INS_adr, EA_8BYTE, node->GetRegNum(), REG_NA, node->GetFieldHandle());
+    DefReg(node);
+}
+
 void CodeGen::instGen_Set_Reg_To_Zero(emitAttr size, regNumber reg)
 {
     GetEmitter()->emitIns_R_I(INS_mov, size, reg, 0);

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -377,16 +377,7 @@ void CodeGen::GenNode(GenTree* treeNode, BasicBlock* block)
             break;
 
         case GT_CLS_VAR_ADDR:
-#ifdef TARGET_ARM
-            void* addr;
-            addr = compiler->info.compCompHnd->getFieldAddress(treeNode->AsClsVar()->GetFieldHandle(), nullptr);
-            noway_assert(addr != nullptr);
-            instGen_Set_Reg_To_Addr(treeNode->GetRegNum(), addr);
-#else
-            GetEmitter()->emitIns_R_C(INS_adr, EA_8BYTE, treeNode->GetRegNum(), REG_NA,
-                                      treeNode->AsClsVar()->GetFieldHandle());
-#endif
-            DefReg(treeNode);
+            GenClsVarAddr(treeNode->AsClsVar());
             break;
 
         case GT_INSTR:

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -1587,8 +1587,22 @@ void CodeGen::GenNode(GenTree* treeNode, BasicBlock* block)
             break;
 
         case GT_CLS_VAR_ADDR:
+#ifdef TARGET_X86
+            if (Emitter::IsRoDataField(treeNode->AsClsVar()->GetFieldHandle()))
+            {
+                GetEmitter()->emitIns_R_L(treeNode->GetRegNum(), treeNode->AsClsVar()->GetFieldHandle());
+            }
+            else
+            {
+                void* addr =
+                    compiler->info.compCompHnd->getFieldAddress(treeNode->AsClsVar()->GetFieldHandle(), nullptr);
+                noway_assert(addr != nullptr);
+                GetEmitter()->emitIns_R_H(INS_mov, treeNode->GetRegNum(), addr);
+            }
+#else
             GetEmitter()->emitIns_R_C(INS_lea, EA_PTRSIZE, treeNode->GetRegNum(),
                                       treeNode->AsClsVar()->GetFieldHandle());
+#endif
             DefReg(treeNode);
             break;
 


### PR DESCRIPTION
win-x86 pmi diff:
```
Total bytes of base: 47105801
Total bytes of diff: 47091304
Total bytes of delta: -14497 (-0.03 % of base)
Total relative delta: -68.72
    diff is an improvement.
    relative diff is an improvement.


Top file improvements (bytes):
       -1335 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.03% of base)
       -1046 : Microsoft.CodeAnalysis.dasm (-0.07% of base)
        -950 : Microsoft.CodeAnalysis.CSharp.dasm (-0.02% of base)
        -948 : System.Private.Xml.dasm (-0.03% of base)
        -859 : System.Private.CoreLib.dasm (-0.02% of base)
        -793 : CommandLine.dasm (-0.21% of base)
        -767 : System.Threading.Tasks.Dataflow.dasm (-0.09% of base)
        -716 : FSharp.Core.dasm (-0.02% of base)
        -561 : System.Linq.Expressions.dasm (-0.09% of base)
        -505 : System.Private.DataContractSerialization.dasm (-0.08% of base)
        -323 : System.Drawing.Common.dasm (-0.11% of base)
        -296 : System.Net.Http.dasm (-0.05% of base)
        -232 : Newtonsoft.Json.dasm (-0.03% of base)
        -230 : System.Linq.Parallel.dasm (-0.01% of base)
        -219 : System.Collections.Immutable.dasm (-0.02% of base)
        -199 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.01% of base)
        -193 : xunit.execution.dotnet.dasm (-0.10% of base)
        -187 : System.ComponentModel.TypeConverter.dasm (-0.09% of base)
        -164 : System.Data.Common.dasm (-0.01% of base)
        -161 : System.Linq.Queryable.dasm (-0.06% of base)

181 total files with Code Size differences (181 improved, 0 regressed), 90 unchanged.

Top method improvements (bytes):
        -365 (-2.06% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - _Closure$__:.cctor() (368 methods)
        -299 (-2.07% of base) : Microsoft.CodeAnalysis.CSharp.dasm - <>c:.cctor() (301 methods)
        -235 (-1.11% of base) : System.Private.Xml.dasm - XmlILMethods:.cctor()
        -167 (-1.84% of base) : FSharp.Core.dasm - $Query:.cctor()
        -165 (-1.78% of base) : System.Threading.Tasks.Dataflow.dasm - <>c:.cctor() (188 methods)
        -146 (-0.84% of base) : Microsoft.CodeAnalysis.dasm - AttributeDescription:.cctor()
        -141 (-2.36% of base) : System.Drawing.Common.dasm - Brushes:.cctor()
        -141 (-2.36% of base) : System.Drawing.Common.dasm - Pens:.cctor()
        -120 (-1.03% of base) : FSharp.Core.dasm - $Linq:.cctor()
        -113 (-1.90% of base) : System.Private.CoreLib.dasm - <>c:.cctor() (122 methods)
         -98 (-0.26% of base) : Microsoft.CodeAnalysis.dasm - AsyncQueue`1:WithCancellation(Task`1,CancellationToken):Task`1 (64 methods)
         -98 (-0.67% of base) : System.Linq.Parallel.dasm - ParallelQuery`1:OfType():ParallelQuery`1:this (64 methods)
         -96 (-1.98% of base) : Microsoft.CodeAnalysis.dasm - <>c:.cctor() (100 methods)
         -95 (-0.69% of base) : System.Net.Http.dasm - KnownHeaders:.cctor()
         -93 (-6.23% of base) : System.DirectoryServices.dasm - PropertyManager:.cctor()
         -79 (-0.87% of base) : System.Private.Xml.dasm - DatatypeImplementation:.cctor()
         -62 (-2.21% of base) : System.Private.DataContractSerialization.dasm - DictionaryGlobals:.cctor()
         -61 (-0.30% of base) : System.Private.Xml.dasm - XsdBuilder:.cctor()
         -58 (-2.65% of base) : System.Private.Xml.dasm - XmlQueryTypeFactory:.cctor()
         -55 (-1.51% of base) : System.ComponentModel.TypeConverter.dasm - StandardCommands:.cctor()

Top method improvements (percentages):
          -1 (-8.33% of base) : Microsoft.CodeAnalysis.dasm - CodeAnalysisResources:set_Culture(CultureInfo)
          -1 (-8.33% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CSharpResources:set_Culture(CultureInfo)
          -1 (-8.33% of base) : System.Private.CoreLib.dasm - CultureInfo:set_DefaultThreadCurrentCulture(CultureInfo)
          -1 (-8.33% of base) : System.Private.CoreLib.dasm - CultureInfo:set_UserDefaultLocaleName(String)
          -1 (-8.33% of base) : Microsoft.CodeAnalysis.dasm - FatalError:OverwriteHandler(Action`1)
          -1 (-8.33% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VBResources:set_Culture(CultureInfo)
          -1 (-7.14% of base) : System.Net.Security.dasm - SSPIAuthType:set_SecurityPackages(ref):this
          -1 (-7.14% of base) : System.Net.Http.dasm - SSPIAuthType:set_SecurityPackages(ref):this
          -1 (-7.14% of base) : System.Net.HttpListener.dasm - SSPIAuthType:set_SecurityPackages(ref):this
          -1 (-7.14% of base) : System.Net.Mail.dasm - SSPIAuthType:set_SecurityPackages(ref):this
          -1 (-7.14% of base) : System.Net.Security.dasm - SSPISecureChannelType:set_SecurityPackages(ref):this
          -1 (-7.14% of base) : System.Net.Http.dasm - SSPISecureChannelType:set_SecurityPackages(ref):this
          -1 (-7.14% of base) : System.Net.HttpListener.dasm - SSPISecureChannelType:set_SecurityPackages(ref):this
          -1 (-7.14% of base) : System.Net.Mail.dasm - SSPISecureChannelType:set_SecurityPackages(ref):this
         -93 (-6.23% of base) : System.DirectoryServices.dasm - PropertyManager:.cctor()
         -43 (-6.20% of base) : System.Data.Common.dasm - DbMetaDataColumnNames:.cctor()
         -17 (-6.14% of base) : System.Data.Common.dasm - SchemaTableColumn:.cctor()
         -14 (-6.11% of base) : System.Data.Common.dasm - SchemaTableOptionalColumn:.cctor()
          -9 (-6.04% of base) : System.Data.OleDb.dasm - OleDbMetaDataCollectionNames:.cctor()
          -7 (-5.98% of base) : Newtonsoft.Json.dasm - JsonConvert:.cctor()

5284 total methods with Code Size differences (5284 improved, 0 regressed), 270012 unchanged.
```
