### PR TITLE
Remove jumps to next instruction

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -373,6 +373,13 @@ public:
         return funGetFunc(currentFuncletIndex);
     }
 
+#ifdef DEBUG
+    unsigned GetCurrentFuncletIndex() const
+    {
+        return currentFuncletIndex;
+    }
+#endif
+
     FuncInfoDsc& funSetCurrentFunc(unsigned index)
     {
         assert(FitsIn<uint16_t>(index));

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -71,7 +71,7 @@ void CodeGen::GenCallFinally(BasicBlock* block)
     // The funclet prolog/epilog will do "push {lr}" / "pop {pc}" to do the return.
     genMov32RelocatableDisplacement(block->bbNext->bbJumpDest->emitLabel, REG_LR);
 
-    GetEmitter()->emitIns_J(INS_b, block->bbJumpDest->emitLabel);
+    GetEmitter()->emitIns_CallFinally(block->bbJumpDest->emitLabel);
 }
 
 void CodeGen::genEHCatchRet(BasicBlock* block)

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -122,6 +122,7 @@ struct insGroup
     double               igPerfScore; // The PerfScore for this insGroup
 #endif
 #ifdef DEBUG
+    uint16_t                  tryIndex;
     jitstd::list<BasicBlock*> igBlocks; // All the blocks that generated code into this insGroup.
 #endif
 

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -713,6 +713,7 @@ private:
                 case IF_LARGEJMP: // b<cond> + b<uncond>
                     return 8;
                 case IF_GC_REG:
+                case IF_NOP_JMP:
                     return 0;
                 default:
                     return 4;
@@ -898,7 +899,13 @@ private:
         {
             return (_idInsFmt == IF_GC_REG)
 #ifdef TARGET_XARCH
-                   || (_idIns == INS_align)
+                   || (_idIns == INS_align) || (_idCodeSize == 0)
+#endif
+#ifdef TARGET_ARM
+                   || (_idInsSize == ISZ_NONE)
+#endif
+#ifdef TARGET_ARM64
+                   || (_idInsFmt == IF_NOP_JMP)
 #endif
                 ;
         }

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -343,7 +343,7 @@ public:
         {
             if (ig->IsNoGC())
             {
-                callback(ig->igFuncIdx, ig->igOffs, ig->igSize);
+                callback(ig->igOffs, ig->igSize DEBUGARG(ig->GetFuncletIndex()));
             }
         }
     }
@@ -458,11 +458,9 @@ private:
     struct instrDescDebugInfo
     {
         unsigned idNum;
-        uint16_t idSize;                // size of the instruction descriptor
-        bool     idFinallyCall = false; // Branch instruction is a call to finally
-        bool     idCatchRet    = false; // Instruction is for a catch 'return'
-        int      varNum        = INT_MIN;
-        int      varOffs       = 0;
+        uint16_t idSize; // size of the instruction descriptor
+        int      varNum  = INT_MIN;
+        int      varOffs = 0;
 #ifdef TARGET_XARCH
         HandleKind dispHandleKind = HandleKind::None;
 #endif
@@ -1523,7 +1521,6 @@ public:
 
     INDEBUG(static bool IsCodeAligned(UNATIVE_OFFSET offset);)
 
-    INDEBUG(void VerifyBranches() const;)
     void ShortenBranches();
 
 #if FEATURE_LOOP_ALIGN
@@ -1544,7 +1541,10 @@ private:
 #endif
 
 private:
-    INDEBUG(void emitCheckFuncletBranch(instrDescJmp* jmp) const;)
+#ifdef DEBUG
+    void VerifyCallFinally(insGroup* label) const;
+    void VerifyCatchRet(insGroup* label) const;
+#endif
 
     // Are we generating IGF_NOGCINTERRUPT insGroups (for prologs, epilogs, etc.)
     bool emitNoGCIG = false;
@@ -1702,7 +1702,7 @@ private:
 #endif
 
 public:
-    insGroup* CreateBlockLabel(BasicBlock* block);
+    insGroup* CreateBlockLabel(BasicBlock* block, unsigned funcletIndex);
     insGroup* CreateTempLabel();
     insGroup* DefineTempLabel();
     void DefineTempLabel(insGroup* label);

--- a/src/coreclr/jit/emitarm.h
+++ b/src/coreclr/jit/emitarm.h
@@ -129,6 +129,7 @@ void emitIns(instruction ins);
 
 void emitIns_J(instruction ins, int instrCount);
 void emitIns_J(instruction ins, insGroup* label);
+void emitIns_CallFinally(insGroup* label);
 
 void emitIns_I(instruction ins, emitAttr attr, int32_t imm);
 

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -7927,8 +7927,9 @@ static bool IsBranch(instruction ins)
 
 void emitter::emitIns_J(instruction ins, int instrCount)
 {
+    assert(IsMainProlog(emitCurIG));
     assert(IsBranch(ins));
-    assert(instrCount != 0);
+    assert(instrCount < 0);
 
     instrDescJmp* id = emitNewInstrJmp();
     id->idIns(ins);
@@ -7942,7 +7943,7 @@ void emitter::emitIns_J(instruction ins, int instrCount)
 void emitter::emitIns_J(instruction ins, insGroup* label)
 {
     assert(IsBranch(ins));
-    assert(label != nullptr);
+    assert(emitCurIG->GetFuncletIndex() == label->GetFuncletIndex());
 
     instrDescJmp* id = emitNewInstrJmp();
     id->idIns(ins);
@@ -7957,13 +7958,12 @@ void emitter::emitIns_J(instruction ins, insGroup* label)
 void emitter::emitIns_CallFinally(insGroup* label)
 {
     assert(codeGen->GetCurrentBlock()->bbJumpKind == BBJ_CALLFINALLY);
-    assert(label != nullptr);
+    INDEBUG(VerifyCallFinally(label));
 
     instrDescJmp* id = emitNewInstrJmp();
     id->idIns(INS_bl_local);
     id->idInsFmt(IF_BI_0A);
     id->SetLabel(label);
-    INDEBUG(id->idDebugOnlyInfo()->idFinallyCall = true);
 
     dispIns(id);
     appendToCurIG(id);

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -338,6 +338,7 @@ void emitter::emitInsSanityCheck(instrDesc* id)
         case IF_BI_0B: // BI_0B   ......iiiiiiiiii iiiiiiiiiiii....               simm19:00
             break;
 
+        case IF_NOP_JMP:
         case IF_LARGEJMP:
         case IF_LARGEADR:
         case IF_LARGELDC:
@@ -8126,7 +8127,7 @@ AGAIN:
         {
             instr->idjOffs -= instrIGSizeReduction;
 
-            assert((previousInstr == nullptr) || (instr->idjOffs > previousInstr->idjOffs));
+            assert((previousInstr == nullptr) || (instr->idjOffs >= previousInstr->idjOffs));
         }
         else
         {
@@ -8139,7 +8140,7 @@ AGAIN:
                 JITDUMP(" to % 04X\n", ig->igOffs);
             }
 
-            assert(instrIG->igOffs > previousInstrIG->igOffs);
+            assert(instrIG->igOffs >= previousInstrIG->igOffs);
 
             previousInstrIG = instrIG;
         }
@@ -8149,17 +8150,17 @@ AGAIN:
             continue;
         }
 
-        if ((instr->idInsFmt() != IF_LARGEJMP) && (instr->idInsFmt() != IF_LARGEADR) &&
-            (instr->idInsFmt() != IF_LARGELDC))
-        {
-            continue;
-        }
-
-        uint32_t instrOffs = instrIG->igOffs + instr->idjOffs;
+        uint32_t instrOffs   = instrIG->igOffs + instr->idjOffs;
+        uint32_t currentSize = instr->idCodeSize();
         int32_t  distanceOverflow;
 
         if (instr->HasConstData())
         {
+            if (currentSize <= 4)
+            {
+                continue;
+            }
+
             uint32_t dataOffs = instr->GetConstData()->offset;
 
             ssize_t imm = emitGetInsSC(instr);
@@ -8179,8 +8180,40 @@ AGAIN:
                     instr->idDebugOnlyInfo()->idNum, instrOffs, instrIG->GetId(), dataOffs, dataOffs - instrOffs,
                     distanceOverflow, distanceOverflow <= 0 ? ", adr" : "adrp/add");
         }
-        else
+        else if (instr->HasLabel())
         {
+            insGroup* label     = instr->GetLabel();
+            uint32_t  labelOffs = label->igOffs;
+
+            if (label->igNum > instrIG->igNum)
+            {
+                labelOffs -= totalSizeReduction;
+            }
+
+            if (((instr->idInsFmt() != IF_LARGEADR) || (instr->idInsFmt() != IF_SMALLADR)) &&
+                (instrOffs + currentSize == labelOffs))
+            {
+                // Removing a "jump to next" could produce another "jump to next", we need to force another pass
+                // to eliminate that too. Ideally we'd traverse the jump list backwards, but it's a forward only
+                // list and given the rarity of such nested jumps it's hard to justify the extra code and memory
+                // required to traverse the list both ways.
+                minDistanceOverflow = 0;
+
+                instr->idInsFmt(IF_NOP_JMP);
+
+                instrIG->igSize -= static_cast<uint16_t>(currentSize);
+                instrIG->igFlags |= IGF_UPD_ISZ;
+                instrIGSizeReduction += currentSize;
+                totalSizeReduction += currentSize;
+
+                continue;
+            }
+
+            if (currentSize <= 4)
+            {
+                continue;
+            }
+
             int32_t maxNegativeDistance;
             int32_t maxPositiveDistance;
 
@@ -8195,13 +8228,8 @@ AGAIN:
                 maxPositiveDistance = (1 << 20) - 1;
             }
 
-            insGroup* label     = instr->GetLabel();
-            uint32_t  labelOffs = label->igOffs;
-
             if (label->igNum > instrIG->igNum)
             {
-                labelOffs -= totalSizeReduction;
-
                 distanceOverflow = (labelOffs - instrOffs) - maxPositiveDistance;
             }
             else
@@ -8213,6 +8241,10 @@ AGAIN:
                     instr->idDebugOnlyInfo()->idNum, instrOffs, instrIG->GetId(), labelOffs, label->GetId(),
                     labelOffs - instrOffs, distanceOverflow, distanceOverflow <= 0 ? ", short" : "");
         }
+        else
+        {
+            continue;
+        }
 
         if (distanceOverflow > 0)
         {
@@ -8221,7 +8253,6 @@ AGAIN:
             continue;
         }
 
-        uint32_t currentSize = instr->idCodeSize();
         assert(currentSize > 4);
 
         emitSetShortJump(instr);
@@ -9606,7 +9637,9 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         case IF_BI_1B: // BI_1B   B.......bbbbbiii iiiiiiiiiiittttt      Rt imm6, simm14:00
         case IF_LARGEJMP:
             dst = emitOutputLJ(dst, static_cast<instrDescJmp*>(id), ig);
-            sz  = sizeof(instrDescJmp);
+            FALLTHROUGH;
+        case IF_NOP_JMP:
+            sz = sizeof(instrDescJmp);
             break;
 
         case IF_DI_1E: // DI_1E   .ii.....iiiiiiii iiiiiiiiiiiddddd      Rd       simm21
@@ -11522,6 +11555,9 @@ void emitter::emitDispIns(instrDesc* id, bool isNew, bool doffs, bool asmfm, uns
             emitDispAddrLoadLabel(static_cast<instrDescJmp*>(id));
             break;
 
+        case IF_NOP_JMP:
+            break;
+
         case IF_BI_0C: // BI_0C   ......iiiiiiiiii iiiiiiiiiiiiiiii               simm26:00
             printf("%s",
                    emitComp->eeGetMethodFullName(static_cast<CORINFO_METHOD_HANDLE>(id->idDebugOnlyInfo()->idHandle)));
@@ -12633,6 +12669,11 @@ emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(ins
             break;
 
         case IF_LARGEJMP: // bcc + b
+            result.insThroughput = PERFSCORE_THROUGHPUT_2C;
+            result.insLatency    = PERFSCORE_LATENCY_2C;
+            break;
+
+        case IF_NOP_JMP:
             result.insThroughput = PERFSCORE_THROUGHPUT_2C;
             result.insLatency    = PERFSCORE_LATENCY_2C;
             break;

--- a/src/coreclr/jit/emitfmtsarm64.h
+++ b/src/coreclr/jit/emitfmtsarm64.h
@@ -18,11 +18,13 @@
 // clang-format off
 IF_DEF(NONE, IS_NONE, NONE) //
 
+IF_DEF(GC_REG, IS_NONE, NONE)  // GC reg update
+
+IF_DEF(NOP_JMP,  IS_NONE, JMP) // nop branch (distance = 0)
 IF_DEF(LARGEJMP, IS_NONE, JMP) // large conditional branch pseudo-op (cond branch + uncond branch)
 IF_DEF(LARGEADR, IS_NONE, JMP) // large address pseudo-op (adrp + add)
 IF_DEF(LARGELDC, IS_NONE, JMP) // large constant pseudo-op (adrp + ldr)
 IF_DEF(SMALLADR, IS_NONE, JMP) // small address pseudo-op (adr)
-IF_DEF(GC_REG, IS_NONE, NONE)  // GC reg update
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //

--- a/src/coreclr/jit/gcencode.cpp
+++ b/src/coreclr/jit/gcencode.cpp
@@ -4392,7 +4392,7 @@ void GCEncoder::AddFullyInterruptibleRanges(const Emitter& emitter, unsigned cod
     Log("Defining interruptible ranges:\n");
 #endif
 
-    emitter.EnumerateNoGCInsGroups([&](unsigned funcletIndex, unsigned offset, unsigned size) {
+    emitter.EnumerateNoGCInsGroups([&](unsigned offset, unsigned size DEBUGARG(unsigned funcletIndex)) {
         if (offset < prevOffset)
         {
             // We're still in the main method prolog, which has already had it's interruptible range reported.

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -1153,6 +1153,7 @@ bool Compiler::fgComputeLifeLIR(VARSET_TP& life, VARSET_VALARG_TP keepAliveVars,
             case GT_IL_OFFSET:
             case GT_KEEPALIVE:
             case GT_BOUNDS_CHECK:
+            case GT_NO_OP:
 #ifdef FEATURE_HW_INTRINSICS
             case GT_HWINTRINSIC:
 #endif


### PR DESCRIPTION
win-x64 crossgen diff:
```
Total bytes of base: 37489809
Total bytes of diff: 37488566
Total bytes of delta: -1243 (-0.00 % of base)
    diff is an improvement.

Top file regressions (bytes):
           3 : System.Security.Cryptography.X509Certificates.dasm (0.00% of base)
           2 : System.Threading.Tasks.Parallel.dasm (0.01% of base)
           1 : System.Threading.Tasks.Dataflow.dasm (0.00% of base)

Top file improvements (bytes):
        -144 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.00% of base)
        -138 : System.Private.Xml.dasm (-0.00% of base)
        -127 : FSharp.Core.dasm (-0.02% of base)
        -111 : System.Private.CoreLib.dasm (-0.00% of base)
         -99 : System.Data.Common.dasm (-0.01% of base)
         -91 : System.Management.dasm (-0.03% of base)
         -65 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
         -60 : System.Data.OleDb.dasm (-0.02% of base)
         -56 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00% of base)
         -46 : System.Data.Odbc.dasm (-0.03% of base)
         -37 : Microsoft.CodeAnalysis.dasm (-0.00% of base)
         -22 : Microsoft.VisualBasic.Core.dasm (-0.01% of base)
         -18 : System.Diagnostics.TextWriterTraceListener.dasm (-0.13% of base)
         -18 : Newtonsoft.Json.dasm (-0.00% of base)
         -15 : System.ComponentModel.Composition.dasm (-0.01% of base)
         -12 : System.Drawing.Common.dasm (-0.00% of base)
         -12 : System.Runtime.Serialization.Formatters.dasm (-0.01% of base)
         -12 : System.Private.Xml.Linq.dasm (-0.01% of base)
         -10 : System.Runtime.Numerics.dasm (-0.01% of base)
         -10 : System.Security.Cryptography.Xml.dasm (-0.01% of base)

60 total files with Code Size differences (57 improved, 3 regressed), 211 unchanged.

Top method regressions (bytes):
           5 ( 0.14% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Dictionary`2:System.Collections.IDictionary.Add(System.Object,System.Object):this (12 methods)
           5 ( 0.14% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Dictionary`2:System.Collections.IDictionary.set_Item(System.Object,System.Object):this (12 methods)
           4 ( 0.17% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.Compilation:SerializeToPeStream(Microsoft.CodeAnalysis.Emit.CommonPEModuleBuilder,Microsoft.CodeAnalysis.Compilation+EmitStreamProvider,Microsoft.CodeAnalysis.Compilation+EmitStreamProvider,System.Func`1[System.Object],Microsoft.CodeAnalysis.DiagnosticBag,bool,System.Threading.CancellationToken):bool:this
           3 ( 0.23% of base) : System.Security.Cryptography.X509Certificates.dasm - Internal.Cryptography.Pal.CertificatePal:AppendPrivateKeyInfo(System.Text.StringBuilder):this
           1 ( 0.04% of base) : System.Net.Sockets.dasm - <<DnsConnectAsync>g__Core|112_0>d:MoveNext():this
           1 ( 0.09% of base) : System.Threading.Tasks.Parallel.dasm - <>c__DisplayClass19_0`1:<ForWorker>b__1(byref,int,byref):this
           1 ( 0.09% of base) : System.Threading.Tasks.Parallel.dasm - <>c__DisplayClass20_0`1:<ForWorker64>b__1(byref,int,byref):this
           1 ( 0.04% of base) : Microsoft.CodeAnalysis.dasm - <ComputeAnalyzerDiagnosticsAsync>d__51:MoveNext():this
           1 ( 0.05% of base) : System.IO.Pipelines.dasm - <FlushAsyncInternal>d__39:MoveNext():this
           1 ( 0.03% of base) : System.Net.Http.dasm - <ProcessServerStreamAsync>d__41:MoveNext():this
           1 ( 0.03% of base) : System.Net.Http.dasm - <SendWithAuthAsync>d__17:MoveNext():this
           1 ( 0.18% of base) : System.Management.dasm - ManagementObjectEnumerator:Reset():this
           1 ( 0.24% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Session.TraceEventSession:DisableProvider(System.Guid):this
           1 ( 0.17% of base) : System.ComponentModel.Composition.dasm - System.ComponentModel.Composition.Hosting.CatalogExportProvider:DetermineRejection(System.ComponentModel.Composition.Primitives.ComposablePartDefinition,System.ComponentModel.Composition.Hosting.AtomicComposition):bool:this
           1 ( 0.05% of base) : System.Data.Common.dasm - System.Data.DataTable:SetNewRecordWorker(System.Data.DataRow,int,int,bool,bool,int,bool,byref):this
           1 ( 0.37% of base) : System.Diagnostics.EventLog.dasm - System.Diagnostics.Eventing.Reader.ProviderMetadataCachedInformation:GetFormatDescription(System.String,System.Diagnostics.Eventing.Reader.EventLogHandle,System.String[]):System.String:this
           1 ( 0.39% of base) : System.Diagnostics.EventLog.dasm - System.Diagnostics.Eventing.Reader.ProviderMetadataCachedInformation:GetFormatDescription(System.String,System.Diagnostics.Eventing.Reader.EventLogHandle):System.String:this
           1 ( 0.08% of base) : System.Private.CoreLib.dasm - System.Diagnostics.StackFrameHelper:InitializeSourceInfo(int,bool,System.Exception):this
           1 ( 0.04% of base) : System.Net.Sockets.dasm - System.Net.Sockets.Socket:.ctor(System.Net.Sockets.SafeSocketHandle,bool):this
           1 ( 0.10% of base) : System.Net.Sockets.dasm - System.Net.Sockets.UdpClient:Connect(System.String,int):this

Top method improvements (bytes):
         -22 (-0.77% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:ProcessPropertyQualifiers(System.Management.PropertyData,byref,byref,byref,bool,byref):System.String:this
         -20 (-1.16% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Etlx.TraceCodeAddresses:OpenPdbForModuleFile(Microsoft.Diagnostics.Symbols.SymbolReader,Microsoft.Diagnostics.Tracing.Etlx.TraceModuleFile):Microsoft.Diagnostics.Symbols.ManagedSymbolModule:this
         -20 (-0.83% of base) : System.Data.OleDb.dasm - OleDbParameterConverter:ConvertToInstanceDescriptor(System.Data.OleDb.OleDbParameter):System.ComponentModel.Design.Serialization.InstanceDescriptor:this
         -14 (-0.42% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Dictionary`2:FindValue(System.__Canon):byref:this (7 methods)
         -14 (-0.24% of base) : System.Private.CoreLib.dasm - System.DateTimeFormat:FormatCustomized(System.DateTime,System.ReadOnlySpan`1[System.Char],System.Globalization.DateTimeFormatInfo,System.TimeSpan,System.Text.StringBuilder):System.Text.StringBuilder
         -12 (-1.19% of base) : FSharp.Core.dasm - OperatorIntrinsics:GetArraySlice4D(System.__Canon[,,,],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32]):System.__Canon[,,,]
         -12 (-1.77% of base) : System.Management.dasm - System.Management.RelatedObjectQuery:BuildQuery():this
         -10 (-0.59% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.ActivityComputer:ResolveWellKnownSymbols():this
         -10 (-1.31% of base) : FSharp.Core.dasm - OperatorIntrinsics:GetArraySlice3D(System.__Canon[,,],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32]):System.__Canon[,,]
         -10 (-0.10% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:GenerateProperties():this
          -8 (-1.26% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.MemberSemanticModel:GetLambdaEnclosingBinder(int,Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode,Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode,Microsoft.CodeAnalysis.CSharp.Binder):Microsoft.CodeAnalysis.CSharp.Binder
          -8 (-0.05% of base) : System.Data.Common.dasm - System.Data.BinaryNode:EvalBinaryOp(int,System.Data.ExpressionNode,System.Data.ExpressionNode,System.Data.DataRow,int,System.Int32[]):System.Object:this
          -8 (-0.71% of base) : System.Private.CoreLib.dasm - System.DefaultBinder:FindMostSpecific(System.Reflection.ParameterInfo[],System.Int32[],System.Type,System.Reflection.ParameterInfo[],System.Int32[],System.Type,System.Type[],System.Object[]):int
          -8 (-0.71% of base) : System.Reflection.MetadataLoadContext.dasm - System.DefaultBinder:FindMostSpecific(System.Reflection.ParameterInfo[],System.Int32[],System.Type,System.Reflection.ParameterInfo[],System.Int32[],System.Type,System.Type[],System.Object[]):int
          -6 (-0.29% of base) : System.Private.Xml.dasm - <ParseAttlistDeclAsync>d__160:MoveNext():this
          -6 (-0.14% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.MethodCompiler:CompileMethod(Microsoft.CodeAnalysis.CSharp.Symbols.MethodSymbol,int,byref,Microsoft.CodeAnalysis.CSharp.SynthesizedSubmissionFields,Microsoft.CodeAnalysis.CSharp.TypeCompilationState):this
          -6 (-0.33% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:InferVariableType(Microsoft.CodeAnalysis.VisualBasic.Symbols.TypeSymbol,Microsoft.CodeAnalysis.VisualBasic.Syntax.ModifiedIdentifierSyntax,Microsoft.CodeAnalysis.VisualBasic.Syntax.ExpressionSyntax,Microsoft.CodeAnalysis.VisualBasic.Symbols.TypeSymbol,Microsoft.CodeAnalysis.VisualBasic.BoundExpression,System.Func`1[Microsoft.CodeAnalysis.DiagnosticInfo],Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.Symbols.TypeSymbol:this
          -6 (-0.26% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Etlx.TraceCodeAddresses:GetSourceLine(Microsoft.Diagnostics.Symbols.SymbolReader,int):Microsoft.Diagnostics.Symbols.SourceLocation:this
          -6 (-0.81% of base) : FSharp.Core.dasm - OperatorIntrinsics:GetArraySlice4DFixedSingle1(System.__Canon[,,,],int,Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32]):System.__Canon[,,]
          -6 (-0.84% of base) : FSharp.Core.dasm - OperatorIntrinsics:GetArraySlice4DFixedSingle2(System.__Canon[,,,],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],int,Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32]):System.__Canon[,,]

Top method regressions (percentages):
           1 ( 0.39% of base) : System.Diagnostics.EventLog.dasm - System.Diagnostics.Eventing.Reader.ProviderMetadataCachedInformation:GetFormatDescription(System.String,System.Diagnostics.Eventing.Reader.EventLogHandle):System.String:this
           1 ( 0.37% of base) : System.Diagnostics.EventLog.dasm - System.Diagnostics.Eventing.Reader.ProviderMetadataCachedInformation:GetFormatDescription(System.String,System.Diagnostics.Eventing.Reader.EventLogHandle,System.String[]):System.String:this
           1 ( 0.33% of base) : System.Private.CoreLib.dasm - System.Threading.ThreadInt64PersistentCounter:get_Count():long:this
           1 ( 0.24% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Session.TraceEventSession:DisableProvider(System.Guid):this
           3 ( 0.23% of base) : System.Security.Cryptography.X509Certificates.dasm - Internal.Cryptography.Pal.CertificatePal:AppendPrivateKeyInfo(System.Text.StringBuilder):this
           1 ( 0.18% of base) : System.Management.dasm - ManagementObjectEnumerator:Reset():this
           1 ( 0.17% of base) : System.ComponentModel.Composition.dasm - System.ComponentModel.Composition.Hosting.CatalogExportProvider:DetermineRejection(System.ComponentModel.Composition.Primitives.ComposablePartDefinition,System.ComponentModel.Composition.Hosting.AtomicComposition):bool:this
           4 ( 0.17% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.Compilation:SerializeToPeStream(Microsoft.CodeAnalysis.Emit.CommonPEModuleBuilder,Microsoft.CodeAnalysis.Compilation+EmitStreamProvider,Microsoft.CodeAnalysis.Compilation+EmitStreamProvider,System.Func`1[System.Object],Microsoft.CodeAnalysis.DiagnosticBag,bool,System.Threading.CancellationToken):bool:this
           5 ( 0.14% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Dictionary`2:System.Collections.IDictionary.Add(System.Object,System.Object):this (12 methods)
           5 ( 0.14% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Dictionary`2:System.Collections.IDictionary.set_Item(System.Object,System.Object):this (12 methods)
           1 ( 0.12% of base) : System.Reflection.Metadata.dasm - System.Reflection.PortableExecutable.PEReader:TryOpenPortablePdbFile(System.String,System.Reflection.Metadata.BlobContentId,System.Func`2[System.String, System.IO.Stream],byref,byref):bool:this
           1 ( 0.11% of base) : System.Private.CoreLib.dasm - ThreadPoolValueTaskSource:ExecuteInternal():this
           1 ( 0.10% of base) : System.Net.Sockets.dasm - System.Net.Sockets.UdpClient:Connect(System.String,int):this
           1 ( 0.10% of base) : System.Threading.Tasks.Dataflow.dasm - System.Threading.Tasks.Dataflow.Internal.TargetCore`1:ProcessMessagesLoopCore():this
           1 ( 0.09% of base) : System.Threading.Tasks.Parallel.dasm - <>c__DisplayClass20_0`1:<ForWorker64>b__1(byref,int,byref):this
           1 ( 0.09% of base) : System.Threading.Tasks.Parallel.dasm - <>c__DisplayClass19_0`1:<ForWorker>b__1(byref,int,byref):this
           1 ( 0.08% of base) : System.Private.CoreLib.dasm - System.Diagnostics.StackFrameHelper:InitializeSourceInfo(int,bool,System.Exception):this
           1 ( 0.06% of base) : System.Speech.dasm - System.Speech.Internal.Synthesis.SsmlParser:ParsePhoneme(System.Xml.XmlReader,System.Speech.Internal.Synthesis.ISsmlParser,int,System.Speech.Internal.Synthesis.SsmlParser+SsmlAttributes,bool)
           1 ( 0.05% of base) : System.Data.Common.dasm - System.Data.DataTable:SetNewRecordWorker(System.Data.DataRow,int,int,bool,bool,int,bool,byref):this
           1 ( 0.05% of base) : System.IO.Pipelines.dasm - <FlushAsyncInternal>d__39:MoveNext():this

Top method improvements (percentages):
          -2 (-11.11% of base) : System.Private.CoreLib.dasm - System.Reflection.Emit.MethodBuilder:get_ReflectedType():System.Type:this
          -2 (-10.00% of base) : Microsoft.CodeAnalysis.dasm - Roslyn.Utilities.WeakList`1:GetExpandedSize(int):int
          -2 (-9.52% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - ToInterfaceConversionClassifier:get_Result():int:this
          -2 (-9.09% of base) : System.Data.Odbc.dasm - System.Data.Odbc.OdbcError:ToString():System.String:this
          -2 (-9.09% of base) : System.Data.OleDb.dasm - System.Data.OleDb.OleDbError:ToString():System.String:this
          -2 (-9.09% of base) : System.Management.dasm - System.Management.WqlEventQuery:get_QueryLanguage():System.String:this
          -2 (-9.09% of base) : System.Management.dasm - System.Management.WqlObjectQuery:get_QueryLanguage():System.String:this
          -2 (-9.09% of base) : System.Private.CoreLib.dasm - System.Reflection.Emit.ConstructorBuilder:get_DeclaringType():System.Type:this
          -2 (-9.09% of base) : System.Private.CoreLib.dasm - System.Reflection.Emit.ConstructorBuilder:get_ReflectedType():System.Type:this
          -2 (-9.09% of base) : System.Private.Xml.dasm - System.Xml.Schema.SchemaAttDef:System.Xml.IDtdDefaultAttributeInfo.get_DefaultValueExpanded():System.String:this
          -2 (-8.70% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.TypeSubstitution:GetSubstitutionForGenericDefinition(Microsoft.CodeAnalysis.VisualBasic.Symbol):Microsoft.CodeAnalysis.VisualBasic.Symbols.TypeSubstitution:this
          -2 (-7.69% of base) : System.Drawing.Common.dasm - System.Drawing.Printing.PrinterSettings:get_PrinterName():System.String:this
          -2 (-7.41% of base) : System.Net.Requests.dasm - System.Net.Authorization:set_ProtectionRealm(System.String[]):this
          -2 (-6.67% of base) : System.Data.Odbc.dasm - System.Data.Odbc.OdbcParameter:ToString():System.String:this
          -2 (-6.67% of base) : System.Data.OleDb.dasm - System.Data.OleDb.OleDbParameter:ToString():System.String:this
          -2 (-5.71% of base) : System.Private.DataContractSerialization.dasm - System.Runtime.Serialization.XmlReaderDelegator:GetArrayLengthQuota(System.Runtime.Serialization.XmlObjectSerializerReadContext):int:this
          -2 (-5.56% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE.PENamedTypeSymbol:get_MarshallingCharSet():int:this
          -2 (-5.00% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.SourceMemberMethodSymbol:GetQuickAttributes():ubyte:this
          -2 (-4.88% of base) : System.Data.Odbc.dasm - System.Data.Common.DBConnectionString:ValidateCombinedSet(System.Data.Common.DBConnectionString,System.Data.Common.DBConnectionString):this
          -2 (-4.88% of base) : System.IO.Ports.dasm - System.IO.Ports.SerialStream:ReadByte():int:this

496 total methods with Code Size differences (469 improved, 27 regressed), 249015 unchanged.
```
win-x64 pmi diff:
```
Total bytes of base: 60499345
Total bytes of diff: 60493475
Total bytes of delta: -5870 (-0.01 % of base)
    diff is an improvement.

Top file regressions (bytes):
          61 : System.Threading.Tasks.Parallel.dasm (0.02% of base)
          56 : Microsoft.Extensions.Logging.Abstractions.dasm (0.08% of base)
          45 : System.Private.DataContractSerialization.dasm (0.01% of base)
          25 : System.Threading.Tasks.Dataflow.dasm (0.00% of base)
          17 : System.Text.Json.dasm (0.00% of base)
          16 : System.Threading.Channels.dasm (0.01% of base)
           9 : System.Text.Encodings.Web.dasm (0.03% of base)
           9 : System.DirectoryServices.Protocols.dasm (0.01% of base)
           9 : System.Net.Mail.dasm (0.00% of base)
           7 : System.Security.Cryptography.X509Certificates.dasm (0.00% of base)
           7 : System.Net.Quic.dasm (0.01% of base)
           7 : System.Linq.Expressions.dasm (0.00% of base)
           6 : System.Threading.AccessControl.dasm (0.03% of base)
           6 : System.Net.HttpListener.dasm (0.00% of base)
           6 : System.Console.dasm (0.01% of base)
           5 : System.Diagnostics.Process.dasm (0.01% of base)
           5 : System.Reflection.Context.dasm (0.01% of base)
           4 : System.Security.AccessControl.dasm (0.00% of base)
           3 : System.Security.Cryptography.Algorithms.dasm (0.00% of base)
           3 : xunit.runner.reporters.netcoreapp10.dasm (0.01% of base)

Top file improvements (bytes):
       -1909 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.03% of base)
       -1332 : Microsoft.CodeAnalysis.CSharp.dasm (-0.03% of base)
        -831 : Microsoft.CodeAnalysis.dasm (-0.04% of base)
        -587 : FSharp.Core.dasm (-0.02% of base)
        -367 : System.Private.CoreLib.dasm (-0.01% of base)
        -134 : System.Reflection.Metadata.dasm (-0.02% of base)
        -132 : System.Data.Common.dasm (-0.01% of base)
        -118 : System.Private.Xml.dasm (-0.00% of base)
         -88 : System.Linq.dasm (-0.01% of base)
         -83 : System.Management.dasm (-0.02% of base)
         -72 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
         -60 : System.Data.OleDb.dasm (-0.02% of base)
         -57 : System.Data.Odbc.dasm (-0.03% of base)
         -38 : Microsoft.CSharp.dasm (-0.01% of base)
         -34 : System.Private.Xml.Linq.dasm (-0.02% of base)
         -34 : Microsoft.VisualBasic.Core.dasm (-0.01% of base)
         -32 : Newtonsoft.Json.dasm (-0.00% of base)
         -32 : System.Linq.Parallel.dasm (-0.00% of base)
         -28 : ILCompiler.TypeSystem.ReadyToRun.dasm (-0.01% of base)
         -24 : System.Collections.Concurrent.dasm (-0.01% of base)

98 total files with Code Size differences (56 improved, 42 regressed), 173 unchanged.

Top method regressions (bytes):
           8 ( 4.35% of base) : System.Text.Json.dasm - <<DeserializeAsyncEnumerable>g__CreateAsyncEnumerableDeserializer|63_0>d`1:System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted(Action`1,Object,short,int):this (8 methods)
           8 ( 4.35% of base) : System.Text.Json.dasm - <<DeserializeAsyncEnumerable>g__CreateAsyncEnumerableDeserializer|63_0>d`1:System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.OnCompleted(Action`1,Object,short,int):this (8 methods)
           8 ( 0.08% of base) : System.Threading.Tasks.Parallel.dasm - <<ForEachAsync>b__50_0>d:MoveNext():this (8 methods)
           8 ( 0.04% of base) : System.Threading.Tasks.Parallel.dasm - <<ForEachAsync>b__54_0>d:MoveNext():this (8 methods)
           8 ( 4.35% of base) : System.Threading.Tasks.Dataflow.dasm - <<ReceiveAllAsync>g__ReceiveAllAsyncCore|43_0>d`1:System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted(Action`1,Object,short,int):this (8 methods)
           8 ( 4.35% of base) : System.Threading.Tasks.Dataflow.dasm - <<ReceiveAllAsync>g__ReceiveAllAsyncCore|43_0>d`1:System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.OnCompleted(Action`1,Object,short,int):this (8 methods)
           8 ( 0.08% of base) : System.Threading.Tasks.Parallel.dasm - <>c__DisplayClass19_0`1:<ForWorker>b__1(byref,int,byref):this (8 methods)
           8 ( 0.08% of base) : System.Threading.Tasks.Parallel.dasm - <>c__DisplayClass20_0`1:<ForWorker64>b__1(byref,int,byref):this (8 methods)
           8 ( 0.07% of base) : System.Threading.Tasks.Parallel.dasm - <>c__DisplayClass44_0`2:<PartitionerForEachWorker>b__1(byref,int,byref):this (8 methods)
           8 ( 4.35% of base) : System.Threading.Channels.dasm - <ReadAllAsync>d__12:System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted(Action`1,Object,short,int):this (8 methods)
           8 ( 4.35% of base) : System.Threading.Channels.dasm - <ReadAllAsync>d__12:System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.OnCompleted(Action`1,Object,short,int):this (8 methods)
           8 ( 6.67% of base) : FSharp.Core.dasm - ArrayModule:CopyTo(ref,int,ref,int,int) (8 methods)
           8 ( 0.13% of base) : System.Collections.Concurrent.dasm - BlockingCollection`1:TryTakeWithNoTimeValidation(byref,int,CancellationToken,CancellationTokenSource):bool:this (8 methods)
           8 ( 5.26% of base) : System.Collections.Immutable.dasm - Builder:CopyTo(int,ref,int,int):this (8 methods)
           8 ( 0.34% of base) : System.Private.CoreLib.dasm - Dictionary`2:System.Collections.IDictionary.Add(Object,Object):this (8 methods)
           8 ( 0.34% of base) : System.Private.CoreLib.dasm - Dictionary`2:System.Collections.IDictionary.set_Item(Object,Object):this (8 methods)
           8 ( 5.26% of base) : System.Collections.Immutable.dasm - ImmutableList`1:CopyTo(int,ref,int,int):this (8 methods)
           8 ( 1.01% of base) : Microsoft.Extensions.Logging.Abstractions.dasm - Logger`1:Microsoft.Extensions.Logging.ILogger.Log(int,EventId,double,Exception,Func`3):this (8 methods)
           8 ( 1.06% of base) : Microsoft.Extensions.Logging.Abstractions.dasm - Logger`1:Microsoft.Extensions.Logging.ILogger.Log(int,EventId,int,Exception,Func`3):this (8 methods)
           8 ( 1.06% of base) : Microsoft.Extensions.Logging.Abstractions.dasm - Logger`1:Microsoft.Extensions.Logging.ILogger.Log(int,EventId,long,Exception,Func`3):this (8 methods)

Top method improvements (bytes):
        -112 (-0.40% of base) : Microsoft.CodeAnalysis.dasm - ArrayBuilder`1:SelectDistinct(Func`2):ImmutableArray`1:this (64 methods)
        -112 (-0.20% of base) : Microsoft.CodeAnalysis.dasm - ArrayBuilder`1:ToDictionary(Func`2,IEqualityComparer`1):Dictionary`2:this (64 methods)
         -96 (-1.17% of base) : FSharp.Core.dasm - OperatorIntrinsics:GetArraySlice4D(ref,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1):ref (8 methods)
         -48 (-0.83% of base) : FSharp.Core.dasm - OperatorIntrinsics:GetArraySlice4DFixedSingle1(ref,int,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1):ref (8 methods)
         -48 (-0.84% of base) : FSharp.Core.dasm - OperatorIntrinsics:GetArraySlice4DFixedSingle2(ref,FSharpOption`1,FSharpOption`1,int,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1):ref (8 methods)
         -48 (-1.01% of base) : FSharp.Core.dasm - OperatorIntrinsics:SetArraySlice4DFixedSingle1(ref,int,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,ref) (8 methods)
         -48 (-1.03% of base) : FSharp.Core.dasm - OperatorIntrinsics:SetArraySlice4DFixedSingle2(ref,FSharpOption`1,FSharpOption`1,int,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,ref) (8 methods)
         -46 (-1.32% of base) : Microsoft.CodeAnalysis.dasm - DeltaMetadataWriter:PopulateEncMapTableRows(List`1,ImmutableArray`1):this
         -46 (-0.65% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SymbolDisplayVisitor:VisitMethod(IMethodSymbol):this
         -40 (-0.20% of base) : System.Private.CoreLib.dasm - Avx2:ShiftLeftLogical128BitLane(Vector256`1,ubyte):Vector256`1 (8 methods)
         -40 (-0.20% of base) : System.Private.CoreLib.dasm - Avx2:ShiftRightLogical128BitLane(Vector256`1,ubyte):Vector256`1 (8 methods)
         -40 (-0.20% of base) : System.Private.CoreLib.dasm - Sse2:ShiftLeftLogical128BitLane(Vector128`1,ubyte):Vector128`1 (8 methods)
         -40 (-0.20% of base) : System.Private.CoreLib.dasm - Sse2:ShiftRightLogical128BitLane(Vector128`1,ubyte):Vector128`1 (8 methods)
         -38 (-0.63% of base) : FSharp.Core.dasm - OperatorIntrinsics:GetArraySlice3D(ref,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1):ref (8 methods)
         -34 (-0.61% of base) : FSharp.Core.dasm - OperatorIntrinsics:GetArraySlice4DFixedSingle3(ref,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,int,FSharpOption`1,FSharpOption`1):ref (8 methods)
         -34 (-0.61% of base) : FSharp.Core.dasm - OperatorIntrinsics:GetArraySlice4DFixedSingle4(ref,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,int):ref (8 methods)
         -34 (-0.76% of base) : FSharp.Core.dasm - OperatorIntrinsics:SetArraySlice4DFixedSingle3(ref,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,int,FSharpOption`1,FSharpOption`1,ref) (8 methods)
         -34 (-0.76% of base) : FSharp.Core.dasm - OperatorIntrinsics:SetArraySlice4DFixedSingle4(ref,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,FSharpOption`1,int,ref) (8 methods)
         -34 (-1.05% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SymbolDisplayVisitor:AddMethodKind(IMethodSymbol):this
         -32 (-1.73% of base) : System.Linq.dasm - Enumerable:Take(IEnumerable`1,Range):IEnumerable`1 (8 methods)

Top method regressions (percentages):
           1 ( 7.69% of base) : FSharp.Core.dasm - Array4DModule:Get(ref,int,int,int,int):double
           1 ( 7.69% of base) : FSharp.Core.dasm - Array4DModule:Get(ref,int,int,int,int):int
           1 ( 7.69% of base) : FSharp.Core.dasm - Array4DModule:Get(ref,int,int,int,int):long
           1 ( 7.69% of base) : FSharp.Core.dasm - Array4DModule:Get(ref,int,int,int,int):Nullable`1
           1 ( 7.69% of base) : FSharp.Core.dasm - Array4DModule:Get(ref,int,int,int,int):short
           1 ( 7.69% of base) : FSharp.Core.dasm - Array4DModule:Get(ref,int,int,int,int):ubyte
           1 ( 7.69% of base) : FSharp.Core.dasm - IntrinsicFunctions:GetArray4D(ref,int,int,int,int):double
           1 ( 7.69% of base) : FSharp.Core.dasm - IntrinsicFunctions:GetArray4D(ref,int,int,int,int):int
           1 ( 7.69% of base) : FSharp.Core.dasm - IntrinsicFunctions:GetArray4D(ref,int,int,int,int):long
           1 ( 7.69% of base) : FSharp.Core.dasm - IntrinsicFunctions:GetArray4D(ref,int,int,int,int):Nullable`1
           1 ( 7.69% of base) : FSharp.Core.dasm - IntrinsicFunctions:GetArray4D(ref,int,int,int,int):short
           1 ( 7.69% of base) : FSharp.Core.dasm - IntrinsicFunctions:GetArray4D(ref,int,int,int,int):ubyte
           1 ( 7.69% of base) : System.Private.CoreLib.dasm - UnmanagedMemoryAccessor:.ctor(SafeBuffer,long,long,int):this
           1 ( 7.69% of base) : System.Private.CoreLib.dasm - UnmanagedMemoryStream:.ctor(long,long,long,int):this
           1 ( 7.69% of base) : System.Private.CoreLib.dasm - UnmanagedMemoryStream:.ctor(SafeBuffer,long,long,int):this
           1 ( 7.69% of base) : Microsoft.VisualBasic.Core.dasm - VB6RandomFile:.ctor(String,int,int,int):this
           1 ( 7.69% of base) : System.Private.Xml.dasm - XmlTextReaderImpl:BlockCopy(ref,int,ref,int,int)
           1 ( 7.14% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SyntaxExtensions:NormalizeWhitespace(SyntaxToken,String,String,bool):SyntaxToken
           1 ( 7.14% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SyntaxExtensions:NormalizeWhitespace(SyntaxTriviaList,String,String,bool):SyntaxTriviaList
           1 ( 7.14% of base) : System.Private.Xml.dasm - XPathAncestorIterator:.ctor(XPathNavigator,String,String,bool):this

Top method improvements (percentages):
          -2 (-11.11% of base) : System.Private.CoreLib.dasm - MethodBuilder:get_ReflectedType():Type:this
          -2 (-10.00% of base) : Microsoft.CodeAnalysis.dasm - WeakList`1:GetExpandedSize(int):int
          -2 (-9.52% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - ToInterfaceConversionClassifier:get_Result():int:this
          -2 (-9.52% of base) : System.Private.DataContractSerialization.dasm - XmlReaderDelegator:GetArrayLengthQuota(XmlObjectSerializerReadContext):int:this
          -2 (-9.09% of base) : System.Private.CoreLib.dasm - ConstructorBuilder:get_DeclaringType():Type:this
          -2 (-9.09% of base) : System.Private.CoreLib.dasm - ConstructorBuilder:get_ReflectedType():Type:this
          -2 (-8.70% of base) : System.IO.Ports.dasm - SerialStream:ReadByte():int:this
          -2 (-8.70% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - TypeSubstitution:GetSubstitutionForGenericDefinition(Symbol):TypeSubstitution:this
          -2 (-8.00% of base) : System.Data.Odbc.dasm - OdbcError:ToString():String:this
          -2 (-8.00% of base) : System.Data.Odbc.dasm - OdbcParameter:ToString():String:this
          -2 (-8.00% of base) : System.Data.OleDb.dasm - OleDbError:ToString():String:this
          -2 (-8.00% of base) : System.Data.OleDb.dasm - OleDbParameter:ToString():String:this
          -2 (-8.00% of base) : System.Private.Xml.dasm - SchemaAttDef:System.Xml.IDtdDefaultAttributeInfo.get_DefaultValueExpanded():String:this
          -2 (-8.00% of base) : System.Management.dasm - WqlEventQuery:get_QueryLanguage():String:this
          -2 (-8.00% of base) : System.Management.dasm - WqlObjectQuery:get_QueryLanguage():String:this
          -6 (-7.89% of base) : System.Private.CoreLib.dasm - Statics:.cctor()
          -2 (-7.69% of base) : System.Net.Requests.dasm - Authorization:set_ProtectionRealm(ref):this
          -2 (-6.45% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - PENamedTypeSymbol:get_MarshallingCharSet():int:this
          -2 (-5.00% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceMemberMethodSymbol:GetQuickAttributes():ubyte:this
          -2 (-4.88% of base) : System.Data.Odbc.dasm - DBConnectionString:ValidateCombinedSet(DBConnectionString,DBConnectionString):this

2272 total methods with Code Size differences (1719 improved, 553 regressed), 273851 unchanged.
```